### PR TITLE
v1.65.5: Proposta — gestor/indicador no relatório + logo separado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.4",
+  "version": "1.65.5",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.4',
+  version: '1.65.5',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -852,6 +852,20 @@ export async function runMigrations(): Promise<void> {
   // Desambiguação por descricao (não tem UNIQUE — confiamos no IGNORE de PRIMARY).
   await popularCatalogoSinapi();
 
+  // v1.65.5: campos do gestor/indicador da proposta (sai no relatório)
+  for (const col of [
+    "ADD COLUMN gestor_cargo    VARCHAR(40)  DEFAULT NULL AFTER criada_por",
+    "ADD COLUMN gestor_nome     VARCHAR(150) DEFAULT NULL AFTER gestor_cargo",
+    "ADD COLUMN gestor_telefone VARCHAR(20)  DEFAULT NULL AFTER gestor_nome",
+  ]) {
+    try { await pool.execute(`ALTER TABLE propostas ${col}`); }
+    catch (err) {
+      if (!/Duplicate column|already exists/i.test((err as Error).message)) {
+        console.warn('[migrations] alter propostas falhou (não-bloqueante):', (err as Error).message.slice(0, 100));
+      }
+    }
+  }
+
   console.log('[DB] Migrations complete');
 }
 

--- a/src/integrations/propostas.ts
+++ b/src/integrations/propostas.ts
@@ -41,6 +41,9 @@ type PropostaRow = RowDataPacket & {
   pdf_path: string | null;
   enviada_whatsapp: number; enviada_em: Date | null;
   criada_por: string | null;
+  gestor_cargo: string | null;
+  gestor_nome: string | null;
+  gestor_telefone: string | null;
   criado_em: Date; atualizado_em: Date;
 };
 
@@ -236,6 +239,9 @@ export async function listarPropostas(input: {
     enviada_whatsapp: !!r.enviada_whatsapp,
     enviada_em: r.enviada_em ? formatBRDate(r.enviada_em) : null,
     criada_por: r.criada_por,
+    gestor_cargo: r.gestor_cargo,
+    gestor_nome: r.gestor_nome,
+    gestor_telefone: r.gestor_telefone,
   }));
 }
 
@@ -282,6 +288,9 @@ export async function buscarProposta(id: string) {
     enviada_whatsapp: !!p.enviada_whatsapp,
     enviada_em: p.enviada_em ? formatBRDate(p.enviada_em) : null,
     criada_por: p.criada_por,
+    gestor_cargo: p.gestor_cargo,
+    gestor_nome: p.gestor_nome,
+    gestor_telefone: p.gestor_telefone,
     itens: itens.map(i => ({
       id: String(i.id),
       servico_id: i.servico_id ? String(i.servico_id) : null,
@@ -303,6 +312,9 @@ export async function criarProposta(input: {
   validade_dias?: number;
   observacoes?: string;
   criada_por?: string;
+  gestor_cargo?: string;
+  gestor_nome?: string;
+  gestor_telefone?: string;
 }): Promise<MutationResult> {
   const cliId = Number(input.cliente_id);
   if (!cliId) throw new Error('cliente_id obrigatório');
@@ -312,8 +324,9 @@ export async function criarProposta(input: {
     : new Date().toISOString().slice(0, 10);
   const [r] = await pool.execute<ResultSetHeader>(
     `INSERT INTO propostas
-       (numero, cliente_id, endereco_obra, data_proposta, validade_dias, observacoes, criada_por)
-     VALUES (?,?,?,?,?,?,?)`,
+       (numero, cliente_id, endereco_obra, data_proposta, validade_dias, observacoes, criada_por,
+        gestor_cargo, gestor_nome, gestor_telefone)
+     VALUES (?,?,?,?,?,?,?,?,?,?)`,
     [
       numero, cliId,
       input.endereco_obra ?? null,
@@ -321,6 +334,9 @@ export async function criarProposta(input: {
       Number(input.validade_dias) || 15,
       input.observacoes ?? null,
       input.criada_por ?? null,
+      input.gestor_cargo ?? null,
+      input.gestor_nome ?? null,
+      input.gestor_telefone ?? null,
     ]
   );
   return { ok: true, insertId: r.insertId, message: `Proposta ${numero} criada.` };
@@ -333,6 +349,9 @@ export async function atualizarProposta(input: {
   validade_dias?: number;
   observacoes?: string;
   status?: 'rascunho' | 'enviada' | 'aceita' | 'recusada' | 'expirada';
+  gestor_cargo?: string;
+  gestor_nome?: string;
+  gestor_telefone?: string;
 }): Promise<MutationResult> {
   const id = Number(input.id);
   if (!id) throw new Error('id inválido');
@@ -346,6 +365,9 @@ export async function atualizarProposta(input: {
   if (input.validade_dias !== undefined) { fields.push('validade_dias = ?'); params.push(Number(input.validade_dias)); }
   set('observacoes', input.observacoes);
   set('status', input.status);
+  set('gestor_cargo',    input.gestor_cargo);
+  set('gestor_nome',     input.gestor_nome);
+  set('gestor_telefone', input.gestor_telefone);
   if (!fields.length) return { ok: true, affected: 0, message: 'Nada a atualizar.' };
   params.push(id);
   const [r] = await pool.execute<ResultSetHeader>(
@@ -505,11 +527,16 @@ function escapeHtml(s: string | null | undefined): string {
     .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
+// v1.65.5: relatórios usam o logo "tradicional" (/romatec-logo.jpg).
+// O logo R (/logo_R-removebg-preview.png) fica reservado pra UI do app
+// (cabeçalho da tela "Gestão de Obras"), pois é decisão do CEO separar.
+const LOGO_RELATORIO = '/romatec-logo.jpg';
+
 export async function gerarHtmlPropostaRelatorio(id: string): Promise<string> {
   const p = await buscarProposta(id);
   const t = await getTenantSettings(1).catch(() => null);
   const brand = t?.brand_name || 'Romatec Consultoria Imobiliária';
-  const logo  = t?.logo_path  || '/logo_R-removebg-preview.png';
+  const logo  = LOGO_RELATORIO;
   const cor   = t?.primary_color || '#10b981';
 
   const itensHtml = p.itens.map((it, idx) => `
@@ -600,6 +627,15 @@ export async function gerarHtmlPropostaRelatorio(id: string): Promise<string> {
     <div><span class="label">Validade:</span> ${p.validade_dias} dias</div>
   </div>
 
+  ${(p.gestor_nome || p.gestor_cargo || p.gestor_telefone) ? `
+  <h2>Responsável Técnico / Indicador</h2>
+  <div class="grid2">
+    ${p.gestor_cargo    ? `<div><p class="label">Cargo</p><p style="margin:0;">${escapeHtml(p.gestor_cargo)}</p></div>` : ''}
+    ${p.gestor_nome     ? `<div><p class="label">Nome</p><p style="margin:0; font-weight:500;">${escapeHtml(p.gestor_nome)}</p></div>` : ''}
+    ${p.gestor_telefone ? `<div><p class="label">Telefone</p><p style="margin:0;">${escapeHtml(p.gestor_telefone)}</p></div>` : ''}
+  </div>
+  ` : ''}
+
   ${p.observacoes ? `<div class="obs"><strong>Observações:</strong><br>${escapeHtml(p.observacoes).replace(/\n/g, '<br>')}</div>` : ''}
 
   <div class="footer">
@@ -617,8 +653,8 @@ export async function gerarHtmlPropostaRelatorio(id: string): Promise<string> {
 export async function gerarPdfProposta(id: string): Promise<Buffer> {
   const p = await buscarProposta(id);
   const t = await getTenantSettings(1).catch(() => null);
-  const brand = t?.brand_name || 'Romatec Consultoria Imobiliária';
-  const logoPath = t?.logo_path || '/logo_R-removebg-preview.png';
+  const brand    = t?.brand_name || 'Romatec Consultoria Imobiliária';
+  const logoPath = LOGO_RELATORIO; // v1.65.5: logo "tradicional" nos PDFs
   const corHex   = t?.primary_color || '#10b981';
 
   const doc = new PDFDocument({ size: 'A4', margin: 48, info: {
@@ -720,6 +756,20 @@ export async function gerarPdfProposta(id: string): Promise<Buffer> {
   doc.fontSize(9).fillColor('#444');
   doc.text(`Data: ${p.data_proposta}    ·    Validade: ${p.validade_dias} dias`);
   doc.moveDown(0.4);
+
+  // Responsável técnico / indicador
+  if (p.gestor_nome || p.gestor_cargo || p.gestor_telefone) {
+    doc.fontSize(11).fillColor(corHex).text('Responsável Técnico / Indicador');
+    doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+    doc.fontSize(10).fillColor('#111');
+    const partes: string[] = [];
+    if (p.gestor_cargo)    partes.push(p.gestor_cargo);
+    if (p.gestor_nome)     partes.push(p.gestor_nome);
+    doc.text(partes.join(' — ') || '-');
+    if (p.gestor_telefone) doc.text(`Tel: ${p.gestor_telefone}`);
+    doc.moveDown(0.4);
+  }
 
   if (p.observacoes) {
     doc.fontSize(10).fillColor(corHex).text('Observações');

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1513,12 +1513,12 @@ const ROMATEC_HEADER_CSS = `
 .romatec-header{text-align:center;border-bottom:3px solid #0a3d2a;padding-bottom:14px;margin-bottom:18px;}
 .romatec-header img{max-height:100px;max-width:80%;height:auto;display:inline-block;}
 `;
-// v1.65.1: troca pro logo R em PNG transparente (logo_R-removebg-preview.png).
-// Histórico: /LOGO%20ROMATEC%20ATUAL.jpg (deletado) → /romatec-logo.jpg → atual.
-// brand vem do tenant_settings via JS quando relevante.
+// v1.65.5: relatórios/recibos voltam pro logo "tradicional" /romatec-logo.jpg
+// por decisão do CEO. O logo R (logo_R-removebg-preview.png) fica reservado
+// pra UI da tela "Gestão de Obras" (header da app via tenant_settings.logo_path).
 const ROMATEC_HEADER_HTML = `
 <div class="romatec-header">
-  <img src="/logo_R-removebg-preview.png" alt="Romatec Consultoria Total — Engenharia e Agrimensura">
+  <img src="/romatec-logo.jpg" alt="Romatec Consultoria Total — Engenharia e Agrimensura">
 </div>
 `;
 
@@ -1968,6 +1968,25 @@ async function abrirNovaProposta() {
         <input id="npValidade" type="number" min="1" value="15">
       </label>
       <textarea id="npObs" rows="2" placeholder="Observações (opcional)" style="grid-column:1/-1;"></textarea>
+      <hr style="grid-column:1/-1; border:none; border-top:1px solid var(--border-strong); margin:8px 0;">
+      <p style="grid-column:1/-1; margin:0; font-size:12px; color:var(--text-muted);">
+        Responsável Técnico / Indicador (sai no relatório):
+      </p>
+      <label><span style="font-size:12px; color:var(--text-muted);">Cargo</span>
+        <select id="npGestorCargo">
+          <option value="">— Selecionar —</option>
+          <option>Engenheiro</option>
+          <option>Arquiteto</option>
+          <option>Técnico em Edificações</option>
+          <option>Mestre de Obra</option>
+          <option>Pedreiro</option>
+          <option>Encarregado</option>
+          <option>Indicador</option>
+          <option>Outro</option>
+        </select>
+      </label>
+      <input id="npGestorNome" placeholder="Nome do responsável">
+      <input id="npGestorTel" placeholder="Telefone (com DDD)" style="grid-column:1/-1;">
     </div>
   `;
   abrirEditar('Nova proposta', body, async () => {
@@ -1994,6 +2013,9 @@ async function abrirNovaProposta() {
         data_proposta: document.getElementById('npData').value,
         validade_dias: Number(document.getElementById('npValidade').value) || 15,
         observacoes: document.getElementById('npObs').value.trim() || undefined,
+        gestor_cargo:    document.getElementById('npGestorCargo').value || undefined,
+        gestor_nome:     document.getElementById('npGestorNome').value.trim() || undefined,
+        gestor_telefone: document.getElementById('npGestorTel').value.trim() || undefined,
       })
     });
     fecharEditar();
@@ -2098,6 +2120,16 @@ function renderPropostaEditor() {
           <input data-h="validade_dias" type="number" min="1" value="${p.validade_dias}">
         </label>
         <textarea data-h="observacoes" rows="2" placeholder="Observações" style="grid-column:1/-1;">${escape(p.observacoes||'')}</textarea>
+        <hr style="grid-column:1/-1; border:none; border-top:1px solid var(--border-strong); margin:6px 0;">
+        <p style="grid-column:1/-1; margin:0; font-size:12px; color:var(--text-muted);">Responsável Técnico / Indicador (sai no relatório):</p>
+        <label><span style="font-size:12px; color:var(--text-muted);">Cargo</span>
+          <select data-h="gestor_cargo">
+            ${['','Engenheiro','Arquiteto','Técnico em Edificações','Mestre de Obra','Pedreiro','Encarregado','Indicador','Outro']
+              .map(c => `<option value="${escape(c)}" ${ (p.gestor_cargo||'')===c?'selected':'' }>${c||'— Selecionar —'}</option>`).join('')}
+          </select>
+        </label>
+        <input data-h="gestor_nome" placeholder="Nome do responsável" value="${escape(p.gestor_nome||'')}">
+        <input data-h="gestor_telefone" placeholder="Telefone (com DDD)" value="${escape(p.gestor_telefone||'')}" style="grid-column:1/-1;">
       </div>
       <button data-salvar-header style="margin-top:8px;">Salvar cabeçalho</button>
     </div>
@@ -2197,6 +2229,10 @@ function renderPropostaEditor() {
         data_proposta: document.querySelector('[data-h="data_proposta"]').value || undefined,
         validade_dias: Number(document.querySelector('[data-h="validade_dias"]').value) || undefined,
         observacoes:   document.querySelector('[data-h="observacoes"]').value.trim() || undefined,
+        // v1.65.5: gestor/indicador
+        gestor_cargo:    document.querySelector('[data-h="gestor_cargo"]').value || '',
+        gestor_nome:     document.querySelector('[data-h="gestor_nome"]').value.trim(),
+        gestor_telefone: document.querySelector('[data-h="gestor_telefone"]').value.trim(),
       };
       await api('/api/propostas/' + p.id, { method: 'PUT', body: JSON.stringify(body) });
       await loadProposta(p.id);


### PR DESCRIPTION
## Resumo
Dois ajustes pedidos pelo CEO após validação da PR #17:

## 1. Campo gestor/indicador da proposta
- **Migration**: `ALTER TABLE propostas` adiciona `gestor_cargo`, `gestor_nome`, `gestor_telefone` (idempotente, try/catch em 'Duplicate column').
- **Backend** (`integrations/propostas.ts`): `PropostaRow` + `listarPropostas` + `buscarProposta` + `criarProposta` + `atualizarProposta` propagam os 3 campos.
- **Relatório HTML & PDF**: novo bloco **'Responsável Técnico / Indicador'** com cargo + nome + telefone, renderizado antes das observações.
- **UI**:
  - Modal Nova proposta: 3 campos novos (cargo como select com opções `Engenheiro / Arquiteto / Técnico em Edificações / Mestre de Obra / Pedreiro / Encarregado / Indicador / Outro` + nome + telefone)
  - Cabeçalho do editor: mesmos 3 campos editáveis com salvar inline pelo botão 'Salvar cabeçalho'

## 2. Logo separado entre app e relatórios
- **Recibos/PDFs/relatórios** voltam pra `/romatec-logo.jpg` (logo 'tradicional'):
  - `ROMATEC_HEADER_HTML` em `obras.html` (recibos financeiros)
  - `gerarHtmlPropostaRelatorio` + `gerarPdfProposta` em `integrations/propostas.ts`
- **Logo R em PNG transparente** (`/logo_R-removebg-preview.png`) fica reservado pra UI da tela 'Gestão de Obras' via `tenant_settings.logo_path` (já configurado na v1.65.1).
- Constante `LOGO_RELATORIO` em `propostas.ts` pra centralizar o caminho.

## Test plan
- [ ] Após merge + deploy:
  - Abrir uma proposta no editor → preencher cargo/nome/telefone do gestor → Salvar cabeçalho
  - Visualizar HTML / PDF → bloco 'Responsável Técnico' deve aparecer
  - Logo no relatório = `/romatec-logo.jpg` (compass tradicional)
  - Header da app continua com logo R PNG
  - Recibo de transação financeira também volta pro logo tradicional
  - Criar nova proposta com gestor preenchido desde o início → idem

Generated with Claude Code