### PR TITLE
v1.65.11: comando /clear no Telegram pra limpar histórico da sessão ZAYRA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.10",
+  "version": "1.65.11",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.10',
+  version: '1.65.11',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -53,6 +53,25 @@ export function getSessionHistory(): SessionMsg[] {
   return [...sessionMsgs];
 }
 
+// v1.65.11: limpa o histórico de uma sessão específica (DB) + esvazia o
+// buffer global em memória + invalida cache de contexto. Chamada pelos
+// comandos /clear, /limpar, /reset no Telegram (e potencialmente no chat web).
+export async function clearSession(sessionId: string): Promise<{ apagadas: number }> {
+  let apagadas = 0;
+  try {
+    const [r] = await db().execute<ResultSetHeader>(
+      'DELETE FROM zayra_conversations WHERE session_id = ?',
+      [sessionId],
+    );
+    apagadas = r.affectedRows ?? 0;
+  } catch (err) {
+    console.warn('[Memory] clearSession DB falhou:', (err as Error).message);
+  }
+  sessionMsgs.length = 0;
+  invalidateContextCache();
+  return { apagadas };
+}
+
 export async function loadSessionFromDb(): Promise<void> {
   try {
     const [rows] = await db().execute<RowDataPacket[]>(

--- a/src/integrations/telegram.ts
+++ b/src/integrations/telegram.ts
@@ -394,6 +394,31 @@ export async function processTelegramIncoming(incoming: TelegramIncoming): Promi
 
   // Autorizado — passa pra ZAYRA via think()
   const sessionId = `tg_${incoming.chatId}`;
+
+  // v1.65.11: comandos administrativos da sessão Telegram.
+  // /clear, /limpar, /reset, /novachat → apaga histórico desta conversa
+  // (zayra_conversations) + esvazia buffer em memória + invalida contexto.
+  // Útil quando ZAYRA mantém infos antigas (ex: transações já excluídas
+  // no banco mas ainda mencionadas no chat).
+  const cmd = (incoming.text || '').trim().toLowerCase();
+  if (/^\/(clear|limpar|reset|novachat)\b/.test(cmd)) {
+    try {
+      const m = await import('../agent/memory');
+      const r = await m.clearSession(sessionId);
+      await sendMessage(
+        incoming.chatId,
+        `🧹 Histórico desta conversa zerado (${r.apagadas} mensagens apagadas).\n\n` +
+        `Comece agora — vou consultar tudo do zero pelas tools.`,
+      );
+    } catch (err) {
+      await sendMessage(
+        incoming.chatId,
+        `⚠️ Falhei ao limpar: ${escapeMd((err as Error).message ?? String(err))}`,
+      );
+    }
+    return;
+  }
+
   try {
     const callerOpt = auth.role && auth.membro_nome ? {
       caller: { role: auth.role, nome: auth.membro_nome, via: auth.via === 'env' ? 'env' as const : 'db' as const },


### PR DESCRIPTION
## Bug operacional
CEO reportou via Telegram: a ZAYRA continuava mencionando movimentações financeiras (R$ 5.000 entrada/saída na obra Posto Chapadão) que já tinham sido excluídas no Financeiro. UI mostrava `Movimentações: 0` e `Saldo: R$ 0,00`, mas a ZAYRA repetia números antigos.

## Causa
- Sessão Telegram usa `session_id` fixo: `tg_<chatId>`.
- As últimas 50 mensagens da conversa entram no contexto de cada turno.
- ZAYRA respondia da **memória de conversa** em vez de re-chamar a tool `listar_transacoes_obra`.

## Fix
Comandos administrativos da sessão Telegram:
- `/clear`, `/limpar`, `/reset`, `/novachat`
- Apaga histórico em `zayra_conversations WHERE session_id = tg_<chatId>` + esvazia buffer global em memória + invalida cache de contexto.
- Próximo turno: ZAYRA sem histórico → forçada a re-consultar tudo via tools → dados frescos do banco.

Helper novo: `memory.clearSession(sessionId) → { apagadas }` (pra reuso futuro em outros canais).

## Test plan
- [ ] Após merge + deploy: enviar `/clear` no Telegram para a ZAYRA
- [ ] Resposta: `🧹 Histórico desta conversa zerado (X mensagens apagadas).`
- [ ] Perguntar de novo sobre obra Posto Chapadão → ZAYRA chama tools e retorna `R$ 0,00 / 0 movimentações` (igual a UI)

Generated with Claude Code