### PR TITLE
feat(v1.63.0): equipe - cadastro completo 15 campos (Implementacao 2 final)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.62.0",
+  "version": "1.63.0",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.62.0',
+  version: '1.63.0',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -690,14 +690,28 @@ export async function runMigrations(): Promise<void> {
   `);
 
   // v1.62.0: campos de auditoria pra romatec_obra_transacoes (soft delete + tracking).
+  // v1.63.0: 9 colunas novas em romatec_obra_equipe (cadastro completo de membro:
+  //          RG, email, data_admissao, endereço completo, foto).
   // Idempotente: cada ALTER em try/catch porque ALTER TABLE ADD COLUMN não tem IF NOT EXISTS no MySQL 5.7/8.0
   // (existe em MariaDB 10.4+ e MySQL 8.0.29+, mas Railway usa imagens variáveis).
   for (const stmt of [
+    // v1.62.0
     `ALTER TABLE romatec_obra_transacoes ADD COLUMN deleted_at TIMESTAMP NULL`,
     `ALTER TABLE romatec_obra_transacoes ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`,
     `ALTER TABLE romatec_obra_transacoes ADD COLUMN updated_by VARCHAR(80) NULL`,
     `ALTER TABLE romatec_obra_transacoes ADD COLUMN deleted_by VARCHAR(80) NULL`,
     `ALTER TABLE romatec_obra_transacoes ADD INDEX idx_obra_deleted (obra_id, deleted_at)`,
+    // v1.63.0 — cadastro completo de membro
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN rg                VARCHAR(20)  NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN email             VARCHAR(150) NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN data_admissao     DATE         NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_rua      VARCHAR(200) NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_numero   VARCHAR(20)  NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_bairro   VARCHAR(120) NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_cidade   VARCHAR(120) NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_estado   VARCHAR(2)   NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_cep      VARCHAR(10)  NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN foto_url          VARCHAR(500) NULL`,
   ]) {
     try {
       await pool.execute(stmt);
@@ -705,7 +719,7 @@ export async function runMigrations(): Promise<void> {
       const msg = (err as Error).message ?? '';
       // Ignora "Duplicate column name" / "Duplicate key name" — coluna/index já existe (idempotência manual).
       if (!/Duplicate column|Duplicate key/i.test(msg)) {
-        console.warn(`[DB] migration v1.62.0 stmt falhou (não-bloqueante): ${msg.slice(0, 120)}`);
+        console.warn(`[DB] migration ALTER falhou (não-bloqueante): ${msg.slice(0, 120)}`);
       }
     }
   }

--- a/src/integrations/obras.ts
+++ b/src/integrations/obras.ts
@@ -483,17 +483,29 @@ export async function listarEquipe(input: { obra_id?: string; somente_geral?: bo
 export async function atualizarMembroEquipe(input: {
   id: string;
   nome?: string; funcao?: string; tipo_contrato?: string;
-  cpf?: string; telefone?: string; valor_dia?: number;
+  cpf?: string; rg?: string; telefone?: string; email?: string;
+  valor_dia?: number;
   especialidade?: string; observacoes?: string;
+  data_admissao?: string;
+  endereco_rua?: string; endereco_numero?: string; endereco_bairro?: string;
+  endereco_cidade?: string; endereco_estado?: string; endereco_cep?: string;
+  foto_url?: string;
   obra_id?: string | null; ativo?: boolean;
   confirm?: boolean;
 }): Promise<MutationResult> {
   if (!input.id) throw new Error('id obrigatório');
   const fields: string[] = []; const params: (string | number | null)[] = [];
+  // v1.63.0: aceita 9 colunas novas (RG, email, data_admissao, endereço, foto)
   const map: Record<string, string> = {
     nome: 'nome', funcao: 'funcao', tipo_contrato: 'tipo_contrato',
-    cpf: 'cpf', telefone: 'telefone', valor_dia: 'valor_dia',
+    cpf: 'cpf', rg: 'rg', telefone: 'telefone', email: 'email',
+    valor_dia: 'valor_dia',
     especialidade: 'especialidade', observacoes: 'observacoes',
+    data_admissao: 'data_admissao',
+    endereco_rua: 'endereco_rua', endereco_numero: 'endereco_numero',
+    endereco_bairro: 'endereco_bairro', endereco_cidade: 'endereco_cidade',
+    endereco_estado: 'endereco_estado', endereco_cep: 'endereco_cep',
+    foto_url: 'foto_url',
   };
   for (const [k, col] of Object.entries(map)) {
     const v = (input as Record<string, unknown>)[k];
@@ -509,7 +521,7 @@ export async function atualizarMembroEquipe(input: {
   }
   if (fields.length === 0) throw new Error('nada pra atualizar');
   if (!input.confirm) {
-    return { preview: true, message: `[PREVIEW] Atualizar membro ${input.id}: ${fields.join(', ')}. Reenvie com confirm:true.` };
+    return { preview: true, message: `[PREVIEW] Atualizar membro ${input.id}: ${fields.length} campo(s). Reenvie com confirm:true.` };
   }
   params.push(input.id);
   const [r] = await pool.execute<ResultSetHeader>(
@@ -588,23 +600,37 @@ export async function apagarMaterial(input: {
 
 export async function criarMembroEquipe(input: {
   nome: string; funcao?: string; tipo_contrato?: string;
-  cpf?: string; telefone?: string; valor_dia?: number;
+  cpf?: string; rg?: string; telefone?: string; email?: string;
+  valor_dia?: number;
   especialidade?: string; observacoes?: string;
+  data_admissao?: string;
+  endereco_rua?: string; endereco_numero?: string; endereco_bairro?: string;
+  endereco_cidade?: string; endereco_estado?: string; endereco_cep?: string;
+  foto_url?: string;
   obras_ids?: string[]; obra_id?: string; confirm?: boolean;
 }): Promise<MutationResult> {
   if (!input.nome) throw new Error('nome obrigatório');
   if (!input.confirm) {
     return { preview: true, message: `[PREVIEW] Criar ${input.nome} na equipe${input.obra_id ? ` (obra ${input.obra_id})` : ' (geral)'}. Reenvie com confirm:true.` };
   }
+  // v1.63.0: insert com 18 colunas (9 novas)
   const [r] = await pool.execute<ResultSetHeader>(
     `INSERT INTO romatec_obra_equipe
-      (nome, funcao, tipo_contrato, cpf, telefone, valor_dia, especialidade, observacoes, obras_ids, obra_id)
-     VALUES (?,?,?,?,?,?,?,?,?,?)`,
+      (nome, funcao, tipo_contrato, cpf, rg, telefone, email, valor_dia,
+       especialidade, observacoes, data_admissao,
+       endereco_rua, endereco_numero, endereco_bairro, endereco_cidade,
+       endereco_estado, endereco_cep, foto_url, obras_ids, obra_id)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     [
       input.nome, input.funcao ?? null, input.tipo_contrato ?? 'diarista',
-      input.cpf ?? null, input.telefone ?? null,
+      input.cpf ?? null, input.rg ?? null,
+      input.telefone ?? null, input.email ?? null,
       input.valor_dia ?? null, input.especialidade ?? null,
-      input.observacoes ?? null,
+      input.observacoes ?? null, input.data_admissao ?? null,
+      input.endereco_rua ?? null, input.endereco_numero ?? null,
+      input.endereco_bairro ?? null, input.endereco_cidade ?? null,
+      input.endereco_estado ?? null, input.endereco_cep ?? null,
+      input.foto_url ?? null,
       (input.obras_ids ?? []).join(','),
       input.obra_id ? Number(input.obra_id) : null,
     ],

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1041,15 +1041,30 @@ function renderEquipe() {
       <select id="pObraId" style="width:100%; margin-top:4px;">${obraOpts}</select>
     </div>
     <div class="form-grid">
-      <input id="pNome" placeholder="Nome *">
+      <input id="pNome" placeholder="Nome completo *">
       <input id="pFunc" placeholder="Função (auto)">
-      <select id="pTipo"><option value="diarista">Diarista</option><option value="clt">CLT</option><option value="empreitada">Empreitada</option><option value="terceirizado">Terceirizado</option></select>
+      <select id="pTipo"><option value="diarista">Diarista</option><option value="clt">CLT</option><option value="empreitada">Empreitada</option><option value="terceirizado">Terceirizado</option><option value="pj">PJ</option></select>
       <input id="pCPF" placeholder="CPF">
+      <input id="pRG" placeholder="RG">
       <input id="pTel" placeholder="Telefone">
+      <input id="pEmail" type="email" placeholder="E-mail">
+      <input id="pDtAdm" type="date" placeholder="Data admissão">
       <input id="pVal" type="number" step="0.01" placeholder="Valor diária (R$) *" required>
       <input id="pEsp" placeholder="Especialidade">
     </div>
-    <textarea id="pObs" placeholder="Observações" rows="2" style="margin-bottom:8px;"></textarea>
+    <p style="margin:14px 0 6px; font-size:11px; color:var(--text-muted); text-transform:uppercase; letter-spacing:0.5px;">Endereço (opcional)</p>
+    <div class="form-grid">
+      <input id="pEndRua" placeholder="Rua / Logradouro" style="grid-column: span 2;">
+      <input id="pEndNum" placeholder="Número">
+      <input id="pEndBairro" placeholder="Bairro">
+      <input id="pEndCidade" placeholder="Cidade">
+      <select id="pEndUf"><option value="">UF</option>${['AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'].map(u=>`<option>${u}</option>`).join('')}</select>
+      <input id="pEndCep" placeholder="CEP">
+    </div>
+    <div style="margin-top:8px;">
+      <input id="pFoto" placeholder="Foto (URL — opcional)" style="width:100%;">
+    </div>
+    <textarea id="pObs" placeholder="Observações" rows="2" style="margin:8px 0;"></textarea>
     <button class="btn-primary" id="addEq">Adicionar membro</button>
   </div>
   <p class="section-title" style="margin-top:16px;">Equipe (${state.equipe.length})</p>
@@ -1092,14 +1107,24 @@ function renderEquipe() {
         method: 'POST',
         body: JSON.stringify({
           nome,
-          funcao: document.getElementById('pFunc').value.trim() || null,
-          tipo_contrato: document.getElementById('pTipo').value,
-          cpf: document.getElementById('pCPF').value.trim() || null,
-          telefone: document.getElementById('pTel').value.trim() || null,
-          valor_dia: valorDia,
-          especialidade: document.getElementById('pEsp').value.trim() || null,
-          observacoes: document.getElementById('pObs').value.trim() || null,
-          obra_id: document.getElementById('pObraId').value || null,
+          funcao:          document.getElementById('pFunc').value.trim() || null,
+          tipo_contrato:   document.getElementById('pTipo').value,
+          cpf:             document.getElementById('pCPF').value.trim() || null,
+          rg:              document.getElementById('pRG').value.trim() || null,
+          telefone:        document.getElementById('pTel').value.trim() || null,
+          email:           document.getElementById('pEmail').value.trim() || null,
+          data_admissao:   document.getElementById('pDtAdm').value || null,
+          valor_dia:       valorDia,
+          especialidade:   document.getElementById('pEsp').value.trim() || null,
+          endereco_rua:    document.getElementById('pEndRua').value.trim() || null,
+          endereco_numero: document.getElementById('pEndNum').value.trim() || null,
+          endereco_bairro: document.getElementById('pEndBairro').value.trim() || null,
+          endereco_cidade: document.getElementById('pEndCidade').value.trim() || null,
+          endereco_estado: document.getElementById('pEndUf').value || null,
+          endereco_cep:    document.getElementById('pEndCep').value.trim() || null,
+          foto_url:        document.getElementById('pFoto').value.trim() || null,
+          observacoes:     document.getElementById('pObs').value.trim() || null,
+          obra_id:         document.getElementById('pObraId').value || null,
         }),
       });
       render();
@@ -1823,44 +1848,82 @@ function fecharEditar() {
 function abrirEditarMembro(m) {
   const obraOpts = '<option value="">Geral (todas as obras)</option>' +
     state.obras.map(o => `<option value="${o.id}" ${o.id===m.obra_id?'selected':''}>${escape(o.nome)}</option>`).join('');
-  const tipos = ['diarista','clt','empreitada','terceirizado'];
+  const tipos = ['diarista','clt','empreitada','terceirizado','pj'];
   const tipoOpts = tipos.map(t => `<option value="${t}" ${t===m.tipo_contrato?'selected':''}>${t}</option>`).join('');
+  const ufs = ['AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'];
+  const ufOpts = '<option value="">UF</option>' + ufs.map(u => `<option ${u===m.endereco_estado?'selected':''}>${u}</option>`).join('');
+  const dtAdm = m.data_admissao ? String(m.data_admissao).slice(0, 10) : '';
 
-  // v1.62.0: modal completo — adicionados CPF e Observações (faltavam pre-1.62)
+  // v1.63.0: modal espelho do form de cadastro — 15 campos completos
   const body = `
     <div class="form-grid">
-      <input id="eNome" placeholder="Nome *" value="${escape(m.nome||'')}">
-      <input id="eFunc" placeholder="Função" value="${escape(m.funcao||'')}">
+      <input id="eNome" placeholder="Nome completo *" value="${escape(m.nome||'')}">
+      <input id="eFunc" placeholder="Cargo / Função" value="${escape(m.funcao||'')}">
       <select id="eTipo">${tipoOpts}</select>
       <input id="eCpf" placeholder="CPF" value="${escape(m.cpf||'')}">
+      <input id="eRg" placeholder="RG" value="${escape(m.rg||'')}">
       <input id="eTel" placeholder="Telefone" value="${escape(m.telefone||'')}">
-      <input id="eVal" type="number" step="0.01" placeholder="Valor diária (R$)" value="${m.valor_dia||''}">
+      <input id="eEmail" type="email" placeholder="E-mail" value="${escape(m.email||'')}">
+      <input id="eDtAdm" type="date" placeholder="Data admissão" value="${dtAdm}">
+      <input id="eVal" type="number" step="0.01" placeholder="Valor diária / salário (R$)" value="${m.valor_dia||''}">
       <input id="eEsp" placeholder="Especialidade" value="${escape(m.especialidade||'')}">
     </div>
-    <div style="margin-top:8px;">
-      <label style="font-size:11px; color:var(--text-muted); text-transform:uppercase;">Obra</label>
+    <p style="margin:14px 0 6px; font-size:11px; color:var(--text-muted); text-transform:uppercase; letter-spacing:0.5px;">Endereço</p>
+    <div class="form-grid">
+      <input id="eEndRua" placeholder="Rua / Logradouro" value="${escape(m.endereco_rua||'')}" style="grid-column: span 2;">
+      <input id="eEndNum" placeholder="Número" value="${escape(m.endereco_numero||'')}">
+      <input id="eEndBairro" placeholder="Bairro" value="${escape(m.endereco_bairro||'')}">
+      <input id="eEndCidade" placeholder="Cidade" value="${escape(m.endereco_cidade||'')}">
+      <select id="eEndUf">${ufOpts}</select>
+      <input id="eEndCep" placeholder="CEP" value="${escape(m.endereco_cep||'')}">
+    </div>
+    <div style="margin-top:14px;">
+      <label style="font-size:11px; color:var(--text-muted); text-transform:uppercase;">Obra principal</label>
       <select id="eObraId" style="width:100%; margin-top:4px;">${obraOpts}</select>
+    </div>
+    <div style="margin-top:8px;">
+      <label style="font-size:11px; color:var(--text-muted); text-transform:uppercase;">Foto (URL)</label>
+      <input id="eFoto" placeholder="https://..." value="${escape(m.foto_url||'')}" style="width:100%; margin-top:4px;">
     </div>
     <div style="margin-top:8px;">
       <label style="font-size:11px; color:var(--text-muted); text-transform:uppercase;">Observações</label>
       <textarea id="eObs" rows="3" style="width:100%; margin-top:4px; resize:vertical;">${escape(m.observacoes||'')}</textarea>
     </div>
+    <div style="margin-top:12px; display:flex; gap:6px; align-items:center;">
+      <input type="checkbox" id="eAtivo" ${m.ativo===false || m.ativo===0?'':'checked'}>
+      <label for="eAtivo" style="font-size:13px; color:var(--text-muted);">Membro ativo</label>
+    </div>
   `;
   abrirEditar(`Editar membro — ${m.nome}`, body, async () => {
     const nome = document.getElementById('eNome').value.trim();
     if (!nome) { alert('Nome é obrigatório'); throw new Error('Nome obrigatório'); }
+    const email = document.getElementById('eEmail').value.trim();
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      alert('E-mail inválido'); throw new Error('Email inválido');
+    }
     await api('/api/equipe/' + m.id, {
       method: 'PUT',
       body: JSON.stringify({
         nome,
-        funcao:        document.getElementById('eFunc').value.trim() || null,
-        tipo_contrato: document.getElementById('eTipo').value,
-        cpf:           document.getElementById('eCpf').value.trim() || null,
-        telefone:      document.getElementById('eTel').value.trim() || null,
-        valor_dia:     parseFloat(document.getElementById('eVal').value) || null,
-        especialidade: document.getElementById('eEsp').value.trim() || null,
-        observacoes:   document.getElementById('eObs').value.trim() || null,
-        obra_id:       document.getElementById('eObraId').value || null,
+        funcao:          document.getElementById('eFunc').value.trim() || null,
+        tipo_contrato:   document.getElementById('eTipo').value,
+        cpf:             document.getElementById('eCpf').value.trim() || null,
+        rg:              document.getElementById('eRg').value.trim() || null,
+        telefone:        document.getElementById('eTel').value.trim() || null,
+        email:           email || null,
+        data_admissao:   document.getElementById('eDtAdm').value || null,
+        valor_dia:       parseFloat(document.getElementById('eVal').value) || null,
+        especialidade:   document.getElementById('eEsp').value.trim() || null,
+        endereco_rua:    document.getElementById('eEndRua').value.trim() || null,
+        endereco_numero: document.getElementById('eEndNum').value.trim() || null,
+        endereco_bairro: document.getElementById('eEndBairro').value.trim() || null,
+        endereco_cidade: document.getElementById('eEndCidade').value.trim() || null,
+        endereco_estado: document.getElementById('eEndUf').value || null,
+        endereco_cep:    document.getElementById('eEndCep').value.trim() || null,
+        foto_url:        document.getElementById('eFoto').value.trim() || null,
+        observacoes:     document.getElementById('eObs').value.trim() || null,
+        ativo:           document.getElementById('eAtivo').checked,
+        obra_id:         document.getElementById('eObraId').value || null,
       }),
     });
   });


### PR DESCRIPTION
Completa a Implementacao 2 do briefing (PR #10 entregou CPF + Observacoes; esse PR entrega o resto).

## Migration

9 colunas novas em romatec_obra_equipe (idempotente):
rg, email, data_admissao, endereco_rua, endereco_numero, endereco_bairro, endereco_cidade, endereco_estado, endereco_cep, foto_url.

## Integration

atualizarMembroEquipe e criarMembroEquipe agora aceitam todos os 15 campos.

## Frontend (obras.html)

**Modal de edicao (abrirEditarMembro)**: 15 campos completos divididos em secoes (dados pessoais / endereco / obra / foto / observacoes / status). Validacao de email regex.

**Form de cadastro 'Novo membro'**: espelhado, 15 campos identicos. DRY entre cadastro e edicao.

**Adicionados**: select de UF com 27 estados, opcao PJ no tipo_contrato.

## Criterios de aceite

? Modal mostra TODOS os 15 campos do cadastro
? Validacao email regex
? Status ativo/inativo via checkbox
? Endereco completo (5 campos)
? Form de cadastro tambem foi atualizado (DRY)

## Arquivos

- src/database/migrations.ts
- src/integrations/obras.ts
- src/public/obras.html

Nao toca core (tools.ts, think.ts, aiCascade.ts).