### PR TITLE
v1.65.1: troca logo do header pro logo_R-removebg-preview.png

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.0",
+  "version": "1.65.1",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.0',
+  version: '1.65.1',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -749,8 +749,20 @@ export async function runMigrations(): Promise<void> {
     INSERT IGNORE INTO tenant_settings
       (tenant_id, brand_name, brand_short_name, logo_path, primary_color, cnpj, telefone, email)
     VALUES
-      (1, 'Romatec Consultoria Imobiliária', 'Romatec', '/romatec-logo.jpg', '#10b981',
+      (1, 'Romatec Consultoria Imobiliária', 'Romatec', '/logo_R-removebg-preview.png', '#10b981',
        NULL, NULL, 'romateccrm@gmail.com')
+  `);
+  // v1.65.1: migra logos antigos (jpg, removebg-preview anterior) pro novo PNG transparente
+  await pool.execute(`
+    UPDATE tenant_settings
+       SET logo_path = '/logo_R-removebg-preview.png'
+     WHERE tenant_id = 1
+       AND logo_path IN (
+         '/romatec-logo.jpg',
+         '/LOGO ROMATEC ATUAL.jpg',
+         '/LOGO%20ROMATEC%20ATUAL.jpg',
+         '/romatec-logo-removebg-preview.png'
+       )
   `);
 
   // v1.65.0: Implementação 1 — Proposta de Mão de Obra (schema + catálogo SINAPI)

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1471,12 +1471,12 @@ const ROMATEC_HEADER_CSS = `
 .romatec-header{text-align:center;border-bottom:3px solid #0a3d2a;padding-bottom:14px;margin-bottom:18px;}
 .romatec-header img{max-height:100px;max-width:80%;height:auto;display:inline-block;}
 `;
-// v1.65.0: logo path veio pra /romatec-logo.jpg após limpeza de arquivos
-// (PR #12). Antes: /LOGO%20ROMATEC%20ATUAL.jpg (deletado, dava 404 nos recibos/PDFs).
-// alt-text mantido conservador; brand vem do tenant_settings via JS quando relevante.
+// v1.65.1: troca pro logo R em PNG transparente (logo_R-removebg-preview.png).
+// Histórico: /LOGO%20ROMATEC%20ATUAL.jpg (deletado) → /romatec-logo.jpg → atual.
+// brand vem do tenant_settings via JS quando relevante.
 const ROMATEC_HEADER_HTML = `
 <div class="romatec-header">
-  <img src="/romatec-logo.jpg" alt="Romatec Consultoria Total — Engenharia e Agrimensura">
+  <img src="/logo_R-removebg-preview.png" alt="Romatec Consultoria Total — Engenharia e Agrimensura">
 </div>
 `;
 


### PR DESCRIPTION
## Resumo
Troca o logo do header (e dos recibos/PDFs) pro novo PNG transparente logo_R-removebg-preview.png (175KB) que o CEO subiu.

## Mudancas
- migrations.ts: INSERT IGNORE com novo logo_path + UPDATE conditional migrando paths antigos (/romatec-logo.jpg, /LOGO ROMATEC ATUAL.jpg, /romatec-logo-removebg-preview.png) pro novo PNG.
- obras.html ROMATEC_HEADER_HTML: aponta pra /logo_R-removebg-preview.png (recibos/PDFs).
- Bump versao pra 1.65.1 (package.json + identity.ts).

## Como aplica na UI
- Barra superior: brandLogo le logo_path dinamico de /api/tenant-settings. Apos boot, a migracao UPDATE corrige tenant_settings.logo_path -> proximo refresh mostra o logo novo automaticamente.
- Recibos/PDFs: ROMATEC_HEADER_HTML e fallback estatico embedded no HTML, tambem trocado.

## Test plan
- [ ] Apos merge + deploy Railway, validar logo na barra superior de /obras.html
- [ ] Gerar recibo de transacao e validar logo no PDF
- [ ] Confirmar via API que tenant_settings.logo_path = /logo_R-removebg-preview.png