### PR TITLE
fix(v1.61.1): boot order startDraftCleanup + camelCase em syncContatosCRM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.61.0",
+  "version": "1.61.1",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.61.0',
+  version: '1.61.1',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/server.ts
+++ b/src/server.ts
@@ -703,10 +703,13 @@ app.listen(PORT, () => {
   void import('./agent/briefingSemanal').then(m => m.startWeeklyBriefingScheduler()).catch(() => {});
   alarmes.startAlarmesTicker();
   cowork.startCoworkWorker();
-  // v1.61.0: limpa drafts WhatsApp expirados (status awaiting_confirmation com TTL vencido)
-  void import('./services/whatsappDrafts').then(m => m.startDraftCleanup()).catch(() => {});
+  // v1.61.1: cleanup de drafts roda APÓS migrations criarem a tabela.
+  // Antes (v1.61.0), startDraftCleanup era chamado direto e a 1ª execução
+  // falhava com ER_NO_SUCH_TABLE pq runMigrations ainda nem tinha rodado.
   void initDb()
     .then(() => loadSessionFromDb())
+    .then(() => import('./services/whatsappDrafts'))
+    .then(m => m.startDraftCleanup())
     .catch(err => console.warn('[Memory] Init failed (continuing without DB):', err));
 
   // v1.39.1: sync contatos CRM → memória ZAYRA (1x ao boot + 1x/dia 04:00 BRT)

--- a/src/services/syncContatosCRM.ts
+++ b/src/services/syncContatosCRM.ts
@@ -18,7 +18,9 @@ interface LeadRow extends RowDataPacket {
   score:              string | null;
   stage:              string | null;
   campanhaOrigem:     string | null;
-  created_at:         Date | null;
+  // Schema CRM (Drizzle) usa camelCase. Antes da v1.61.1 estava 'created_at'
+  // (snake_case) e quebrava com ER_BAD_FIELD_ERROR. Mesmo bug do PR #4.
+  createdAt:          Date | null;
 }
 
 interface ContactRow extends RowDataPacket {
@@ -50,7 +52,7 @@ function leadToContent(lead: LeadRow): string {
   if (lead.score) partes.push(`Score: ${lead.score}`);
   if (lead.stage) partes.push(`Estágio: ${lead.stage}`);
   if (lead.campanhaOrigem) partes.push(`Origem: ${lead.campanhaOrigem}`);
-  if (lead.created_at) partes.push(`Cadastrado em: ${new Date(lead.created_at).toLocaleDateString('pt-BR')}`);
+  if (lead.createdAt) partes.push(`Cadastrado em: ${new Date(lead.createdAt).toLocaleDateString('pt-BR')}`);
   return partes.join(' · ');
 }
 
@@ -101,7 +103,7 @@ export async function sincronizarContatosCRM(): Promise<SyncResult> {
   let leads: LeadRow[] = [];
   try {
     const [rows] = await pool.execute<LeadRow[]>(
-      `SELECT id, phone, nome, score, stage, campanhaOrigem, created_at
+      `SELECT id, phone, nome, score, stage, campanhaOrigem, createdAt
        FROM leadQualifications
        ORDER BY id DESC LIMIT 5000`,
     );


### PR DESCRIPTION
PR #8 corrige 2 bugs detectados nos logs pos-merge do PR #7.

## Bug 1 - race condition boot (regressao PR #7)

limparExpirados rodava antes do runMigrations criar a tabela. Nao bloqueante (ticker em 5min funciona) mas errado. Fix: encadear startDraftCleanup no .then() de initDb().

## Bug 2 - syncContatosCRM com snake_case (residual PR #4)

PR #4 corrigiu dashboardRomatec.ts mas eu nao apliquei o grep no projeto inteiro. syncContatosCRM.ts continuava com 'created_at'. Corrigido pra 'createdAt' (3 lugares: interface, uso, SQL).

## Validacao
- typecheck passa
- proxima exec sync deve mostrar leads reais
- proximo boot sem 'limparExpirados inicial falhou'

## Arquivos
- src/server.ts (boot order)
- src/services/syncContatosCRM.ts (snake to camel)

Nao toca core (tools.ts, think.ts, aiCascade.ts).

Licao registrada: grep do termo problematico no projeto inteiro antes de commit, nao so no arquivo de origem do bug.