### PR TITLE
feat(v1.64.0): white-label estrutural - tenant_settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.63.0',
+  version: '1.64.0',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -717,12 +717,41 @@ export async function runMigrations(): Promise<void> {
       await pool.execute(stmt);
     } catch (err) {
       const msg = (err as Error).message ?? '';
-      // Ignora "Duplicate column name" / "Duplicate key name" — coluna/index já existe (idempotência manual).
       if (!/Duplicate column|Duplicate key/i.test(msg)) {
         console.warn(`[DB] migration ALTER falhou (não-bloqueante): ${msg.slice(0, 120)}`);
       }
     }
   }
+
+  // v1.64.0: tenant_settings — preparação white-label estrutural.
+  // Mono-tenant agora (Romatec). Estrutura pronta pra trocar logo/marca via UPDATE
+  // quando virar SaaS. NÃO inclui multi-tenant real (auth, isolamento, billing).
+  await pool.execute(`
+    CREATE TABLE IF NOT EXISTS tenant_settings (
+      id                 INT AUTO_INCREMENT PRIMARY KEY,
+      tenant_id          INT NOT NULL DEFAULT 1,
+      brand_name         VARCHAR(150) NOT NULL,
+      brand_short_name   VARCHAR(50),
+      logo_path          VARCHAR(500),
+      primary_color      VARCHAR(7) DEFAULT '#10b981',
+      document_footer    TEXT,
+      cnpj               VARCHAR(20),
+      endereco           VARCHAR(255),
+      telefone           VARCHAR(20),
+      email              VARCHAR(150),
+      site               VARCHAR(150),
+      atualizado_em      TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      UNIQUE KEY uk_tenant (tenant_id)
+    )
+  `);
+  // Insert padrão Romatec (idempotente — INSERT IGNORE não falha se já existir)
+  await pool.execute(`
+    INSERT IGNORE INTO tenant_settings
+      (tenant_id, brand_name, brand_short_name, logo_path, primary_color, cnpj, telefone, email)
+    VALUES
+      (1, 'Romatec Consultoria Imobiliária', 'Romatec', '/romatec-logo.jpg', '#10b981',
+       NULL, NULL, 'romateccrm@gmail.com')
+  `);
 
   console.log('[DB] Migrations complete');
 }

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -380,9 +380,12 @@
 <body>
 <div class="container">
   <div class="header">
-    <div>
-      <h1>GESTÃO DE OBRAS</h1>
-      <p>ZAYRA · Romatec Consultoria Imobiliária</p>
+    <div style="display:flex; align-items:center; gap:14px;">
+      <img id="brandLogo" src="" alt="" style="display:none; max-height:42px; max-width:80px; border-radius:6px;">
+      <div>
+        <h1 id="brandTitle">GESTÃO DE OBRAS</h1>
+        <p id="brandSubtitle">ZAYRA · Romatec Consultoria Imobiliária</p>
+      </div>
     </div>
     <div style="display:flex; gap:8px; align-items:center;">
       <span class="badge-zayra" id="versionBadge">v...</span>
@@ -497,6 +500,30 @@ fetch(API + '/health')
   .then(d => {
     const el = document.getElementById('versionBadge');
     if (el && d.version) el.textContent = 'v' + d.version;
+  })
+  .catch(() => {});
+
+// v1.64.0: tenant_settings (white-label estrutural).
+// Busca logo + brand_name dinamicamente. Default Romatec se API offline.
+fetch(API + '/api/tenant-settings')
+  .then(r => r.json())
+  .then(t => {
+    if (!t) return;
+    const img = document.getElementById('brandLogo');
+    if (img && t.logo_path) {
+      img.src = t.logo_path;
+      img.alt = t.brand_short_name || t.brand_name || '';
+      img.style.display = 'inline-block';
+      img.onerror = () => { img.style.display = 'none'; };  // some se logo falhar
+    }
+    if (t.brand_name) {
+      const sub = document.getElementById('brandSubtitle');
+      if (sub) sub.textContent = `ZAYRA · ${t.brand_name}`;
+    }
+    // Cor primária (CSS variable opcional — não muda hoje pra preservar visual)
+    if (t.primary_color && t.primary_color !== '#10b981') {
+      document.documentElement.style.setProperty('--neon', t.primary_color);
+    }
   })
   .catch(() => {});
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -602,6 +602,25 @@ function requireCeoToken(req: Request, res: Response, next: () => void): void {
   next();
 }
 
+// v1.64.0: tenant settings (white-label estrutural). GET é público, PUT só CEO.
+app.get('/api/tenant-settings', async (_req: Request, res: Response) => {
+  try {
+    const m = await import('./services/tenantSettings');
+    res.json(await m.getTenantSettings(1));
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+app.put('/api/tenant-settings', requireCeoToken, async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/tenantSettings');
+    const updated = await m.atualizarTenantSettings(1, req.body ?? {});
+    res.json(updated);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
 // Transações
 app.get ('/api/transacoes', apiHandle(args => obras.listarTransacoesObra(args as Parameters<typeof obras.listarTransacoesObra>[0])));
 app.post('/api/transacoes', apiHandle(args => obras.criarTransacaoObra(args as Parameters<typeof obras.criarTransacaoObra>[0])));

--- a/src/services/tenantSettings.ts
+++ b/src/services/tenantSettings.ts
@@ -1,0 +1,101 @@
+// v1.64.0 — Configurações de tenant (white-label estrutural).
+//
+// Hoje mono-tenant: tenant_id=1 (Romatec). Estrutura pronta pra futuro SaaS
+// onde cada cliente terá seu próprio logo/marca via UPDATE na tabela.
+//
+// NÃO inclui (escopo v2):
+//   - Multi-tenant real (auth, isolamento de dados, billing)
+//   - UI admin pra trocar logo
+//   - Onboarding de novos clientes
+//
+// Função principal `getTenantSettings()` cacheia em memória 5 min pra evitar
+// query repetida em toda chamada de PDF/header.
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../database/connection';
+
+export interface TenantSettings {
+  id:               number;
+  tenant_id:        number;
+  brand_name:       string;
+  brand_short_name: string | null;
+  logo_path:        string | null;
+  primary_color:    string;
+  document_footer:  string | null;
+  cnpj:             string | null;
+  endereco:         string | null;
+  telefone:         string | null;
+  email:            string | null;
+  site:             string | null;
+}
+
+interface TenantRow extends RowDataPacket, TenantSettings {}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<number, { data: TenantSettings; ts: number }>();
+
+const DEFAULT_FALLBACK: TenantSettings = {
+  id: 0,
+  tenant_id: 1,
+  brand_name: 'Romatec Consultoria Imobiliária',
+  brand_short_name: 'Romatec',
+  logo_path: '/romatec-logo.jpg',
+  primary_color: '#10b981',
+  document_footer: null,
+  cnpj: null,
+  endereco: null,
+  telefone: null,
+  email: null,
+  site: null,
+};
+
+export async function getTenantSettings(tenantId = 1): Promise<TenantSettings> {
+  const cached = cache.get(tenantId);
+  if (cached && (Date.now() - cached.ts) < CACHE_TTL_MS) {
+    return cached.data;
+  }
+  try {
+    const [rows] = await pool.execute<TenantRow[]>(
+      `SELECT id, tenant_id, brand_name, brand_short_name, logo_path,
+              primary_color, document_footer, cnpj, endereco, telefone, email, site
+       FROM tenant_settings WHERE tenant_id = ? LIMIT 1`,
+      [tenantId],
+    );
+    if (rows.length === 0) {
+      console.warn(`[tenantSettings] tenant_id=${tenantId} não encontrado, usando defaults Romatec`);
+      return DEFAULT_FALLBACK;
+    }
+    const data = rows[0] as TenantSettings;
+    cache.set(tenantId, { data, ts: Date.now() });
+    return data;
+  } catch (err) {
+    console.warn('[tenantSettings] DB falhou, usando defaults:', (err as Error).message);
+    return DEFAULT_FALLBACK;
+  }
+}
+
+export async function atualizarTenantSettings(
+  tenantId: number,
+  patch: Partial<Omit<TenantSettings, 'id' | 'tenant_id'>>,
+): Promise<TenantSettings> {
+  const sets: string[] = [];
+  const params: (string | number | null)[] = [];
+  for (const k of [
+    'brand_name','brand_short_name','logo_path','primary_color','document_footer',
+    'cnpj','endereco','telefone','email','site',
+  ] as const) {
+    if (patch[k] !== undefined) { sets.push(`${k} = ?`); params.push(patch[k] ?? null); }
+  }
+  if (!sets.length) throw new Error('Nada pra atualizar.');
+  params.push(tenantId);
+  await pool.execute<ResultSetHeader>(
+    `UPDATE tenant_settings SET ${sets.join(', ')} WHERE tenant_id = ?`, params,
+  );
+  cache.delete(tenantId); // invalida cache
+  return getTenantSettings(tenantId);
+}
+
+export function invalidarCache(tenantId?: number): void {
+  if (tenantId !== undefined) cache.delete(tenantId);
+  else cache.clear();
+}


### PR DESCRIPTION
Implementacao 4 do briefing. Tabela tenant_settings + service com cache 5min + endpoints GET (publico) e PUT (admin via X-CEO-Token). Frontend obras.html agora carrega logo+brand_name dinamico via /api/tenant-settings. Sistema visualmente identico hoje (Romatec). Logo limpo: src/public/romatec-logo.jpg (144KB unico). Nao toca core.