### PR TITLE
fix(scheduler): elimina loop infinito do briefing diario causado por NaN no setTimeout

### DIFF
--- a/src/agent/scheduler.ts
+++ b/src/agent/scheduler.ts
@@ -3,15 +3,48 @@ import { sendReply } from '../integrations/whatsapp';
 
 const CEO_PHONE = process.env.CEO_WHATSAPP_PHONE ?? '';
 
-// Calcula ms até o próximo HH:MM no fuso de Fortaleza (BRT = UTC-3)
+// Fallback contra loop infinito: se o cálculo der NaN/inválido/<60s, usa 1h.
+const FALLBACK_DELAY_MS = 60 * 60 * 1000;
+const MIN_VALID_DELAY_MS = 60 * 1000;
+
+/**
+ * Calcula ms até o próximo HH:MM no fuso de Fortaleza (BRT = UTC-3, sem DST).
+ *
+ * Bug histórico (corrigido em fix/scheduler-briefing-nan-loop):
+ *   `new Date(date.toLocaleString('en-CA', { timeZone: 'America/Fortaleza' }))`
+ *   produzia "2026-05-01, 00:35:04" (com vírgula), que `new Date()` parseia como
+ *   Invalid Date no Node 20. A cadeia subsequente propagava NaN até o setTimeout,
+ *   que o Node trata como 1ms — resultando em loop infinito disparando o briefing
+ *   centenas de vezes por hora (incidente 2026-05-01).
+ *
+ * Fix: usa Intl.DateTimeFormat.formatToParts() — única forma robusta de extrair
+ * componentes de hora em timezone específica sem parsear strings.
+ */
 function msUntilNext(hour: number, minute = 0): number {
   const now = new Date();
-  const bsb = new Date(now.toLocaleString('en-CA', { timeZone: 'America/Fortaleza', hour12: false }));
-  const [h, m, s] = (bsb.toTimeString().split(' ')[0]).split(':').map(Number);
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Fortaleza',
+    hour:   '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(now);
+  const h = Number(parts.find(p => p.type === 'hour')?.value ?? NaN);
+  const m = Number(parts.find(p => p.type === 'minute')?.value ?? NaN);
+  const s = Number(parts.find(p => p.type === 'second')?.value ?? NaN);
 
-  const nowSecs = h * 3600 + m * 60 + s;
-  const targetSecs = hour * 3600 + minute * 60;
-  const diffSecs = targetSecs > nowSecs
+  if (!Number.isFinite(h) || !Number.isFinite(m) || !Number.isFinite(s)) {
+    console.warn(`[Scheduler] ⚠️ Intl.formatToParts retornou valores inválidos (h=${h} m=${m} s=${s}) — fallback 1h`);
+    return FALLBACK_DELAY_MS;
+  }
+
+  // Em algumas versões do ICU, "24" aparece em vez de "00" à meia-noite.
+  const hourNorm = h === 24 ? 0 : h;
+
+  const nowSecs    = hourNorm * 3600 + m * 60 + s;
+  const targetSecs = hour     * 3600 + minute * 60;
+  const diffSecs   = targetSecs > nowSecs
     ? targetSecs - nowSecs
     : 24 * 3600 - nowSecs + targetSecs;
 
@@ -39,13 +72,32 @@ async function sendDailyBriefing(): Promise<void> {
 }
 
 export function startDailyScheduler(): void {
-  const BRIEFING_HOUR = parseInt(process.env.BRIEFING_HOUR ?? '8', 10);
+  const BRIEFING_HOUR   = parseInt(process.env.BRIEFING_HOUR   ?? '8', 10);
   const BRIEFING_MINUTE = parseInt(process.env.BRIEFING_MINUTE ?? '0', 10);
 
+  // Se as env vars vierem com lixo (NaN do parseInt), usa default e avisa.
+  const safeHour   = Number.isFinite(BRIEFING_HOUR)   && BRIEFING_HOUR   >= 0 && BRIEFING_HOUR   < 24 ? BRIEFING_HOUR   : 8;
+  const safeMinute = Number.isFinite(BRIEFING_MINUTE) && BRIEFING_MINUTE >= 0 && BRIEFING_MINUTE < 60 ? BRIEFING_MINUTE : 0;
+  if (safeHour !== BRIEFING_HOUR || safeMinute !== BRIEFING_MINUTE) {
+    console.warn(`[Scheduler] env BRIEFING_HOUR/MINUTE inválido — usando ${safeHour}:${safeMinute}`);
+  }
+
   const schedule = () => {
-    const delay = msUntilNext(BRIEFING_HOUR, BRIEFING_MINUTE);
+    let delay = msUntilNext(safeHour, safeMinute);
+
+    // GUARD ANTI-LOOP: defesa em profundidade caso msUntilNext um dia falhe.
+    // setTimeout(NaN) ou setTimeout(<1ms) executa imediatamente em loop.
+    if (!Number.isFinite(delay) || delay < MIN_VALID_DELAY_MS) {
+      console.error(
+        `[Scheduler] 🚨 GUARD ANTI-LOOP: delay=${delay}ms é inválido ou muito curto. ` +
+        `Aplicando fallback de 1h pra evitar disparo em loop. ` +
+        `Investigar msUntilNext(${safeHour}, ${safeMinute}).`,
+      );
+      delay = FALLBACK_DELAY_MS;
+    }
+
     const horas = Math.round(delay / 3600000 * 10) / 10;
-    console.log(`[Scheduler] Próximo briefing diário em ${horas}h (${BRIEFING_HOUR}:${String(BRIEFING_MINUTE).padStart(2, '0')} BRT)`);
+    console.log(`[Scheduler] Próximo briefing diário em ${horas}h (${safeHour}:${String(safeMinute).padStart(2, '0')} BRT)`);
 
     setTimeout(async () => {
       await sendDailyBriefing();


### PR DESCRIPTION
## INCIDENTE EM PRODUCAO

2026-05-01 ~03:35 BRT - apos boot do v1.60.0, scheduler disparou briefing diario em loop infinito (~1 iteracao a cada 12-15 segundos), enviando 240+ mensagens WhatsApp/hora ao CEO + queimando ~46k tokens OpenAI por iteracao. Risco real de banimento WhatsApp.

Z-API foi desconectado manualmente as 03:38 pra cortar a sangria. Railway service pausado em seguida pra parar custos OpenAI.

## CAUSA RAIZ - cadeia de propagacao NaN

`msUntilNext()` em `src/agent/scheduler.ts:9-18` (codigo antigo):

```typescript
const bsb = new Date(now.toLocaleString('en-CA', { timeZone: 'America/Fortaleza', hour12: false }));
const [h, m, s] = (bsb.toTimeString().split(' ')[0]).split(':').map(Number);
```

1. `toLocaleString('en-CA', ...)` retorna `"2026-05-01, 00:35:04"` (com virgula)
2. `new Date("2026-05-01, 00:35:04")` no **Node 20 do Railway** -> `Invalid Date`
3. `Invalid Date.toTimeString()` -> `"Invalid Date"` (string literal)
4. `"Invalid Date".split(' ')[0]` -> `"Invalid"`
5. `"Invalid".split(':').map(Number)` -> `[NaN]`
6. `h = NaN`, `m = undefined`, `s = undefined`
7. `nowSecs = NaN * 3600 + undefined * 60 + undefined` -> `NaN`
8. `diffSecs = NaN`, `return NaN * 1000` -> `NaN`

`schedule()` em `scheduler.ts:50-53`:

```typescript
setTimeout(async () => { ... schedule(); }, delay);  // delay = NaN
```

Node trata `setTimeout(handler, NaN)` como 1ms. Handler executa, `schedule()` chama de novo, NaN de novo, 1ms de novo -> **loop infinito recursivo**.

## EVIDENCIA NO LOG (incidente real)

Linha repetida ~17 vezes em 5 minutos:

```
[Scheduler] Proximo briefing diario em NaNh (8:00 BRT)
[Scheduler] Gerando briefing diario das 8h...
[Tool] -> resumo_dia {}
[Tool] -> listar_eventos_hoje {}
[AI] OK OpenAI gpt-4o-mini (46533 in / 153 out)
[ZAPI sendReply] POST send-text (phone=5599991811246, msgLen=300)
[Scheduler] OK Briefing diario enviado ao CEO via WhatsApp
[Scheduler] Proximo briefing diario em NaNh (8:00 BRT)   <- LOOP
```

## FIX EM 2 CAMADAS

### Camada 1 - substituir parsing de string por Intl.DateTimeFormat.formatToParts()

```typescript
const fmt = new Intl.DateTimeFormat('en-US', {
  timeZone: 'America/Fortaleza',
  hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
});
const parts = fmt.formatToParts(now);
const h = Number(parts.find(p => p.type === 'hour')?.value ?? NaN);
const m = Number(parts.find(p => p.type === 'minute')?.value ?? NaN);
const s = Number(parts.find(p => p.type === 'second')?.value ?? NaN);
```

Robusto cross-Node-version. Sem strings intermediarias que dependem do locale.

### Camada 2 - guard anti-loop em schedule()

```typescript
if (!Number.isFinite(delay) || delay < MIN_VALID_DELAY_MS) {
  console.error(`[Scheduler] GUARD ANTI-LOOP: delay=${delay}ms invalido. Fallback 1h.`);
  delay = FALLBACK_DELAY_MS; // 1h
}
```

Defesa em profundidade: mesmo que `msUntilNext()` retorne valor invalido por outro motivo no futuro, `setTimeout` recebe minimo 1h.

### Camada 2.5 - sanitize das env vars

`BRIEFING_HOUR`/`BRIEFING_MINUTE` validados (out-of-range ou NaN -> default 8:00 + warn).

## VALIDACAO MANUAL LOCAL

```
msUntilNext(8, 0)   -> 25937000ms = 7.2h  OK (briefing diario)
msUntilNext(17, 0)  -> 58337000ms = 16.2h OK (briefing semanal)
msUntilNext(0, 0)   -> 83537000ms = 23.2h OK (meia-noite)
msUntilNext(23, 59) -> 83477000ms = 23.2h OK
Hora atual Fortaleza: 00:47:43 OK
```

**Limitacao:** meu Node 24 local parseia `"2026-05-01, 00:47:31"` SEM dar Invalid Date. Bug reproduz so no Node 20 do Railway. Evidencia primaria permanece o log do incidente em producao.

## PLANO POS-MERGE

1. Reativar Railway service
2. Verificar logs primeiros ~5 min - deve aparecer `[Scheduler] Proximo briefing diario em ~Xh (8:00 BRT)` UMA vez (X = horas reais ate proxima 8h)
3. Reconectar Z-API
4. Sem reativar Z-API se logs mostrarem qualquer `NaN` ou valor < 1h sem motivo

## ARQUIVOS-CORE NAO TOCADOS

- `src/agent/tools.ts` (vetado pelo compromisso bilateral)
- `src/agent/think.ts` (vetado)
- `src/services/aiCascade.ts` (vetado)

Apenas `src/agent/scheduler.ts` mudou (61+/9-).

## REFERENCIAS

- Issue #2 P0 race condition (sem relacao)
- Issue #3 bootstrap testes (validacao automatizada de fixes assim - pendente)
- Issue #5 tabelas faltantes (sem relacao)

## QUESTAO ABERTA - abrir issue separada se quiser?

O scheduler do briefing **semanal** (linhas similares no codigo) tambem usa o mesmo padrao? Vale auditar e estender o fix se sim. Logs do incidente mostraram so o diario falhando (semanal mostrou `16.4h` valido). Mas se o pattern existe em outros schedulers, mesmo bug pode acontecer em outras versoes do Node.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>