### PR TITLE
v1.65.2: aba Proposta — backend + UI editor com catálogo SINAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.1",
+  "version": "1.65.2",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.1',
+  version: '1.65.2',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/integrations/propostas.ts
+++ b/src/integrations/propostas.ts
@@ -1,0 +1,493 @@
+// v1.65.2: módulo de Propostas de Mão de Obra (Romatec) — backend CRUD.
+// Tabelas: sinapi_servicos (catálogo), propostas_clientes (clientes da proposta,
+// distinto do CRM), propostas (cabeçalho), proposta_itens (linhas).
+// Soft delete via deleted_at em propostas e propostas_clientes.
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../database/connection';
+import { formatBR, formatBRDate } from '../util/format';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+type SinapiRow = RowDataPacket & {
+  id: number; codigo_sinapi: string | null;
+  categoria: string; subcategoria: string | null;
+  descricao: string; unidade: string;
+  valor_referencia: string | null;
+  valor_e_referencial: number; ativo: number;
+};
+
+type ClienteRow = RowDataPacket & {
+  id: number; nome: string; cpf_cnpj: string | null;
+  telefone: string | null; email: string | null;
+  endereco: string | null; cidade: string | null;
+  estado: string | null; cep: string | null;
+  observacoes: string | null;
+  criado_em: Date; atualizado_em: Date;
+};
+
+type PropostaRow = RowDataPacket & {
+  id: number; numero: string;
+  cliente_id: number; cliente_nome?: string;
+  endereco_obra: string | null;
+  data_proposta: Date; validade_dias: number;
+  valor_total: string;
+  observacoes: string | null;
+  status: 'rascunho' | 'enviada' | 'aceita' | 'recusada' | 'expirada';
+  pdf_path: string | null;
+  enviada_whatsapp: number; enviada_em: Date | null;
+  criada_por: string | null;
+  criado_em: Date; atualizado_em: Date;
+};
+
+type ItemRow = RowDataPacket & {
+  id: number; proposta_id: number; servico_id: number | null;
+  descricao: string; unidade: string;
+  quantidade: string; valor_unitario: string; valor_total: string;
+  ordem: number;
+};
+
+export interface MutationResult {
+  ok: true;
+  affected?: number;
+  insertId?: number;
+  message: string;
+}
+
+const num = (v: string | null | undefined): number => v ? Number(v) : 0;
+
+// ── Catálogo SINAPI ──────────────────────────────────────────────────────────
+export async function listarCatalogoSinapi(input: {
+  busca?: string; categoria?: string; ativo?: boolean;
+  agrupado?: boolean;
+} = {}) {
+  const params: (string | number)[] = [];
+  let sql = `SELECT id, codigo_sinapi, categoria, subcategoria, descricao, unidade,
+                    valor_referencia, valor_e_referencial, ativo
+               FROM sinapi_servicos WHERE 1=1`;
+  if (input.ativo !== false) { sql += ' AND ativo = 1'; }
+  if (input.categoria) { sql += ' AND categoria = ?'; params.push(input.categoria); }
+  if (input.busca) {
+    sql += ' AND (descricao LIKE ? OR codigo_sinapi LIKE ?)';
+    params.push(`%${input.busca}%`, `%${input.busca}%`);
+  }
+  sql += ' ORDER BY categoria, subcategoria, descricao';
+  const [rows] = await pool.execute<SinapiRow[]>(sql, params);
+  const items = rows.map(r => ({
+    id: String(r.id),
+    codigo_sinapi: r.codigo_sinapi,
+    categoria: r.categoria,
+    subcategoria: r.subcategoria,
+    descricao: r.descricao,
+    unidade: r.unidade,
+    valor_referencia: num(r.valor_referencia),
+    valor_e_referencial: !!r.valor_e_referencial,
+    ativo: !!r.ativo,
+  }));
+  if (input.agrupado) {
+    const grupos: Record<string, typeof items> = {};
+    for (const it of items) {
+      if (!grupos[it.categoria]) grupos[it.categoria] = [];
+      grupos[it.categoria].push(it);
+    }
+    return { agrupado: true, total: items.length, categorias: grupos };
+  }
+  return { total: items.length, items };
+}
+
+export async function listarCategoriasSinapi() {
+  const [rows] = await pool.execute<RowDataPacket[]>(`
+    SELECT categoria, COUNT(*) AS qtd
+      FROM sinapi_servicos WHERE ativo = 1
+     GROUP BY categoria ORDER BY categoria
+  `);
+  return rows.map(r => ({ categoria: String(r.categoria), qtd: Number(r.qtd) }));
+}
+
+// ── Clientes ─────────────────────────────────────────────────────────────────
+export async function listarClientesProposta(input: { busca?: string; limite?: number } = {}) {
+  const limit = Math.min(Math.max(Number(input.limite) || 100, 1), 500);
+  const params: (string | number)[] = [];
+  let sql = 'SELECT * FROM propostas_clientes WHERE deleted_at IS NULL';
+  if (input.busca) {
+    sql += ' AND (nome LIKE ? OR cpf_cnpj LIKE ? OR telefone LIKE ?)';
+    const q = `%${input.busca}%`;
+    params.push(q, q, q);
+  }
+  sql += ` ORDER BY nome ASC LIMIT ${limit}`;
+  const [rows] = await pool.execute<ClienteRow[]>(sql, params);
+  return rows.map(r => ({
+    id: String(r.id),
+    nome: r.nome,
+    cpf_cnpj: r.cpf_cnpj,
+    telefone: r.telefone,
+    email: r.email,
+    endereco: r.endereco,
+    cidade: r.cidade,
+    estado: r.estado,
+    cep: r.cep,
+    observacoes: r.observacoes,
+  }));
+}
+
+export async function criarClienteProposta(input: {
+  nome: string; cpf_cnpj?: string; telefone?: string; email?: string;
+  endereco?: string; cidade?: string; estado?: string; cep?: string; observacoes?: string;
+}): Promise<MutationResult> {
+  if (!input.nome?.trim()) throw new Error('nome obrigatório');
+  const [r] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO propostas_clientes
+       (nome, cpf_cnpj, telefone, email, endereco, cidade, estado, cep, observacoes)
+     VALUES (?,?,?,?,?,?,?,?,?)`,
+    [
+      input.nome.trim(),
+      input.cpf_cnpj ?? null, input.telefone ?? null, input.email ?? null,
+      input.endereco ?? null, input.cidade ?? null, input.estado ?? null, input.cep ?? null,
+      input.observacoes ?? null,
+    ]
+  );
+  return { ok: true, insertId: r.insertId, message: `Cliente "${input.nome}" criado.` };
+}
+
+export async function atualizarClienteProposta(input: {
+  id: string;
+  nome?: string; cpf_cnpj?: string; telefone?: string; email?: string;
+  endereco?: string; cidade?: string; estado?: string; cep?: string; observacoes?: string;
+}): Promise<MutationResult> {
+  const id = Number(input.id);
+  if (!id) throw new Error('id inválido');
+  const fields: string[] = [];
+  const params: (string | number | null)[] = [];
+  const set = (k: string, v: unknown) => { if (v !== undefined) { fields.push(`${k} = ?`); params.push((v as string) ?? null); } };
+  set('nome', input.nome); set('cpf_cnpj', input.cpf_cnpj); set('telefone', input.telefone);
+  set('email', input.email); set('endereco', input.endereco); set('cidade', input.cidade);
+  set('estado', input.estado); set('cep', input.cep); set('observacoes', input.observacoes);
+  if (!fields.length) return { ok: true, affected: 0, message: 'Nada a atualizar.' };
+  params.push(id);
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE propostas_clientes SET ${fields.join(', ')} WHERE id = ? AND deleted_at IS NULL`,
+    params
+  );
+  return { ok: true, affected: r.affectedRows, message: 'Cliente atualizado.' };
+}
+
+export async function apagarClienteProposta(input: { id: string }): Promise<MutationResult> {
+  const id = Number(input.id);
+  if (!id) throw new Error('id inválido');
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE propostas_clientes SET deleted_at = CURRENT_TIMESTAMP
+      WHERE id = ? AND deleted_at IS NULL`,
+    [id]
+  );
+  return { ok: true, affected: r.affectedRows, message: 'Cliente removido.' };
+}
+
+// ── Numeração ────────────────────────────────────────────────────────────────
+async function gerarNumeroProposta(): Promise<string> {
+  const ano = new Date().getFullYear();
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT numero FROM propostas
+      WHERE numero LIKE ? ORDER BY id DESC LIMIT 1`,
+    [`PROP-${ano}-%`]
+  );
+  let seq = 1;
+  if (rows.length) {
+    const m = String(rows[0].numero).match(/PROP-\d{4}-(\d+)/);
+    if (m) seq = Number(m[1]) + 1;
+  }
+  return `PROP-${ano}-${String(seq).padStart(4, '0')}`;
+}
+
+// ── Propostas ────────────────────────────────────────────────────────────────
+export async function listarPropostas(input: {
+  status?: string; cliente_id?: string; busca?: string; limite?: number;
+} = {}) {
+  const limit = Math.min(Math.max(Number(input.limite) || 50, 1), 500);
+  const params: (string | number)[] = [];
+  let sql = `SELECT p.*, c.nome AS cliente_nome
+               FROM propostas p
+               LEFT JOIN propostas_clientes c ON c.id = p.cliente_id
+              WHERE p.deleted_at IS NULL`;
+  if (input.status)     { sql += ' AND p.status = ?';     params.push(input.status); }
+  if (input.cliente_id) { sql += ' AND p.cliente_id = ?'; params.push(Number(input.cliente_id)); }
+  if (input.busca) {
+    sql += ' AND (p.numero LIKE ? OR c.nome LIKE ?)';
+    const q = `%${input.busca}%`;
+    params.push(q, q);
+  }
+  sql += ` ORDER BY p.criado_em DESC LIMIT ${limit}`;
+  const [rows] = await pool.execute<PropostaRow[]>(sql, params);
+  return rows.map(r => ({
+    id: String(r.id),
+    numero: r.numero,
+    cliente_id: String(r.cliente_id),
+    cliente_nome: r.cliente_nome ?? null,
+    endereco_obra: r.endereco_obra,
+    data_proposta: formatBRDate(r.data_proposta),
+    validade_dias: r.validade_dias,
+    valor_total: num(r.valor_total),
+    valor_total_br: formatBR(num(r.valor_total)),
+    status: r.status,
+    pdf_path: r.pdf_path,
+    enviada_whatsapp: !!r.enviada_whatsapp,
+    enviada_em: r.enviada_em ? formatBRDate(r.enviada_em) : null,
+    criada_por: r.criada_por,
+  }));
+}
+
+export async function buscarProposta(id: string) {
+  const numId = Number(id);
+  if (!numId) throw new Error('id inválido');
+  const [rows] = await pool.execute<PropostaRow[]>(
+    `SELECT p.*, c.nome AS cliente_nome
+       FROM propostas p
+       LEFT JOIN propostas_clientes c ON c.id = p.cliente_id
+      WHERE p.id = ? AND p.deleted_at IS NULL`,
+    [numId]
+  );
+  if (!rows.length) throw new Error('proposta não encontrada');
+  const p = rows[0];
+
+  const [cliRows] = await pool.execute<ClienteRow[]>(
+    `SELECT * FROM propostas_clientes WHERE id = ?`, [p.cliente_id]
+  );
+  const cli = cliRows[0];
+
+  const [itens] = await pool.execute<ItemRow[]>(
+    `SELECT * FROM proposta_itens WHERE proposta_id = ? ORDER BY ordem ASC, id ASC`,
+    [numId]
+  );
+
+  return {
+    id: String(p.id),
+    numero: p.numero,
+    cliente_id: String(p.cliente_id),
+    cliente: cli ? {
+      id: String(cli.id), nome: cli.nome,
+      cpf_cnpj: cli.cpf_cnpj, telefone: cli.telefone, email: cli.email,
+      endereco: cli.endereco, cidade: cli.cidade, estado: cli.estado, cep: cli.cep,
+    } : null,
+    endereco_obra: p.endereco_obra,
+    data_proposta: formatBRDate(p.data_proposta),
+    validade_dias: p.validade_dias,
+    valor_total: num(p.valor_total),
+    valor_total_br: formatBR(num(p.valor_total)),
+    observacoes: p.observacoes,
+    status: p.status,
+    pdf_path: p.pdf_path,
+    enviada_whatsapp: !!p.enviada_whatsapp,
+    enviada_em: p.enviada_em ? formatBRDate(p.enviada_em) : null,
+    criada_por: p.criada_por,
+    itens: itens.map(i => ({
+      id: String(i.id),
+      servico_id: i.servico_id ? String(i.servico_id) : null,
+      descricao: i.descricao,
+      unidade: i.unidade,
+      quantidade: num(i.quantidade),
+      valor_unitario: num(i.valor_unitario),
+      valor_total: num(i.valor_total),
+      valor_total_br: formatBR(num(i.valor_total)),
+      ordem: i.ordem,
+    })),
+  };
+}
+
+export async function criarProposta(input: {
+  cliente_id: string;
+  endereco_obra?: string;
+  data_proposta?: string;
+  validade_dias?: number;
+  observacoes?: string;
+  criada_por?: string;
+}): Promise<MutationResult> {
+  const cliId = Number(input.cliente_id);
+  if (!cliId) throw new Error('cliente_id obrigatório');
+  const numero = await gerarNumeroProposta();
+  const data = input.data_proposta && /^\d{4}-\d{2}-\d{2}$/.test(input.data_proposta)
+    ? input.data_proposta
+    : new Date().toISOString().slice(0, 10);
+  const [r] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO propostas
+       (numero, cliente_id, endereco_obra, data_proposta, validade_dias, observacoes, criada_por)
+     VALUES (?,?,?,?,?,?,?)`,
+    [
+      numero, cliId,
+      input.endereco_obra ?? null,
+      data,
+      Number(input.validade_dias) || 15,
+      input.observacoes ?? null,
+      input.criada_por ?? null,
+    ]
+  );
+  return { ok: true, insertId: r.insertId, message: `Proposta ${numero} criada.` };
+}
+
+export async function atualizarProposta(input: {
+  id: string;
+  endereco_obra?: string;
+  data_proposta?: string;
+  validade_dias?: number;
+  observacoes?: string;
+  status?: 'rascunho' | 'enviada' | 'aceita' | 'recusada' | 'expirada';
+}): Promise<MutationResult> {
+  const id = Number(input.id);
+  if (!id) throw new Error('id inválido');
+  const fields: string[] = [];
+  const params: (string | number | null)[] = [];
+  const set = (k: string, v: unknown) => { if (v !== undefined) { fields.push(`${k} = ?`); params.push((v as string) ?? null); } };
+  set('endereco_obra', input.endereco_obra);
+  if (input.data_proposta && /^\d{4}-\d{2}-\d{2}$/.test(input.data_proposta)) {
+    fields.push('data_proposta = ?'); params.push(input.data_proposta);
+  }
+  if (input.validade_dias !== undefined) { fields.push('validade_dias = ?'); params.push(Number(input.validade_dias)); }
+  set('observacoes', input.observacoes);
+  set('status', input.status);
+  if (!fields.length) return { ok: true, affected: 0, message: 'Nada a atualizar.' };
+  params.push(id);
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE propostas SET ${fields.join(', ')} WHERE id = ? AND deleted_at IS NULL`,
+    params
+  );
+  return { ok: true, affected: r.affectedRows, message: 'Proposta atualizada.' };
+}
+
+export async function apagarProposta(input: { id: string }): Promise<MutationResult> {
+  const id = Number(input.id);
+  if (!id) throw new Error('id inválido');
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE propostas SET deleted_at = CURRENT_TIMESTAMP
+      WHERE id = ? AND deleted_at IS NULL`,
+    [id]
+  );
+  return { ok: true, affected: r.affectedRows, message: 'Proposta removida.' };
+}
+
+// ── Itens ────────────────────────────────────────────────────────────────────
+async function recalcularTotalProposta(propostaId: number): Promise<number> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT COALESCE(SUM(valor_total), 0) AS total FROM proposta_itens WHERE proposta_id = ?`,
+    [propostaId]
+  );
+  const total = Number(rows[0]?.total ?? 0);
+  await pool.execute(
+    `UPDATE propostas SET valor_total = ? WHERE id = ?`,
+    [total.toFixed(2), propostaId]
+  );
+  return total;
+}
+
+export async function adicionarItemProposta(input: {
+  proposta_id: string;
+  servico_id?: string;
+  descricao: string;
+  unidade: string;
+  quantidade: number;
+  valor_unitario: number;
+  ordem?: number;
+}): Promise<MutationResult> {
+  const propostaId = Number(input.proposta_id);
+  if (!propostaId) throw new Error('proposta_id obrigatório');
+  if (!input.descricao?.trim()) throw new Error('descricao obrigatória');
+  if (!input.unidade?.trim()) throw new Error('unidade obrigatória');
+  const qtd = Number(input.quantidade);
+  const valor = Number(input.valor_unitario);
+  if (!isFinite(qtd) || qtd <= 0) throw new Error('quantidade inválida');
+  if (!isFinite(valor) || valor < 0) throw new Error('valor_unitario inválido');
+  const total = qtd * valor;
+
+  let ordem = Number(input.ordem);
+  if (!isFinite(ordem) || ordem < 0) {
+    const [maxRows] = await pool.execute<RowDataPacket[]>(
+      `SELECT COALESCE(MAX(ordem), -1) + 1 AS prox FROM proposta_itens WHERE proposta_id = ?`,
+      [propostaId]
+    );
+    ordem = Number(maxRows[0]?.prox ?? 0);
+  }
+
+  const [r] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO proposta_itens
+       (proposta_id, servico_id, descricao, unidade, quantidade, valor_unitario, valor_total, ordem)
+     VALUES (?,?,?,?,?,?,?,?)`,
+    [
+      propostaId,
+      input.servico_id ? Number(input.servico_id) : null,
+      input.descricao.trim(),
+      input.unidade.trim(),
+      qtd.toFixed(2), valor.toFixed(2), total.toFixed(2),
+      ordem,
+    ]
+  );
+  await recalcularTotalProposta(propostaId);
+  return { ok: true, insertId: r.insertId, message: 'Item adicionado.' };
+}
+
+export async function atualizarItemProposta(input: {
+  id: string;
+  descricao?: string;
+  unidade?: string;
+  quantidade?: number;
+  valor_unitario?: number;
+  ordem?: number;
+}): Promise<MutationResult> {
+  const id = Number(input.id);
+  if (!id) throw new Error('id inválido');
+  const [rowsAny] = await pool.execute<ItemRow[]>(
+    `SELECT * FROM proposta_itens WHERE id = ?`, [id]
+  );
+  if (!rowsAny.length) throw new Error('item não encontrado');
+  const cur = rowsAny[0];
+
+  const desc = input.descricao !== undefined ? input.descricao.trim() : cur.descricao;
+  const un   = input.unidade   !== undefined ? input.unidade.trim()   : cur.unidade;
+  const qtd  = input.quantidade !== undefined ? Number(input.quantidade)     : Number(cur.quantidade);
+  const vu   = input.valor_unitario !== undefined ? Number(input.valor_unitario) : Number(cur.valor_unitario);
+  if (!isFinite(qtd) || qtd <= 0) throw new Error('quantidade inválida');
+  if (!isFinite(vu)  || vu  <  0) throw new Error('valor_unitario inválido');
+  const total = qtd * vu;
+
+  const fields = ['descricao = ?', 'unidade = ?', 'quantidade = ?', 'valor_unitario = ?', 'valor_total = ?'];
+  const params: (string | number)[] = [desc, un, qtd.toFixed(2), vu.toFixed(2), total.toFixed(2)];
+  if (input.ordem !== undefined) { fields.push('ordem = ?'); params.push(Number(input.ordem)); }
+  params.push(id);
+
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE proposta_itens SET ${fields.join(', ')} WHERE id = ?`, params
+  );
+  await recalcularTotalProposta(cur.proposta_id);
+  return { ok: true, affected: r.affectedRows, message: 'Item atualizado.' };
+}
+
+export async function removerItemProposta(input: { id: string }): Promise<MutationResult> {
+  const id = Number(input.id);
+  if (!id) throw new Error('id inválido');
+  const [rowsAny] = await pool.execute<ItemRow[]>(
+    `SELECT proposta_id FROM proposta_itens WHERE id = ?`, [id]
+  );
+  if (!rowsAny.length) return { ok: true, affected: 0, message: 'Item já removido.' };
+  const propostaId = rowsAny[0].proposta_id;
+  const [r] = await pool.execute<ResultSetHeader>(
+    `DELETE FROM proposta_itens WHERE id = ?`, [id]
+  );
+  await recalcularTotalProposta(propostaId);
+  return { ok: true, affected: r.affectedRows, message: 'Item removido.' };
+}
+
+export async function reordenarItensProposta(input: {
+  proposta_id: string; ordem_ids: string[];
+}): Promise<MutationResult> {
+  const propostaId = Number(input.proposta_id);
+  if (!propostaId) throw new Error('proposta_id obrigatório');
+  if (!Array.isArray(input.ordem_ids) || !input.ordem_ids.length) {
+    return { ok: true, affected: 0, message: 'Nada a reordenar.' };
+  }
+  let i = 0;
+  for (const idStr of input.ordem_ids) {
+    const id = Number(idStr);
+    if (!id) continue;
+    await pool.execute(
+      `UPDATE proposta_itens SET ordem = ? WHERE id = ? AND proposta_id = ?`,
+      [i, id, propostaId]
+    );
+    i++;
+  }
+  return { ok: true, affected: i, message: 'Ordem atualizada.' };
+}

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -403,6 +403,7 @@
     <button class="tab" data-tab="marcar">Marcar Dias</button>
     <button class="tab" data-tab="folha">Folha Mensal</button>
     <button class="tab" data-tab="vto">Vistoria (VTO)</button>
+    <button class="tab" data-tab="proposta">Proposta</button>
   </div>
 
   <div id="view-dashboard" class="view active"></div>
@@ -415,6 +416,7 @@
   <div id="view-diario" class="view"></div>
   <div id="view-folha" class="view"></div>
   <div id="view-vto" class="view"></div>
+  <div id="view-proposta" class="view"></div>
 </div>
 
 <button class="zayra-fab" id="zayraFab">Z</button>
@@ -570,6 +572,14 @@ const state = {
   folhaObraId: '',
   vistorias: [], vistoriaAtual: null,
   vtoFotos: [], // {legenda, mime, data_base64} antes de salvar
+  // v1.65.2: Propostas
+  propostas: [],
+  propostaAtual: null,           // proposta sendo editada (com itens)
+  sinapiCategorias: [],          // ['ALVENARIA', 'PINTURA', ...]
+  sinapiAgrupado: null,          // { categoria → [items] }
+  sinapiBusca: '',               // filtro autocomplete
+  propostasClientes: [],         // cache de clientes
+  propostaCategoriaAberta: '',   // qual acordeão de categoria está aberto
 };
 
 const fmt = n => 'R$ ' + (Number(n)||0).toLocaleString('pt-BR', {minimumFractionDigits:2, maximumFractionDigits:2});
@@ -650,6 +660,24 @@ async function loadDiario() {
   state.diario = await api('/api/diario?obra_id=' + state.currentObra);
 }
 
+// v1.65.2: Propostas
+async function loadPropostas() {
+  state.propostas = await api('/api/propostas');
+}
+async function loadPropostasClientes() {
+  state.propostasClientes = await api('/api/propostas-clientes');
+}
+async function loadSinapiAgrupado() {
+  if (!state.sinapiAgrupado) {
+    const r = await api('/api/sinapi-servicos?agrupado=1');
+    state.sinapiAgrupado = r.categorias || {};
+    state.sinapiCategorias = Object.keys(state.sinapiAgrupado).sort();
+  }
+}
+async function loadProposta(id) {
+  state.propostaAtual = await api('/api/propostas/' + id);
+}
+
 async function render() {
   document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
   document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
@@ -673,6 +701,17 @@ async function render() {
       diario: async () => { await Promise.all([loadObras(), loadDiario()]); renderDiario(); },
       folha: async () => { await Promise.all([loadObras(), loadFolha()]); renderFolha(); },
       vto:   async () => { await Promise.all([loadObras(), loadVistorias()]); renderVto(); },
+      proposta: async () => {
+        await loadPropostas();
+        if (state.propostaAtual) {
+          // se tem proposta aberta, recarrega ela e renderiza editor
+          await loadProposta(state.propostaAtual.id);
+          await Promise.all([loadPropostasClientes(), loadSinapiAgrupado()]);
+          renderPropostaEditor();
+        } else {
+          renderPropostasLista();
+        }
+      },
     };
     await fns[state.currentTab]();
   } catch (e) {
@@ -1798,6 +1837,389 @@ function renderVto() {
     try { await api('/api/vistorias/' + b.dataset.delVto, { method: 'DELETE' }); render(); }
     catch (e) { alert('Erro: ' + e.message); }
   });
+}
+
+// ── PROPOSTA (v1.65.2) ──
+// Lista de propostas + editor com cabeçalho + acordeão SINAPI + edição inline.
+function renderPropostasLista() {
+  const v = document.getElementById('view-proposta');
+  const linhas = state.propostas.map(p => {
+    const sb = {
+      rascunho: 'badge-info', enviada: 'badge-warning',
+      aceita: 'badge-success', recusada: 'badge-danger', expirada: 'badge-danger'
+    }[p.status] || 'badge-info';
+    return `<div class="card">
+      <div style="display:flex; justify-content:space-between; gap:8px; align-items:flex-start;">
+        <div style="flex:1; min-width:0;">
+          <p style="margin:0; font-weight:600;">${escape(p.numero)} · ${escape(p.cliente_nome || '(cliente removido)')}</p>
+          <p style="margin:4px 0; font-size:12px; color:var(--text-muted);">
+            ${escape(p.data_proposta)} · validade ${p.validade_dias}d · <strong>${escape(p.valor_total_br)}</strong>
+            ${p.enviada_whatsapp ? ' · 📱 enviada' : ''}
+          </p>
+          <span class="badge ${sb}">${escape(p.status)}</span>
+        </div>
+        <div style="display:flex; flex-direction:column; gap:4px;">
+          <button data-edit-prop="${p.id}">Abrir</button>
+          <button class="btn-danger" data-del-prop="${p.id}">Excluir</button>
+        </div>
+      </div>
+    </div>`;
+  }).join('') || '<div class="card empty">Nenhuma proposta ainda.</div>';
+
+  v.innerHTML = `
+  <div class="card">
+    <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap;">
+      <p class="section-title" style="margin:0;">Propostas de Mão de Obra</p>
+      <button data-nova-prop>+ Nova proposta</button>
+    </div>
+  </div>
+  ${linhas}`;
+
+  document.querySelector('[data-nova-prop]').onclick = abrirNovaProposta;
+  document.querySelectorAll('[data-edit-prop]').forEach(b => b.onclick = async () => {
+    try {
+      await loadProposta(b.dataset.editProp);
+      await Promise.all([loadPropostasClientes(), loadSinapiAgrupado()]);
+      renderPropostaEditor();
+    } catch (e) { alert('Erro: ' + e.message); }
+  });
+  document.querySelectorAll('[data-del-prop]').forEach(b => b.onclick = async () => {
+    const ok = await confirmarAcao({
+      titulo: 'Excluir proposta',
+      mensagem: 'A proposta será removida (soft delete). Itens permanecem no histórico do banco.',
+      textoConfirmar: 'Excluir', perigoso: true,
+    });
+    if (!ok) return;
+    try { await api('/api/propostas/' + b.dataset.delProp, { method: 'DELETE' }); render(); }
+    catch (e) { alert('Erro: ' + e.message + (e.message.includes('Forbidden') ? '\n\nConfigure o token CEO no botão Admin.' : '')); }
+  });
+}
+
+async function abrirNovaProposta() {
+  await loadPropostasClientes();
+  const cliOpts = state.propostasClientes.map(c =>
+    `<option value="${c.id}">${escape(c.nome)}${c.cpf_cnpj ? ' · ' + escape(c.cpf_cnpj) : ''}</option>`
+  ).join('');
+
+  const body = `
+    <div class="form-grid">
+      <label style="grid-column:1/-1;">
+        <span style="font-size:12px; color:var(--text-muted);">Cliente existente</span>
+        <select id="npCliente">
+          <option value="">— Selecionar cliente cadastrado —</option>
+          ${cliOpts}
+        </select>
+      </label>
+      <p style="grid-column:1/-1; margin:4px 0; font-size:12px; color:var(--text-muted);">
+        Ou cadastre um novo cliente:
+      </p>
+      <input id="npNovoNome" placeholder="Nome do novo cliente">
+      <input id="npNovoTel" placeholder="Telefone (com DDD)">
+      <input id="npNovoCpf" placeholder="CPF/CNPJ">
+      <input id="npNovoEmail" type="email" placeholder="E-mail">
+      <hr style="grid-column:1/-1; border:none; border-top:1px solid var(--border-strong); margin:8px 0;">
+      <input id="npEnderecoObra" placeholder="Endereço da obra (opcional)" style="grid-column:1/-1;">
+      <label><span style="font-size:12px; color:var(--text-muted);">Data</span>
+        <input id="npData" type="date" value="${today()}">
+      </label>
+      <label><span style="font-size:12px; color:var(--text-muted);">Validade (dias)</span>
+        <input id="npValidade" type="number" min="1" value="15">
+      </label>
+      <textarea id="npObs" rows="2" placeholder="Observações (opcional)" style="grid-column:1/-1;"></textarea>
+    </div>
+  `;
+  abrirEditar('Nova proposta', body, async () => {
+    let cliente_id = document.getElementById('npCliente').value;
+    const novoNome = document.getElementById('npNovoNome').value.trim();
+    if (!cliente_id && !novoNome) throw new Error('Selecione ou cadastre um cliente.');
+    if (!cliente_id && novoNome) {
+      const r = await api('/api/propostas-clientes', {
+        method: 'POST',
+        body: JSON.stringify({
+          nome: novoNome,
+          telefone: document.getElementById('npNovoTel').value.trim() || undefined,
+          cpf_cnpj: document.getElementById('npNovoCpf').value.trim() || undefined,
+          email:    document.getElementById('npNovoEmail').value.trim() || undefined,
+        })
+      });
+      cliente_id = String(r.insertId);
+    }
+    const criada = await api('/api/propostas', {
+      method: 'POST',
+      body: JSON.stringify({
+        cliente_id,
+        endereco_obra: document.getElementById('npEnderecoObra').value.trim() || undefined,
+        data_proposta: document.getElementById('npData').value,
+        validade_dias: Number(document.getElementById('npValidade').value) || 15,
+        observacoes: document.getElementById('npObs').value.trim() || undefined,
+      })
+    });
+    fecharEditar();
+    await loadProposta(String(criada.insertId));
+    await loadSinapiAgrupado();
+    renderPropostaEditor();
+  });
+}
+
+function renderPropostaEditor() {
+  const v = document.getElementById('view-proposta');
+  const p = state.propostaAtual;
+  if (!p) return renderPropostasLista();
+
+  // Itens da proposta
+  const itensHtml = (p.itens || []).map((it, idx) => `
+    <tr data-item="${it.id}">
+      <td style="text-align:center; color:var(--text-muted); font-size:12px;">${idx + 1}</td>
+      <td><input data-fld="descricao" value="${escape(it.descricao)}" style="width:100%;"></td>
+      <td><input data-fld="unidade" value="${escape(it.unidade)}" style="width:60px;"></td>
+      <td><input data-fld="quantidade" type="number" step="0.01" min="0.01" value="${it.quantidade}" style="width:80px; text-align:right;"></td>
+      <td><input data-fld="valor_unitario" type="number" step="0.01" min="0" value="${it.valor_unitario}" style="width:100px; text-align:right;"></td>
+      <td style="text-align:right; white-space:nowrap;" data-total>${escape(it.valor_total_br)}</td>
+      <td><button class="btn-danger" data-rm-item="${it.id}" title="Remover">×</button></td>
+    </tr>
+  `).join('');
+
+  // Acordeão SINAPI
+  const cats = state.sinapiCategorias || [];
+  const aberta = state.propostaCategoriaAberta;
+  const sinapiHtml = cats.map(cat => {
+    const items = (state.sinapiAgrupado[cat] || []);
+    const filtrados = state.sinapiBusca
+      ? items.filter(s => s.descricao.toLowerCase().includes(state.sinapiBusca.toLowerCase()))
+      : items;
+    if (state.sinapiBusca && filtrados.length === 0) return '';
+    const aberto = aberta === cat || (state.sinapiBusca && filtrados.length > 0);
+    const linhas = aberto ? filtrados.map(s => `
+      <tr>
+        <td style="font-size:12px;">${escape(s.descricao)}</td>
+        <td style="font-size:12px; color:var(--text-muted);">${escape(s.unidade)}</td>
+        <td style="font-size:12px; text-align:right;">${fmt(s.valor_referencia)}</td>
+        <td><button data-add-sinapi="${s.id}" data-desc="${escape(s.descricao)}" data-un="${escape(s.unidade)}" data-vu="${s.valor_referencia}">+</button></td>
+      </tr>
+    `).join('') : '';
+    return `
+      <div class="card" style="padding:8px; margin:4px 0;">
+        <button data-toggle-cat="${escape(cat)}" style="width:100%; text-align:left; background:transparent; border:none; padding:4px 8px; color:var(--text); cursor:pointer; font-weight:500;">
+          ${aberto ? '▼' : '▶'} ${escape(cat)} <span style="color:var(--text-muted); font-weight:400; font-size:12px;">(${items.length})</span>
+        </button>
+        ${aberto ? `
+          <table style="width:100%; margin-top:4px; font-size:12px;">
+            <tbody>${linhas}</tbody>
+          </table>
+        ` : ''}
+      </div>
+    `;
+  }).join('');
+
+  const sb = {
+    rascunho: 'badge-info', enviada: 'badge-warning',
+    aceita: 'badge-success', recusada: 'badge-danger', expirada: 'badge-danger'
+  }[p.status] || 'badge-info';
+
+  v.innerHTML = `
+    <div class="card">
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap;">
+        <button data-voltar-prop>← Voltar para lista</button>
+        <p class="section-title" style="margin:0; flex:1;">${escape(p.numero)} <span class="badge ${sb}">${escape(p.status)}</span></p>
+        <select data-status-prop>
+          <option value="rascunho" ${p.status==='rascunho'?'selected':''}>rascunho</option>
+          <option value="enviada" ${p.status==='enviada'?'selected':''}>enviada</option>
+          <option value="aceita" ${p.status==='aceita'?'selected':''}>aceita</option>
+          <option value="recusada" ${p.status==='recusada'?'selected':''}>recusada</option>
+          <option value="expirada" ${p.status==='expirada'?'selected':''}>expirada</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="card">
+      <p class="section-title">Cabeçalho</p>
+      <div class="form-grid">
+        <div style="grid-column:1/-1;">
+          <span style="font-size:12px; color:var(--text-muted);">Cliente</span>
+          <p style="margin:2px 0; font-weight:500;">${escape(p.cliente?.nome || '(removido)')}</p>
+          <p style="margin:0; font-size:12px; color:var(--text-muted);">
+            ${escape(p.cliente?.cpf_cnpj || '')} ${p.cliente?.telefone ? '· ' + escape(p.cliente.telefone) : ''}
+          </p>
+        </div>
+        <input data-h="endereco_obra" placeholder="Endereço da obra" value="${escape(p.endereco_obra||'')}" style="grid-column:1/-1;">
+        <label><span style="font-size:12px; color:var(--text-muted);">Data</span>
+          <input data-h="data_proposta" type="date" value="${escape(parseDataBR(p.data_proposta))}">
+        </label>
+        <label><span style="font-size:12px; color:var(--text-muted);">Validade (dias)</span>
+          <input data-h="validade_dias" type="number" min="1" value="${p.validade_dias}">
+        </label>
+        <textarea data-h="observacoes" rows="2" placeholder="Observações" style="grid-column:1/-1;">${escape(p.observacoes||'')}</textarea>
+      </div>
+      <button data-salvar-header style="margin-top:8px;">Salvar cabeçalho</button>
+    </div>
+
+    <div class="card">
+      <p class="section-title">Itens (${(p.itens||[]).length}) — Total: <span id="propTotal">${escape(p.valor_total_br)}</span></p>
+      <div style="overflow-x:auto;">
+        <table style="width:100%; min-width:600px; font-size:13px;">
+          <thead>
+            <tr style="text-align:left; color:var(--text-muted); font-size:11px;">
+              <th style="width:30px;">#</th>
+              <th>Descrição</th>
+              <th style="width:60px;">Un</th>
+              <th style="width:80px; text-align:right;">Qtd</th>
+              <th style="width:100px; text-align:right;">V. Unit</th>
+              <th style="width:110px; text-align:right;">Subtotal</th>
+              <th style="width:40px;"></th>
+            </tr>
+          </thead>
+          <tbody id="propItensTbody">${itensHtml || '<tr><td colspan="7" style="text-align:center; color:var(--text-muted); padding:12px;">Nenhum item ainda. Selecione abaixo.</td></tr>'}</tbody>
+        </table>
+      </div>
+      <p style="font-size:11px; color:var(--text-muted); margin:6px 0 0;">Edite qtd/valor unit/descrição direto na tabela. Salva ao sair do campo (blur).</p>
+    </div>
+
+    <div class="card">
+      <p class="section-title">Catálogo SINAPI</p>
+      <input id="sinapiBuscaInput" placeholder="Buscar serviço (ex: 'concreto', 'pintura', 'piso cerâmico')…" value="${escape(state.sinapiBusca)}" style="width:100%; margin-bottom:8px;">
+      <p style="font-size:11px; color:var(--text-muted); margin:0 0 6px;">Clique numa categoria pra abrir. Valores são referenciais (estimativa de mercado) — ajuste o V. Unit após adicionar.</p>
+      <div id="sinapiCategoriasList">${sinapiHtml || '<div class="card empty">Catálogo vazio.</div>'}</div>
+    </div>
+
+    <div class="card">
+      <p style="font-size:12px; color:var(--text-muted); margin:0 0 6px;">Adicionar item manual (fora do catálogo):</p>
+      <div class="form-grid">
+        <input id="manDesc" placeholder="Descrição" style="grid-column:1/-1;">
+        <input id="manUn" placeholder="Unidade (m², h, un, kg…)">
+        <input id="manQtd" type="number" step="0.01" min="0.01" placeholder="Quantidade">
+        <input id="manVu" type="number" step="0.01" min="0" placeholder="Valor unitário">
+        <button id="manAdd">+ Adicionar manual</button>
+      </div>
+    </div>
+  `;
+
+  // Voltar
+  document.querySelector('[data-voltar-prop]').onclick = () => {
+    state.propostaAtual = null;
+    state.sinapiBusca = '';
+    state.propostaCategoriaAberta = '';
+    render();
+  };
+
+  // Mudar status
+  document.querySelector('[data-status-prop]').onchange = async (ev) => {
+    try {
+      await api('/api/propostas/' + p.id, { method: 'PUT', body: JSON.stringify({ status: ev.target.value }) });
+      await loadProposta(p.id);
+      renderPropostaEditor();
+    } catch (e) { alert('Erro: ' + e.message); }
+  };
+
+  // Salvar header
+  document.querySelector('[data-salvar-header]').onclick = async () => {
+    try {
+      const body = {
+        endereco_obra: document.querySelector('[data-h="endereco_obra"]').value.trim() || undefined,
+        data_proposta: document.querySelector('[data-h="data_proposta"]').value || undefined,
+        validade_dias: Number(document.querySelector('[data-h="validade_dias"]').value) || undefined,
+        observacoes:   document.querySelector('[data-h="observacoes"]').value.trim() || undefined,
+      };
+      await api('/api/propostas/' + p.id, { method: 'PUT', body: JSON.stringify(body) });
+      await loadProposta(p.id);
+      renderPropostaEditor();
+    } catch (e) { alert('Erro: ' + e.message); }
+  };
+
+  // Toggle categoria
+  document.querySelectorAll('[data-toggle-cat]').forEach(b => b.onclick = () => {
+    state.propostaCategoriaAberta = state.propostaCategoriaAberta === b.dataset.toggleCat ? '' : b.dataset.toggleCat;
+    renderPropostaEditor();
+  });
+
+  // Busca SINAPI
+  const buscaInput = document.getElementById('sinapiBuscaInput');
+  let buscaTimer;
+  buscaInput.oninput = () => {
+    clearTimeout(buscaTimer);
+    buscaTimer = setTimeout(() => {
+      state.sinapiBusca = buscaInput.value;
+      renderPropostaEditor();
+      const novoInput = document.getElementById('sinapiBuscaInput');
+      if (novoInput) { novoInput.focus(); novoInput.setSelectionRange(novoInput.value.length, novoInput.value.length); }
+    }, 200);
+  };
+
+  // Adicionar do catálogo SINAPI
+  document.querySelectorAll('[data-add-sinapi]').forEach(b => b.onclick = async () => {
+    try {
+      await api('/api/propostas/' + p.id + '/itens', {
+        method: 'POST',
+        body: JSON.stringify({
+          proposta_id: p.id,
+          servico_id: b.dataset.addSinapi,
+          descricao: b.dataset.desc,
+          unidade: b.dataset.un,
+          quantidade: 1,
+          valor_unitario: Number(b.dataset.vu) || 0,
+        })
+      });
+      await loadProposta(p.id);
+      renderPropostaEditor();
+    } catch (e) { alert('Erro: ' + e.message); }
+  });
+
+  // Adicionar manual
+  document.getElementById('manAdd').onclick = async () => {
+    try {
+      const desc = document.getElementById('manDesc').value.trim();
+      const un   = document.getElementById('manUn').value.trim();
+      const qtd  = Number(document.getElementById('manQtd').value);
+      const vu   = Number(document.getElementById('manVu').value);
+      if (!desc || !un || !isFinite(qtd) || qtd <= 0 || !isFinite(vu) || vu < 0) {
+        return alert('Preencha descrição, unidade, qtd > 0 e valor unit ≥ 0.');
+      }
+      await api('/api/propostas/' + p.id + '/itens', {
+        method: 'POST',
+        body: JSON.stringify({
+          proposta_id: p.id,
+          descricao: desc, unidade: un, quantidade: qtd, valor_unitario: vu,
+        })
+      });
+      await loadProposta(p.id);
+      renderPropostaEditor();
+    } catch (e) { alert('Erro: ' + e.message); }
+  };
+
+  // Edição inline (blur salva)
+  document.querySelectorAll('#propItensTbody tr[data-item]').forEach(tr => {
+    const itemId = tr.dataset.item;
+    tr.querySelectorAll('input[data-fld]').forEach(inp => {
+      inp.onblur = async () => {
+        const fld = inp.dataset.fld;
+        const val = ['quantidade','valor_unitario'].includes(fld) ? Number(inp.value) : inp.value;
+        try {
+          await api('/api/proposta-itens/' + itemId, {
+            method: 'PUT',
+            body: JSON.stringify({ id: itemId, [fld]: val }),
+          });
+          await loadProposta(p.id);
+          renderPropostaEditor();
+        } catch (e) { alert('Erro: ' + e.message); }
+      };
+    });
+  });
+
+  // Remover item
+  document.querySelectorAll('[data-rm-item]').forEach(b => b.onclick = async () => {
+    try {
+      await api('/api/proposta-itens/' + b.dataset.rmItem, { method: 'DELETE' });
+      await loadProposta(p.id);
+      renderPropostaEditor();
+    } catch (e) { alert('Erro: ' + e.message); }
+  });
+}
+
+// Helper: converte data BR (dd/MM/yyyy) pra ISO (yyyy-MM-dd) pra input type=date
+function parseDataBR(s) {
+  if (!s) return today();
+  const m = String(s).match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return s;
 }
 
 function fileToBase64(file) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import {
 import { startDailyScheduler } from './agent/scheduler';
 import * as calendar from './integrations/calendar';
 import * as obras from './integrations/obras';
+import * as propostas from './integrations/propostas';
 import * as alarmes from './integrations/alarmes';
 import * as cofre from './integrations/cofre';
 import * as vistorias from './integrations/vistorias';
@@ -647,6 +648,26 @@ app.post('/api/diario', apiHandle(args => obras.registrarDiarioObra(args as Para
 // Catálogo de profissões
 app.get('/api/profissoes-catalogo', apiHandle(() => obras.listarProfissoesCatalogo()));
 app.put('/api/profissoes-catalogo/:id', apiHandle(args => obras.atualizarProfissaoCatalogo(args as Parameters<typeof obras.atualizarProfissaoCatalogo>[0])));
+
+// v1.65.2: Propostas de Mão de Obra (catálogo SINAPI + clientes + propostas + itens)
+app.get   ('/api/sinapi-servicos',       apiHandle(args => propostas.listarCatalogoSinapi(args as Parameters<typeof propostas.listarCatalogoSinapi>[0])));
+app.get   ('/api/sinapi-categorias',     apiHandle(() => propostas.listarCategoriasSinapi()));
+
+app.get   ('/api/propostas-clientes',    apiHandle(args => propostas.listarClientesProposta(args as Parameters<typeof propostas.listarClientesProposta>[0])));
+app.post  ('/api/propostas-clientes',    apiHandle(args => propostas.criarClienteProposta(args as Parameters<typeof propostas.criarClienteProposta>[0])));
+app.put   ('/api/propostas-clientes/:id', requireCeoToken, apiHandle(args => propostas.atualizarClienteProposta(args as Parameters<typeof propostas.atualizarClienteProposta>[0])));
+app.delete('/api/propostas-clientes/:id', requireCeoToken, apiHandle(args => propostas.apagarClienteProposta(args as { id: string })));
+
+app.get   ('/api/propostas',             apiHandle(args => propostas.listarPropostas(args as Parameters<typeof propostas.listarPropostas>[0])));
+app.get   ('/api/propostas/:id',         apiHandle(args => propostas.buscarProposta((args as { id: string }).id)));
+app.post  ('/api/propostas',             apiHandle(args => propostas.criarProposta(args as Parameters<typeof propostas.criarProposta>[0])));
+app.put   ('/api/propostas/:id',         apiHandle(args => propostas.atualizarProposta(args as Parameters<typeof propostas.atualizarProposta>[0])));
+app.delete('/api/propostas/:id',         requireCeoToken, apiHandle(args => propostas.apagarProposta(args as { id: string })));
+
+app.post  ('/api/propostas/:proposta_id/itens',         apiHandle(args => propostas.adicionarItemProposta(args as Parameters<typeof propostas.adicionarItemProposta>[0])));
+app.put   ('/api/proposta-itens/:id',                   apiHandle(args => propostas.atualizarItemProposta(args as Parameters<typeof propostas.atualizarItemProposta>[0])));
+app.delete('/api/proposta-itens/:id',                   apiHandle(args => propostas.removerItemProposta(args as { id: string })));
+app.post  ('/api/propostas/:proposta_id/itens/reordenar', apiHandle(args => propostas.reordenarItensProposta(args as Parameters<typeof propostas.reordenarItensProposta>[0])));
 
 // Cowork (tarefas em background)
 app.get   ('/api/cowork',       apiHandle(args => cowork.listarTarefasCowork(args as Parameters<typeof cowork.listarTarefasCowork>[0])));


### PR DESCRIPTION
## Resumo
Implementa a Implementação #1 do briefing de Gestão de Obras: Proposta de Mão de Obra com catálogo SINAPI. Esta PR cobre backend completo + UI da nova aba (lista, editor com cabeçalho, catálogo navegável, edição inline). Geração de PDF + envio Z-API ficam pra PR #16.

## Backend
`src/integrations/propostas.ts` (~430 LOC novas):
- `listarCatalogoSinapi` (filtros busca/categoria/ativo + modo agrupado por categoria)
- `listarCategoriasSinapi` (com contagem)
- CRUD `propostas_clientes` (soft delete, busca por nome/cpf/telefone)
- CRUD `propostas` (geração automática de número `PROP-YYYY-NNNN`, status enum, soft delete)
- CRUD `proposta_itens` (recálculo automático de `valor_total` da proposta a cada mutação)
- Reordenação em massa

Endpoints REST em `src/server.ts`:
- `GET /api/sinapi-servicos`, `/api/sinapi-categorias`
- CRUD `/api/propostas-clientes` (PUT/DELETE protegidos por `requireCeoToken`)
- CRUD `/api/propostas` + nested `/api/propostas/:id/itens`
- `/api/proposta-itens/:id` (PUT/DELETE)
- `/api/propostas/:id/itens/reordenar`

## UI (`src/public/obras.html`)
- Nova aba **Proposta** no menu
- **Lista de propostas** com status colorido + botões abrir/excluir
- Modal **Nova proposta**: seleciona cliente cadastrado OU cadastra novo (nome, telefone, CPF/CNPJ, e-mail), header (endereço da obra, data, validade, observações)
- **Editor de proposta**:
  - Cabeçalho editável (endereço, data, validade, observações) com botão Salvar
  - Mudança de status inline (rascunho/enviada/aceita/recusada/expirada)
  - **Catálogo SINAPI em acordeão por categoria**, com busca em tempo real (debounce 200ms)
  - Botão `+` por item do catálogo adiciona com qtd=1 e valor referencial
  - Tabela de itens com **edição inline** (descrição, unidade, qtd, V.unit) — salva no blur
  - **Total em tempo real** no header da seção de itens
  - Adicionar item manual (fora do catálogo)
  - Remover item por linha

## Test plan
- [ ] Após merge + deploy Railway, validar nova aba 'Proposta' no menu
- [ ] Criar nova proposta cadastrando cliente novo
- [ ] Abrir editor, navegar acordeão SINAPI, adicionar 3-5 itens de categorias diferentes
- [ ] Editar qtd e V.unit inline, validar total atualizando
- [ ] Mudar status rascunho → enviada
- [ ] Tentar excluir proposta sem CEO_TOKEN configurado e validar 403
- [ ] Configurar token e validar exclusão funcionando

## Próximas PRs
- **PR #16**: Geração de PDF (PDFKit) + envio via Z-API + flow rascunho→enviada com timestamp.

Generated with Claude Code