### PR TITLE
v1.65.9: fix modal de confirmação aparecendo sem estilo no canto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.8",
+  "version": "1.65.9",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.8',
+  version: '1.65.9',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -2462,24 +2462,34 @@ function confirmarAcao({ titulo, mensagem, textoConfirmar, perigoso }) {
   return new Promise((resolve) => {
     let overlay = document.getElementById('confAcaoOverlay');
     if (!overlay) {
+      // v1.65.9: usa as classes 'cal-overlay'/'cal-modal'/'cal-head' (existentes
+      // no CSS) em vez de 'overlay'/'modal' (não existiam) — antes o modal saía
+      // sem estilo, ancorado no canto inferior esquerdo da página.
       overlay = document.createElement('div');
       overlay.id = 'confAcaoOverlay';
-      overlay.className = 'overlay';
+      overlay.className = 'cal-overlay';
       overlay.innerHTML = `
-        <div class="modal" style="max-width:420px;">
-          <div class="modal-header">
-            <h3 id="confAcaoTitle">Confirmar</h3>
-            <button class="btn-close" id="confAcaoX">×</button>
+        <div class="cal-modal" style="max-width:440px;">
+          <div class="cal-head">
+            <h2 id="confAcaoTitle">Confirmar</h2>
+            <button id="confAcaoX" style="border:none;background:transparent;color:var(--text-muted);font-size:22px;cursor:pointer;">×</button>
           </div>
-          <div class="modal-body">
-            <p id="confAcaoMsg" style="margin:8px 0;"></p>
-            <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:16px;">
-              <button class="btn-secondary" id="confAcaoCancel">Cancelar</button>
+          <div style="padding:16px 20px;">
+            <p id="confAcaoMsg" style="margin:0 0 16px;"></p>
+            <div style="display:flex; gap:8px; justify-content:flex-end;">
+              <button id="confAcaoCancel">Cancelar</button>
               <button class="btn-primary" id="confAcaoOk"></button>
             </div>
           </div>
         </div>`;
       document.body.appendChild(overlay);
+      // Fecha clicando fora (no backdrop)
+      overlay.addEventListener('click', (e) => {
+        if (e.target.id === 'confAcaoOverlay') {
+          const cancel = document.getElementById('confAcaoCancel');
+          if (cancel) cancel.click();
+        }
+      });
     }
     document.getElementById('confAcaoTitle').textContent = titulo || 'Confirmar';
     document.getElementById('confAcaoMsg').innerHTML = mensagem || 'Tem certeza?';
@@ -2487,6 +2497,7 @@ function confirmarAcao({ titulo, mensagem, textoConfirmar, perigoso }) {
     okBtn.textContent = textoConfirmar || 'Confirmar';
     okBtn.style.background = perigoso ? 'var(--danger)' : '';
     okBtn.style.color      = perigoso ? '#fff' : '';
+    okBtn.style.border     = perigoso ? '1px solid var(--danger)' : '';
 
     const fechar = (resp) => {
       overlay.classList.remove('open');


### PR DESCRIPTION
## Bug reportado pelo CEO
Ao excluir uma movimentação no **Financeiro** ou clicar **Enviar WhatsApp** na proposta, o modal de confirmação aparecia 'vazado' no canto inferior esquerdo da página — sem fundo escurecido, sem centralização, sem borda. Bastava atualizar a página pra sumir, mas a UX ficava estranha.

## Causa raiz
`confirmarAcao` criava `<div class='overlay'>` + `<div class='modal'>`, mas o projeto não tem essas classes no CSS — todos os outros modais (`editOverlay`, `calOverlay`) usam `cal-overlay` / `cal-modal` / `cal-head`. Sem CSS, o overlay caía no fluxo normal do documento, herdando posição estática.

## Fix
- Troca `className` do overlay para `cal-overlay` (que tem `position:fixed; inset:0; backdrop; flex centering; .open exibe`).
- Estrutura interna agora usa `cal-modal` + `cal-head` (consistente com os outros modais).
- Adiciona fechar-clicando-fora no backdrop (mesmo comportamento de `editOverlay` em `obras.html:2706`).
- Botão 'perigoso' ganha border vermelho pra ficar visível no fundo escuro.

## Test plan
- [ ] Após merge + deploy:
  - Financeiro → 🗑️ excluir transação → modal centralizado, fundo escuro, botão Excluir vermelho
  - Proposta → 📱 Enviar WhatsApp → modal centralizado, botão Enviar verde
  - Clicar fora do modal (backdrop) → fecha como Cancelar

Generated with Claude Code