### PR TITLE
v1.65.3: fix valores monetários da proposta (mostrava 31/12/1969)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.2",
+  "version": "1.65.3",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.2',
+  version: '1.65.3',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/integrations/propostas.ts
+++ b/src/integrations/propostas.ts
@@ -5,7 +5,7 @@
 
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import pool from '../database/connection';
-import { formatBR, formatBRDate } from '../util/format';
+import { formatBRDate, formatBRL } from '../util/format';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 type SinapiRow = RowDataPacket & {
@@ -225,7 +225,7 @@ export async function listarPropostas(input: {
     data_proposta: formatBRDate(r.data_proposta),
     validade_dias: r.validade_dias,
     valor_total: num(r.valor_total),
-    valor_total_br: formatBR(num(r.valor_total)),
+    valor_total_br: formatBRL(num(r.valor_total)),
     status: r.status,
     pdf_path: r.pdf_path,
     enviada_whatsapp: !!r.enviada_whatsapp,
@@ -270,7 +270,7 @@ export async function buscarProposta(id: string) {
     data_proposta: formatBRDate(p.data_proposta),
     validade_dias: p.validade_dias,
     valor_total: num(p.valor_total),
-    valor_total_br: formatBR(num(p.valor_total)),
+    valor_total_br: formatBRL(num(p.valor_total)),
     observacoes: p.observacoes,
     status: p.status,
     pdf_path: p.pdf_path,
@@ -285,7 +285,7 @@ export async function buscarProposta(id: string) {
       quantidade: num(i.quantidade),
       valor_unitario: num(i.valor_unitario),
       valor_total: num(i.valor_total),
-      valor_total_br: formatBR(num(i.valor_total)),
+      valor_total_br: formatBRL(num(i.valor_total)),
       ordem: i.ordem,
     })),
   };

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -38,3 +38,20 @@ export function formatBRDate(d: Date | string | number | null | undefined): stri
   if (Number.isNaN(date.getTime())) return '';
   return _fmtDateOnly.format(date);
 }
+
+const _fmtBRL = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/**
+ * Formata valor monetário em BRL: "R$ 1.234,56".
+ */
+export function formatBRL(v: number | string | null | undefined): string {
+  if (v === null || v === undefined || v === '') return 'R$ 0,00';
+  const n = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(n)) return 'R$ 0,00';
+  return _fmtBRL.format(n);
+}


### PR DESCRIPTION
## Bug
Na PR #15 usei `formatBR` (formato de **data**) pra formatar `valor_total` e `valor_total_br` das propostas e itens. Como o número é R$, o JS tratava como timestamp Unix → `0` virava `31/12/1969 21:00`.

Visto na produção: editor de proposta mostrando `TOTAL: 31/12/1969, 21:00` e cada subtotal `31/12/1969, 21:00`.

## Fix
- Adiciona `formatBRL` em `src/util/format.ts` (Intl.NumberFormat pt-BR/BRL → `R$ 1.234,56`).
- Troca `formatBR(num(...))` por `formatBRL(num(...))` em `src/integrations/propostas.ts` (3 ocorrências: `listarPropostas`, `buscarProposta` cabeçalho, `buscarProposta` itens).
- Bump v1.65.3.

## Test plan
- [ ] Após merge + deploy, abrir proposta existente e validar:
  - Total no header da seção 'Itens' = `R$ X.XXX,XX`
  - Cada subtotal de linha = valor monetário correto
  - Lista de propostas mostra `valor_total_br` correto