### PR TITLE
v1.65.10 (PR A): sync Equipe ↔ contacts ↔ memória ZAYRA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.9",
+  "version": "1.65.10",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.9',
+  version: '1.65.10',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -712,6 +712,19 @@ export async function runMigrations(): Promise<void> {
     `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_estado   VARCHAR(2)   NULL`,
     `ALTER TABLE romatec_obra_equipe ADD COLUMN endereco_cep      VARCHAR(10)  NULL`,
     `ALTER TABLE romatec_obra_equipe ADD COLUMN foto_url          VARCHAR(500) NULL`,
+    // v1.65.10 — PR A: sync Equipe ↔ contacts ↔ memória ZAYRA
+    // contacts ganha tratamento (Eng./Sr./Sra./Dr./...) + tom (formal/informal)
+    // + tipo (cliente/colaborador/fornecedor/...) + tags (JSON array de strings)
+    `ALTER TABLE contacts ADD COLUMN tratamento VARCHAR(40)  NULL`,
+    `ALTER TABLE contacts ADD COLUMN tom        VARCHAR(20)  NULL DEFAULT 'formal'`,
+    `ALTER TABLE contacts ADD COLUMN tipo       VARCHAR(40)  NULL`,
+    `ALTER TABLE contacts ADD COLUMN tags       JSON         NULL`,
+    `ALTER TABLE contacts ADD INDEX idx_tipo (tipo)`,
+    // romatec_obra_equipe ganha link pra contacts + chave PIX (futuro fluxo de recibos)
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN contact_id              INT          NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN chave_pix               VARCHAR(150) NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD COLUMN chave_pix_atualizada_em TIMESTAMP    NULL`,
+    `ALTER TABLE romatec_obra_equipe ADD INDEX idx_contact (contact_id)`,
   ]) {
     try {
       await pool.execute(stmt);

--- a/src/integrations/obras.ts
+++ b/src/integrations/obras.ts
@@ -527,6 +527,10 @@ export async function atualizarMembroEquipe(input: {
   const [r] = await pool.execute<ResultSetHeader>(
     `UPDATE romatec_obra_equipe SET ${fields.join(', ')} WHERE id = ?`, params,
   );
+  // v1.65.10: re-sync após edição (cargo/telefone/email/ativo podem ter mudado)
+  void import('../services/syncEquipeMembro')
+    .then(s => s.syncEquipeMembro(Number(input.id)))
+    .catch(err => console.warn('[syncEquipe] falhou após atualizar:', (err as Error).message));
   return { ok: true, affected: r.affectedRows, message: `Membro ${input.id} atualizado.` };
 }
 
@@ -579,6 +583,14 @@ export async function apagarMembroEquipe(input: {
   const [r] = await pool.execute<ResultSetHeader>(
     'DELETE FROM romatec_obra_equipe WHERE id = ?', [input.id],
   );
+  // v1.65.10: limpa memória ZAYRA do colaborador apagado.
+  // Não toca em contacts — o registro pode ser referenciado em outros lugares
+  // (cliente/fornecedor noutro fluxo); só deslinkar é mais seguro.
+  void pool.execute(
+    `DELETE FROM zayra_memory WHERE relevance_tags LIKE ?`,
+    [`%equipe_membro_id_${input.id}%`]
+  ).then(() => import('../agent/memory').then(m => m.invalidateContextCache?.()))
+   .catch(err => console.warn('[syncEquipe] limpeza memória falhou:', (err as Error).message));
   return { ok: true, affected: r.affectedRows, message: `Membro ${input.id} removido.` };
 }
 
@@ -635,6 +647,11 @@ export async function criarMembroEquipe(input: {
       input.obra_id ? Number(input.obra_id) : null,
     ],
   );
+  // v1.65.10: sync Equipe → contacts → zayra_memory (fire-and-forget,
+  // não bloqueia retorno; falha não derruba criação)
+  void import('../services/syncEquipeMembro')
+    .then(s => s.syncEquipeMembro(r.insertId))
+    .catch(err => console.warn('[syncEquipe] falhou após criar:', (err as Error).message));
   return { ok: true, insertId: r.insertId, message: `${input.nome} adicionado${input.obra_id ? ` à obra ${input.obra_id}` : ' à equipe geral'} (ID ${r.insertId}).` };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -633,6 +633,13 @@ app.get   ('/api/equipe',     apiHandle(args => obras.listarEquipe(args as { obr
 app.post  ('/api/equipe',     apiHandle(args => obras.criarMembroEquipe(args as Parameters<typeof obras.criarMembroEquipe>[0])));
 app.put   ('/api/equipe/:id', apiHandle(args => obras.atualizarMembroEquipe(args as Parameters<typeof obras.atualizarMembroEquipe>[0])));
 app.delete('/api/equipe/:id', apiHandle(args => obras.apagarMembroEquipe(args as { id: string; confirm?: boolean })));
+// v1.65.10: backfill manual de sync Equipe→contacts→zayra_memory.
+// Útil para popular tudo após deploy desta migração; depois disso, criar/editar
+// membro dispara sync automaticamente via hook em obras.ts.
+app.post('/api/equipe/sync-all', requireCeoToken, apiHandle(async () => {
+  const m = await import('./services/syncEquipeMembro');
+  return m.syncTodaEquipe();
+}));
 
 // Materiais
 app.get   ('/api/materiais',          apiHandle(args => obras.listarMateriais(args as { apenas_baixos?: boolean; obra_id?: string })));

--- a/src/services/syncEquipeMembro.ts
+++ b/src/services/syncEquipeMembro.ts
@@ -1,0 +1,190 @@
+// v1.65.10 — PR A: sincronização Equipe ↔ contacts ↔ memória ZAYRA.
+// Quando um membro de romatec_obra_equipe é criado/atualizado/apagado/inativado,
+// este service atualiza o registro correspondente em contacts (CRM) e o fato
+// estruturado em zayra_memory. Idempotente: roda 2x não duplica.
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../database/connection';
+
+interface MembroRow extends RowDataPacket {
+  id: number;
+  nome: string;
+  funcao: string | null;
+  tipo_contrato: string | null;
+  cpf: string | null;
+  telefone: string | null;
+  email: string | null;
+  valor_dia: string | null;
+  ativo: number;
+  contact_id: number | null;
+  observacoes: string | null;
+}
+
+interface ContactRow extends RowDataPacket {
+  id: number;
+  phone: string;
+}
+
+// Infere tratamento ("Eng.", "Arq.", etc) a partir do cargo. Conservador:
+// só aplica quando cargo é claro. Caso contrário deixa null (saudação genérica).
+function inferirTratamento(funcao: string | null): string | null {
+  if (!funcao) return null;
+  const f = funcao.toLowerCase();
+  if (f.includes('engenheir')) return 'Eng.';
+  if (f.includes('arquitet'))  return 'Arq.';
+  if (f.includes('mestre'))    return 'Mestre';
+  if (f.includes('técnico') || f.includes('tecnico')) return 'Téc.';
+  if (f.includes('doutor'))    return 'Dr.';
+  return null;
+}
+
+interface SyncResult {
+  ok: boolean;
+  contactId: number | null;
+  memoryId: number | null;
+  skipped?: 'sem_telefone' | 'membro_nao_encontrado';
+  message: string;
+}
+
+export async function syncEquipeMembro(membroId: number): Promise<SyncResult> {
+  // 1) Lê o membro
+  const [rows] = await pool.execute<MembroRow[]>(
+    `SELECT id, nome, funcao, tipo_contrato, cpf, telefone, email,
+            valor_dia, ativo, contact_id, observacoes
+       FROM romatec_obra_equipe WHERE id = ?`,
+    [membroId]
+  );
+  if (!rows.length) {
+    return { ok: false, contactId: null, memoryId: null, skipped: 'membro_nao_encontrado', message: `membro ${membroId} não encontrado` };
+  }
+  const m = rows[0];
+
+  // 2) Sem telefone → não dá pra sincronizar com contacts (UNIQUE phone)
+  // Memória ainda assim é gravada (útil pra ZAYRA mesmo sem contato).
+  const phone = (m.telefone || '').replace(/\D/g, '');
+  let contactId: number | null = null;
+
+  if (phone) {
+    // Phone normalizado pra match: contacts.phone tem formato variado, fazemos
+    // lookup por sufixo de 10 dígitos (DDD + número) pra cobrir 5598... vs 98...
+    const sufixo10 = phone.slice(-11); // 9-dígitos + DDD = 11 (BR celular)
+    const tratamento = inferirTratamento(m.funcao);
+    const tom = m.tipo_contrato === 'pj' || tratamento === 'Eng.' || tratamento === 'Arq.' || tratamento === 'Dr.'
+      ? 'formal' : 'informal';
+    const tipo = 'colaborador';
+    const tags = JSON.stringify(['equipe_romatec', `cargo_${(m.funcao || 'sem_cargo').toLowerCase().replace(/\s+/g, '_')}`]);
+
+    // Busca contact existente via:
+    //   a) já vinculado (contact_id na equipe)
+    //   b) phone exato
+    //   c) phone com mesmo sufixo de 10 dígitos
+    let existingId: number | null = null;
+    if (m.contact_id) {
+      const [c] = await pool.execute<ContactRow[]>('SELECT id, phone FROM contacts WHERE id = ?', [m.contact_id]);
+      if (c.length) existingId = c[0].id;
+    }
+    if (!existingId) {
+      const [c] = await pool.execute<ContactRow[]>(
+        `SELECT id, phone FROM contacts
+          WHERE REPLACE(REPLACE(REPLACE(phone, '+', ''), '-', ''), ' ', '') LIKE ?
+          ORDER BY id ASC LIMIT 1`,
+        [`%${sufixo10}`]
+      );
+      if (c.length) existingId = c[0].id;
+    }
+
+    if (existingId) {
+      contactId = existingId;
+      await pool.execute(
+        `UPDATE contacts
+            SET name = ?, email = COALESCE(?, email),
+                tratamento = ?, tipo = ?,
+                tom = COALESCE(tom, ?),
+                tags = ?
+          WHERE id = ?`,
+        [m.nome, m.email, tratamento, tipo, tom, tags, existingId]
+      );
+    } else {
+      const [r] = await pool.execute<ResultSetHeader>(
+        `INSERT INTO contacts (name, phone, email, tratamento, tipo, tom, tags)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [m.nome, phone, m.email, tratamento, tipo, tom, tags]
+      );
+      contactId = r.insertId;
+    }
+
+    // Vincula no membro se ainda não vinculado
+    if (m.contact_id !== contactId) {
+      await pool.execute(
+        `UPDATE romatec_obra_equipe SET contact_id = ? WHERE id = ?`,
+        [contactId, membroId]
+      );
+    }
+  }
+
+  // 3) Sync zayra_memory — idempotência via tag única `equipe_membro_id_<id>`
+  const tagUnica = `equipe_membro_id_${membroId}`;
+  const tags = `colaborador,${tagUnica}`;
+  const conteudo = m.ativo
+    ? `${m.nome} é colaborador da Romatec` +
+      (m.funcao        ? `, cargo ${m.funcao}` : '') +
+      (m.tipo_contrato ? `, vínculo ${m.tipo_contrato}` : '') +
+      (m.telefone      ? `, telefone ${m.telefone}` : '') +
+      (m.cpf           ? `, CPF ${m.cpf}` : '') + '.'
+    : `${m.nome} foi colaborador da Romatec, atualmente inativo` +
+      (m.funcao ? ` (cargo: ${m.funcao})` : '') + '.';
+
+  const [memRows] = await pool.execute<RowDataPacket[]>(
+    `SELECT id FROM zayra_memory WHERE relevance_tags LIKE ? LIMIT 1`,
+    [`%${tagUnica}%`]
+  );
+  let memoryId: number;
+  if (memRows.length) {
+    memoryId = Number(memRows[0].id);
+    await pool.execute(
+      `UPDATE zayra_memory SET content = ?, relevance_tags = ?, updated_at = NOW() WHERE id = ?`,
+      [conteudo, tags, memoryId]
+    );
+  } else {
+    const [r] = await pool.execute<ResultSetHeader>(
+      `INSERT INTO zayra_memory (type, content, relevance_tags) VALUES ('fact', ?, ?)`,
+      [conteudo, tags]
+    );
+    memoryId = r.insertId;
+  }
+
+  // Invalida cache de contexto da memória (usa import dinâmico pra evitar
+  // dependência circular entre services e agent/memory)
+  void import('../agent/memory').then(m => m.invalidateContextCache?.()).catch(() => {});
+
+  console.log(`[SYNC] equipe.id=${membroId} → contacts.id=${contactId ?? 'pulado(sem-tel)'} → zayra_memory.id=${memoryId}`);
+
+  return {
+    ok: true,
+    contactId,
+    memoryId,
+    skipped: contactId === null ? 'sem_telefone' : undefined,
+    message: contactId
+      ? `Sync ok: contact #${contactId}, memória #${memoryId}.`
+      : `Sync parcial: sem telefone — só memória #${memoryId} foi gravada.`,
+  };
+}
+
+// Helper: re-sincroniza TODA a equipe (útil pra backfill após esta migração).
+// Não chamado automaticamente — disparado manualmente por endpoint /api/equipe/sync-all.
+export async function syncTodaEquipe(): Promise<{ total: number; sucesso: number; pulados: number; falhas: number }> {
+  const [rows] = await pool.execute<RowDataPacket[]>(`SELECT id FROM romatec_obra_equipe ORDER BY id ASC`);
+  let sucesso = 0, pulados = 0, falhas = 0;
+  for (const r of rows) {
+    try {
+      const res = await syncEquipeMembro(Number(r.id));
+      if (res.skipped === 'sem_telefone') pulados++;
+      else if (res.ok) sucesso++;
+      else falhas++;
+    } catch (err) {
+      console.warn(`[SYNC] falhou para equipe.id=${r.id}:`, (err as Error).message);
+      falhas++;
+    }
+  }
+  return { total: rows.length, sucesso, pulados, falhas };
+}


### PR DESCRIPTION
## Resumo
Primeira PR do fluxo **Recibos Quinzenais via ZAYRA** (briefing CEO). Cria a infra de sincronização entre `romatec_obra_equipe` (aba Equipe), `contacts` (CRM) e `zayra_memory` (memória persistente da ZAYRA). Independente e baixo risco — sem tocar em recibos. As PRs B/C/D ficam bloqueadas até esta validar.

## Decisões durante implementação
- **Fonte de verdade**: `romatec_obra_equipe` (aba Equipe, 15 campos), não `romatec_team_members` (system users + telegram).
- **Match com contacts**: por `phone` (sufixo de 11 dígitos pra cobrir 5598... vs 98...) ou via `contact_id` já vinculado.
- **Idempotência da memória**: tag única `equipe_membro_id_<id>` permite UPDATE por LIKE — sem duplicação.
- **Sync fire-and-forget**: falha não derruba criar/editar — só loga warning.
- **Apagar membro**: limpa `zayra_memory`, mas NÃO `contacts` (pode estar referenciado noutro fluxo).

## Migrations idempotentes
```sql
ALTER TABLE contacts ADD tratamento, tom (default 'formal'), tipo, tags JSON, INDEX idx_tipo
ALTER TABLE romatec_obra_equipe ADD contact_id, chave_pix, chave_pix_atualizada_em, INDEX idx_contact
```

## Service `src/services/syncEquipeMembro.ts`
- `syncEquipeMembro(membroId)`: UPSERT em `contacts` + UPSERT em `zayra_memory`. Infere tratamento (Eng./Arq./Mestre/Téc./Dr.) do cargo. Tom default `formal` pra cargos técnicos, `informal` pros demais.
- `syncTodaEquipe()`: backfill em massa. Retorna `{ total, sucesso, pulados, falhas }`.
- Sem telefone → grava só memória, marca `pulado`.

## Hooks (`src/integrations/obras.ts`)
- `criarMembroEquipe` / `atualizarMembroEquipe`: dispara `syncEquipeMembro(id)` via dynamic import
- `apagarMembroEquipe`: DELETE em `zayra_memory` pela tag única

## Endpoint manual
- `POST /api/equipe/sync-all` (protegido por `CEO_API_TOKEN`) — backfill uma vez após deploy.

## Test plan
- [ ] Após merge + deploy: verificar boot logs (migrations não-bloqueantes)
- [ ] Configurar `CEO_API_TOKEN` no front via botão Admin
- [ ] `curl -X POST .../api/equipe/sync-all -H 'X-CEO-Token: ...'` → retorna `{ total, sucesso, pulados, falhas }`
- [ ] Validar no MySQL: `SELECT id, name, tratamento, tipo, tags FROM contacts WHERE tipo='colaborador'`
- [ ] Validar memória: `SELECT id, content, relevance_tags FROM zayra_memory WHERE relevance_tags LIKE '%equipe_membro_id_%'`
- [ ] Cadastrar novo membro pela aba Equipe → verificar log `[SYNC] equipe.id=X → contacts.id=Y → zayra_memory.id=Z`
- [ ] Editar cargo do membro → re-sync atualiza `tratamento`/`content` automaticamente

Generated with Claude Code