### PR TITLE
v1.65.12 (PR B.1): Recibo Quinzenal — ajustes + PDF + QR-code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.3",
+  "version": "1.65.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romatec-voice-agent",
-      "version": "1.65.3",
+      "version": "1.65.11",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.3",
         "@cerebras/cerebras_cloud_sdk": "^1.64.1",
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.105.0",
         "@types/pdfkit": "^0.17.6",
+        "@types/qrcode": "^1.5.6",
         "axios": "^1.8.4",
         "docx": "^9.6.1",
         "dotenv": "^16.4.7",
@@ -26,6 +27,7 @@
         "openai": "^4.96.0",
         "pdf-parse": "^2.4.5",
         "pdfkit": "^0.18.0",
+        "qrcode": "^1.5.4",
         "voyageai": "^0.2.1"
       },
       "devDependencies": {
@@ -967,6 +969,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -1064,6 +1075,30 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/append-field": {
@@ -1414,6 +1449,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
@@ -1428,6 +1472,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -1436,6 +1491,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1607,6 +1680,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1692,6 +1774,12 @@
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/dingbat-to-unicode": {
@@ -1801,6 +1889,12 @@
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2056,6 +2150,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -2250,6 +2357,15 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2593,6 +2709,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -2703,6 +2828,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/long": {
@@ -3104,6 +3241,42 @@
       "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3133,6 +3306,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3221,6 +3403,15 @@
         "browserify-zlib": "^0.2.0"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3286,6 +3477,23 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -3374,6 +3582,21 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -3498,6 +3721,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -3689,6 +3918,32 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tiny-inflate": {
@@ -3931,6 +4186,12 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -3950,6 +4211,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {
@@ -3998,6 +4273,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.11",
+  "version": "1.65.12",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {
@@ -18,6 +18,7 @@
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.105.0",
     "@types/pdfkit": "^0.17.6",
+    "@types/qrcode": "^1.5.6",
     "axios": "^1.8.4",
     "docx": "^9.6.1",
     "dotenv": "^16.4.7",
@@ -31,6 +32,7 @@
     "openai": "^4.96.0",
     "pdf-parse": "^2.4.5",
     "pdfkit": "^0.18.0",
+    "qrcode": "^1.5.4",
     "voyageai": "^0.2.1"
   },
   "devDependencies": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.11',
+  version: '1.65.12',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -879,6 +879,41 @@ export async function runMigrations(): Promise<void> {
     }
   }
 
+  // v1.65.12 — PR B.1: ajustes do recibo quinzenal + emissões com hash de validação.
+  // Período no formato "YYYY-MM-1" (dias 1-15) ou "YYYY-MM-2" (dias 16-fim).
+  await pool.execute(`
+    CREATE TABLE IF NOT EXISTS recibos_ajustes (
+      id          INT AUTO_INCREMENT PRIMARY KEY,
+      membro_id   INT NOT NULL,
+      periodo     VARCHAR(10) NOT NULL,
+      tipo        ENUM('desconto','adiantamento','bonus','horas_extras') NOT NULL,
+      valor       DECIMAL(10,2) NOT NULL,
+      descricao   VARCHAR(255),
+      criado_em   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      criado_por  VARCHAR(80),
+      INDEX idx_membro_periodo (membro_id, periodo)
+    )
+  `);
+  // Snapshot dos recibos emitidos (assinatura digital via QR-code).
+  // Armazena o estado congelado do recibo no momento da emissão.
+  // Re-emitir mesma quinzena cria novo registro com novo hash — assim
+  // recibos antigos continuam validáveis mesmo após edições.
+  await pool.execute(`
+    CREATE TABLE IF NOT EXISTS recibos_quinzena_emitidos (
+      id              INT AUTO_INCREMENT PRIMARY KEY,
+      hash            VARCHAR(64) NOT NULL UNIQUE,
+      membro_id       INT NOT NULL,
+      periodo         VARCHAR(10) NOT NULL,
+      total_dias      DECIMAL(5,1) NOT NULL,
+      valor_diarias   DECIMAL(10,2) NOT NULL,
+      total_ajustes   DECIMAL(10,2) NOT NULL DEFAULT 0,
+      total_liquido   DECIMAL(10,2) NOT NULL,
+      snapshot_json   JSON NOT NULL,
+      emitido_em      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      INDEX idx_membro_periodo (membro_id, periodo, emitido_em)
+    )
+  `);
+
   console.log('[DB] Migrations complete');
 }
 

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1394,7 +1394,10 @@ function renderMarcarDias() {
         <span>Equiv: <strong style="color:var(--text);">${s.total_dias_equivalente}</strong></span>
         <span>Total: <strong style="color:var(--gold);">${fmt(s.total_pagar)}</strong></span>
       </div>
-      <button class="btn-gold" data-cal-marcar="${p.id}" data-nome="${escape(p.nome)}" data-vd="${p.valor_dia}">📅 Marcar dias</button>
+      <div style="display:flex; gap:6px; flex-wrap:wrap;">
+        <button class="btn-gold" data-cal-marcar="${p.id}" data-nome="${escape(p.nome)}" data-vd="${p.valor_dia}">📅 Marcar dias</button>
+        <button data-recibo-q="${p.id}" data-nome="${escape(p.nome)}" title="Recibo quinzenal + ajustes">💰 Recibo</button>
+      </div>
     </div>`;
   }).join('');
 
@@ -1419,6 +1422,9 @@ function renderMarcarDias() {
 
   v.querySelectorAll('[data-cal-marcar]').forEach(b => b.onclick = () => {
     abrirCalendario(b.dataset.calMarcar, b.dataset.nome, parseFloat(b.dataset.vd) || 0, state.currentObra);
+  });
+  v.querySelectorAll('[data-recibo-q]').forEach(b => b.onclick = () => {
+    abrirModalReciboQuinzena(b.dataset.reciboQ, b.dataset.nome);
   });
 
   document.getElementById('mdPrev').onclick = () => {
@@ -2519,6 +2525,11 @@ let _editSaveHandler = null;
 function abrirEditar(titulo, bodyHtml, saveHandler) {
   document.getElementById('editTitle').textContent = titulo;
   document.getElementById('editBody').innerHTML = bodyHtml;
+  // Reset estado visual dos botões (caso modal anterior tenha customizado)
+  const sb = document.getElementById('editSave');
+  if (sb) { sb.style.display = ''; sb.textContent = 'Salvar'; }
+  const cb = document.getElementById('editCancel');
+  if (cb) cb.textContent = 'Cancelar';
   _editSaveHandler = saveHandler;
   document.getElementById('editOverlay').classList.add('open');
 }
@@ -2613,6 +2624,130 @@ function abrirEditarMembro(m) {
 }
 
 // v1.62.0: editar transação financeira (admin/CEO only via X-CEO-Token).
+// v1.65.12 (PR B.1): Modal de recibo quinzenal — gerencia ajustes (descontos,
+// adiantamentos, bônus, horas extras) por colaborador/período e gera PDF preview.
+function periodoQuinzenaAtual() {
+  const d = new Date();
+  const ano = d.getFullYear();
+  const mes = String(d.getMonth() + 1).padStart(2, '0');
+  const q = d.getDate() <= 15 ? 1 : 2;
+  return `${ano}-${mes}-${q}`;
+}
+function periodoLabel(codigo) {
+  const m = /^(\d{4})-(\d{2})-([12])$/.exec(codigo || '');
+  if (!m) return codigo;
+  const meses = ['','Janeiro','Fevereiro','Março','Abril','Maio','Junho','Julho','Agosto','Setembro','Outubro','Novembro','Dezembro'];
+  return `${m[3]}ª quinzena de ${meses[Number(m[2])]}/${m[1]}`;
+}
+
+async function abrirModalReciboQuinzena(membroId, nome) {
+  const periodoIni = periodoQuinzenaAtual();
+  // Gera 6 períodos pra trás + o atual
+  const opts = [];
+  const d = new Date();
+  for (let i = 0; i < 6; i++) {
+    const ano = d.getFullYear();
+    const mes = String(d.getMonth() + 1).padStart(2, '0');
+    opts.push(`${ano}-${mes}-2`);
+    opts.push(`${ano}-${mes}-1`);
+    d.setMonth(d.getMonth() - 1);
+  }
+  const periodoOpts = Array.from(new Set(opts)).sort().reverse()
+    .map(p => `<option value="${p}" ${p === periodoIni ? 'selected' : ''}>${escape(periodoLabel(p))}</option>`)
+    .join('');
+
+  const body = `
+    <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-bottom:10px;">
+      <label style="flex:1; min-width:180px;">
+        <span style="font-size:12px; color:var(--text-muted);">Período</span>
+        <select id="rqPeriodo">${periodoOpts}</select>
+      </label>
+      <button id="rqVerPdf" title="Visualizar PDF preview">📄 Gerar PDF</button>
+    </div>
+    <p class="section-title" style="margin:8px 0 4px; font-size:13px;">Ajustes deste período</p>
+    <div id="rqAjustesLista" style="font-size:12px;">
+      <p style="color:var(--text-muted); text-align:center; padding:12px;">Carregando…</p>
+    </div>
+    <hr style="border:none; border-top:1px solid var(--border-strong); margin:10px 0;">
+    <p style="font-size:12px; color:var(--text-muted); margin:0 0 6px;">Adicionar ajuste:</p>
+    <div class="form-grid">
+      <select id="rqTipo">
+        <option value="desconto">Desconto</option>
+        <option value="adiantamento">Adiantamento</option>
+        <option value="bonus">Bônus</option>
+        <option value="horas_extras">Horas extras</option>
+      </select>
+      <input id="rqValor" type="number" step="0.01" min="0.01" placeholder="Valor R$">
+      <input id="rqDesc" placeholder="Descrição (opcional)" style="grid-column:1/-1;">
+      <button id="rqAddAjuste" class="btn-primary" style="grid-column:1/-1;">+ Adicionar ajuste</button>
+    </div>
+  `;
+
+  // Reusa abrirEditar mas substitui o "Salvar" por um botão Fechar (modal informativo).
+  abrirEditar(`💰 Recibo Quinzenal — ${nome}`, body, async () => fecharEditar());
+
+  // Esconde botão padrão "Salvar" do modal e renomeia "Cancelar" pra "Fechar"
+  const saveBtn = document.getElementById('editSave');
+  if (saveBtn) saveBtn.style.display = 'none';
+  const cancelBtn = document.getElementById('editCancel');
+  if (cancelBtn) cancelBtn.textContent = 'Fechar';
+
+  const recarregarAjustes = async () => {
+    const periodo = document.getElementById('rqPeriodo').value;
+    const lista = document.getElementById('rqAjustesLista');
+    try {
+      const r = await api(`/api/recibos/ajustes?membro_id=${membroId}&periodo=${periodo}`);
+      if (!r.length) {
+        lista.innerHTML = '<p style="color:var(--text-muted); text-align:center; padding:8px;">Sem ajustes neste período.</p>';
+        return;
+      }
+      const tipoLabel = { desconto: 'Desconto', adiantamento: 'Adiantamento', bonus: 'Bônus', horas_extras: 'Horas extras' };
+      const sinal = (t) => (t === 'desconto' || t === 'adiantamento') ? '−' : '+';
+      const cor   = (t) => (t === 'desconto' || t === 'adiantamento') ? 'var(--danger)' : 'var(--neon)';
+      lista.innerHTML = r.map(a => `
+        <div style="display:flex; justify-content:space-between; align-items:center; padding:6px 0; border-bottom:1px solid var(--border);">
+          <div style="flex:1; min-width:0;">
+            <span>${escape(tipoLabel[a.tipo])}</span>${a.descricao ? ` <span style="color:var(--text-muted);">— ${escape(a.descricao)}</span>` : ''}
+          </div>
+          <span style="color:${cor(a.tipo)}; font-weight:500; margin:0 8px;">${sinal(a.tipo)} ${fmt(a.valor)}</span>
+          <button class="btn-danger" data-rm-ajuste="${a.id}" title="Remover" style="padding:2px 8px;">×</button>
+        </div>
+      `).join('');
+      lista.querySelectorAll('[data-rm-ajuste]').forEach(b => b.onclick = async () => {
+        if (!await confirmarAcao({ titulo:'Remover ajuste', mensagem:'Tem certeza?', textoConfirmar:'Remover', perigoso:true })) return;
+        try { await api('/api/recibos/ajustes/' + b.dataset.rmAjuste, { method:'DELETE' }); await recarregarAjustes(); }
+        catch (e) { mostrarErroApi(e); }
+      });
+    } catch (e) {
+      lista.innerHTML = `<p style="color:var(--danger); text-align:center; padding:8px;">Erro: ${escape(e.message)}</p>`;
+    }
+  };
+
+  document.getElementById('rqPeriodo').onchange = recarregarAjustes;
+  document.getElementById('rqAddAjuste').onclick = async () => {
+    const periodo = document.getElementById('rqPeriodo').value;
+    const tipo    = document.getElementById('rqTipo').value;
+    const valor   = Number(document.getElementById('rqValor').value);
+    const descr   = document.getElementById('rqDesc').value.trim();
+    if (!isFinite(valor) || valor <= 0) { alert('Valor deve ser > 0.'); return; }
+    try {
+      await api('/api/recibos/ajustes', {
+        method: 'POST',
+        body: JSON.stringify({ membro_id: membroId, periodo, tipo, valor, descricao: descr || undefined })
+      });
+      document.getElementById('rqValor').value = '';
+      document.getElementById('rqDesc').value  = '';
+      await recarregarAjustes();
+    } catch (e) { mostrarErroApi(e); }
+  };
+  document.getElementById('rqVerPdf').onclick = () => {
+    const periodo = document.getElementById('rqPeriodo').value;
+    window.open(API + `/api/recibos/quinzena/${membroId}/pdf?periodo=${periodo}`, '_blank');
+  };
+
+  await recarregarAjustes();
+}
+
 function abrirEditarTransacao(t) {
   const tipos = ['saida', 'entrada'];
   const tipoOpts = tipos.map(x => `<option value="${x}" ${x===t.tipo?'selected':''}>${x === 'entrada' ? 'Entrada' : 'Saída'}</option>`).join('');

--- a/src/server.ts
+++ b/src/server.ts
@@ -641,6 +641,57 @@ app.post('/api/equipe/sync-all', requireCeoToken, apiHandle(async () => {
   return m.syncTodaEquipe();
 }));
 
+// v1.65.12 — PR B.1: recibo quinzenal (ajustes + PDF + validação por hash)
+app.get   ('/api/recibos/ajustes', apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.listarAjustes(args as { membro_id: string; periodo?: string });
+}));
+app.post  ('/api/recibos/ajustes', requireCeoToken, apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.criarAjuste(args as Parameters<typeof m.criarAjuste>[0]);
+}));
+app.delete('/api/recibos/ajustes/:id', requireCeoToken, apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.removerAjuste(args as { id: string });
+}));
+
+// PDF do recibo quinzenal (preview / download / fonte para o envio em B.2)
+app.get('/api/recibos/quinzena/:membro_id/pdf', async (req: Request, res: Response) => {
+  try {
+    const periodo = String(req.query.periodo || '');
+    if (!periodo) {
+      res.status(400).json({ error: 'parâmetro ?periodo=YYYY-MM-1 obrigatório' });
+      return;
+    }
+    const m = await import('./services/recibosQuinzena');
+    const proto = (req.get('x-forwarded-proto') as string | undefined)?.split(',')[0]?.trim() || 'https';
+    const baseUrl = `${proto}://${req.get('host')}`.replace(/\/$/, '');
+    const r = await m.gerarReciboQuinzenalPdf({
+      membro_id: String(req.params.membro_id),
+      periodo,
+      baseUrl,
+    });
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition',
+      `inline; filename="Recibo_${r.data.membro.nome.replace(/[^a-zA-Z0-9]/g, '_')}_${periodo}.pdf"`);
+    res.send(r.buffer);
+  } catch (err) {
+    res.status(404).json({ error: (err as Error).message });
+  }
+});
+
+// Página pública acessada via QR-code (validação)
+app.get('/recibos/validar/:hash', async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/recibosQuinzena');
+    const html = await m.gerarHtmlValidacao(String(req.params.hash));
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.send(html);
+  } catch (err) {
+    res.status(500).send(`<pre>Erro: ${(err as Error).message}</pre>`);
+  }
+});
+
 // Materiais
 app.get   ('/api/materiais',          apiHandle(args => obras.listarMateriais(args as { apenas_baixos?: boolean; obra_id?: string })));
 app.post  ('/api/materiais',          apiHandle(args => obras.criarMaterial(args as Parameters<typeof obras.criarMaterial>[0])));

--- a/src/services/recibosQuinzena.ts
+++ b/src/services/recibosQuinzena.ts
@@ -1,0 +1,591 @@
+// v1.65.12 — PR B.1: gerador de recibo quinzenal (PDF) + ajustes + assinatura
+// digital via QR-code. Não envia nada — só monta o documento e disponibiliza
+// pra preview/download. PR B.2 plugará isso no fluxo de envio em massa via
+// ZAYRA + Z-API.
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import crypto from 'crypto';
+import path from 'path';
+import fs from 'fs';
+import PDFDocument from 'pdfkit';
+import QRCode from 'qrcode';
+import pool from '../database/connection';
+import { formatBRL } from '../util/format';
+import { getTenantSettings } from './tenantSettings';
+
+const LOGO_RELATORIO = '/romatec-logo.jpg';
+
+// ── Período: "YYYY-MM-1" (dias 1-15) ou "YYYY-MM-2" (dias 16-fim) ───────────
+export interface Periodo {
+  ano: number;
+  mes: number;            // 1-12
+  quinzena: 1 | 2;
+  dataInicio: string;     // "YYYY-MM-DD"
+  dataFim: string;        // "YYYY-MM-DD"
+  label: string;          // "1ª quinzena de Maio/2026"
+  codigo: string;         // "2026-05-1"
+}
+
+const NOMES_MES = [
+  '', 'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+  'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+];
+
+export function parsePeriodo(codigo: string): Periodo {
+  const m = /^(\d{4})-(\d{2})-([12])$/.exec(codigo);
+  if (!m) throw new Error(`período inválido: "${codigo}" (formato esperado YYYY-MM-1 ou YYYY-MM-2)`);
+  const ano = Number(m[1]);
+  const mes = Number(m[2]);
+  const quinzena = Number(m[3]) as 1 | 2;
+  const ultimoDiaMes = new Date(ano, mes, 0).getDate();
+  const dataInicio = quinzena === 1
+    ? `${ano}-${String(mes).padStart(2, '0')}-01`
+    : `${ano}-${String(mes).padStart(2, '0')}-16`;
+  const dataFim = quinzena === 1
+    ? `${ano}-${String(mes).padStart(2, '0')}-15`
+    : `${ano}-${String(mes).padStart(2, '0')}-${String(ultimoDiaMes).padStart(2, '0')}`;
+  return {
+    ano, mes, quinzena, dataInicio, dataFim,
+    codigo,
+    label: `${quinzena}ª quinzena de ${NOMES_MES[mes]}/${ano}`,
+  };
+}
+
+export function calcularPeriodoAtual(now: Date = new Date()): Periodo {
+  const ano = now.getFullYear();
+  const mes = now.getMonth() + 1;
+  const dia = now.getDate();
+  const quinzena = dia <= 15 ? 1 : 2;
+  return parsePeriodo(`${ano}-${String(mes).padStart(2, '0')}-${quinzena}`);
+}
+
+// ── CRUD Ajustes ────────────────────────────────────────────────────────────
+export type TipoAjuste = 'desconto' | 'adiantamento' | 'bonus' | 'horas_extras';
+
+interface AjusteRow extends RowDataPacket {
+  id: number;
+  membro_id: number;
+  periodo: string;
+  tipo: TipoAjuste;
+  valor: string;
+  descricao: string | null;
+  criado_em: Date;
+  criado_por: string | null;
+}
+
+export interface Ajuste {
+  id: string;
+  membro_id: string;
+  periodo: string;
+  tipo: TipoAjuste;
+  valor: number;
+  descricao: string | null;
+  criado_em: Date;
+  criado_por: string | null;
+}
+
+export async function listarAjustes(input: { membro_id: string; periodo?: string }): Promise<Ajuste[]> {
+  const params: (string | number)[] = [Number(input.membro_id)];
+  let sql = 'SELECT * FROM recibos_ajustes WHERE membro_id = ?';
+  if (input.periodo) { sql += ' AND periodo = ?'; params.push(input.periodo); }
+  sql += ' ORDER BY criado_em DESC';
+  const [rows] = await pool.execute<AjusteRow[]>(sql, params);
+  return rows.map(r => ({
+    id: String(r.id),
+    membro_id: String(r.membro_id),
+    periodo: r.periodo,
+    tipo: r.tipo,
+    valor: Number(r.valor),
+    descricao: r.descricao,
+    criado_em: r.criado_em,
+    criado_por: r.criado_por,
+  }));
+}
+
+export async function criarAjuste(input: {
+  membro_id: string; periodo: string; tipo: TipoAjuste;
+  valor: number; descricao?: string; criado_por?: string;
+}): Promise<{ ok: true; insertId: number; message: string }> {
+  if (!input.membro_id) throw new Error('membro_id obrigatório');
+  parsePeriodo(input.periodo); // valida formato
+  if (!['desconto', 'adiantamento', 'bonus', 'horas_extras'].includes(input.tipo)) {
+    throw new Error(`tipo inválido: ${input.tipo}`);
+  }
+  const valor = Number(input.valor);
+  if (!isFinite(valor) || valor <= 0) throw new Error('valor deve ser > 0 (sinal vem do tipo)');
+
+  const [r] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO recibos_ajustes (membro_id, periodo, tipo, valor, descricao, criado_por)
+     VALUES (?,?,?,?,?,?)`,
+    [Number(input.membro_id), input.periodo, input.tipo, valor.toFixed(2),
+     input.descricao ?? null, input.criado_por ?? null]
+  );
+  return { ok: true, insertId: r.insertId, message: `Ajuste ${input.tipo} de ${formatBRL(valor)} adicionado.` };
+}
+
+export async function removerAjuste(input: { id: string }): Promise<{ ok: true; affected: number }> {
+  const [r] = await pool.execute<ResultSetHeader>(
+    'DELETE FROM recibos_ajustes WHERE id = ?', [Number(input.id)]
+  );
+  return { ok: true, affected: r.affectedRows };
+}
+
+// ── Coleta consolidada do recibo ────────────────────────────────────────────
+interface MembroRow extends RowDataPacket {
+  id: number; nome: string; funcao: string | null; cpf: string | null;
+  tipo_contrato: string | null; valor_dia: string | null;
+  endereco_rua: string | null; endereco_cidade: string | null; endereco_estado: string | null;
+}
+
+interface DiaRow extends RowDataPacket {
+  id: number; data: Date; periodo: 'integral' | 'manha' | 'tarde';
+  valor: string | null; obra_id: number | null; obra_nome: string | null;
+  observacoes: string | null;
+}
+
+interface ReciboData {
+  membro: {
+    id: string; nome: string; cpf: string | null; cargo: string | null;
+    vinculo: string | null; valor_dia: number;
+    cidade: string | null; estado: string | null;
+  };
+  periodo: Periodo;
+  dias: Array<{
+    data: string;            // dd/MM/yyyy
+    iso: string;              // YYYY-MM-DD
+    tipo: 'integral' | 'manha' | 'tarde';
+    fracao: number;           // 1.0 ou 0.5
+    valor: number;
+    obra_id: string | null;
+    obra_nome: string | null;
+    observacoes: string | null;
+  }>;
+  obras: Array<{ id: string; nome: string }>;
+  ajustes: Ajuste[];
+  totais: {
+    qtd_dias: number;         // soma de frações (3 integrais + 1 meia = 3.5)
+    valor_diarias: number;
+    descontos: number;        // soma absoluta
+    adiantamentos: number;    // soma absoluta
+    bonus: number;
+    horas_extras: number;
+    total_ajustes: number;    // bonus + horas_extras − descontos − adiantamentos (sinal)
+    total_liquido: number;    // valor_diarias + total_ajustes
+  };
+}
+
+export async function coletarDadosRecibo(membroId: string, periodoCodigo: string): Promise<ReciboData> {
+  const periodo = parsePeriodo(periodoCodigo);
+  const [mRows] = await pool.execute<MembroRow[]>(
+    `SELECT id, nome, funcao, cpf, tipo_contrato, valor_dia,
+            endereco_cidade, endereco_estado
+       FROM romatec_obra_equipe WHERE id = ?`,
+    [Number(membroId)]
+  );
+  if (!mRows.length) throw new Error(`membro ${membroId} não encontrado`);
+  const m = mRows[0];
+
+  const [dRows] = await pool.execute<DiaRow[]>(
+    `SELECT d.id, d.data, d.periodo, d.valor, d.obra_id, d.observacoes,
+            o.nome AS obra_nome
+       FROM romatec_obra_funcionario_dias d
+       LEFT JOIN romatec_obras o ON o.id = d.obra_id
+      WHERE d.funcionario_id = ?
+        AND d.data BETWEEN ? AND ?
+      ORDER BY d.data ASC, d.periodo ASC`,
+    [Number(membroId), periodo.dataInicio, periodo.dataFim]
+  );
+
+  const valorDia = m.valor_dia ? Number(m.valor_dia) : 0;
+  const dias = dRows.map(r => {
+    const fracao = r.periodo === 'integral' ? 1 : 0.5;
+    const valor = r.valor != null ? Number(r.valor) : valorDia * fracao;
+    const isoData = (r.data instanceof Date)
+      ? r.data.toISOString().slice(0, 10)
+      : String(r.data).slice(0, 10);
+    return {
+      data: isoData.split('-').reverse().join('/'),
+      iso: isoData,
+      tipo: r.periodo,
+      fracao,
+      valor,
+      obra_id: r.obra_id ? String(r.obra_id) : null,
+      obra_nome: r.obra_nome,
+      observacoes: r.observacoes,
+    };
+  });
+
+  // Obras únicas trabalhadas
+  const obrasMap = new Map<string, string>();
+  for (const d of dias) {
+    if (d.obra_id && d.obra_nome) obrasMap.set(d.obra_id, d.obra_nome);
+  }
+  const obras = Array.from(obrasMap.entries()).map(([id, nome]) => ({ id, nome }));
+
+  const ajustes = await listarAjustes({ membro_id: membroId, periodo: periodo.codigo });
+
+  // Totais
+  const qtd_dias       = dias.reduce((s, d) => s + d.fracao, 0);
+  const valor_diarias  = dias.reduce((s, d) => s + d.valor, 0);
+  const descontos      = ajustes.filter(a => a.tipo === 'desconto').reduce((s, a) => s + a.valor, 0);
+  const adiantamentos  = ajustes.filter(a => a.tipo === 'adiantamento').reduce((s, a) => s + a.valor, 0);
+  const bonus          = ajustes.filter(a => a.tipo === 'bonus').reduce((s, a) => s + a.valor, 0);
+  const horas_extras   = ajustes.filter(a => a.tipo === 'horas_extras').reduce((s, a) => s + a.valor, 0);
+  const total_ajustes  = bonus + horas_extras - descontos - adiantamentos;
+  const total_liquido  = valor_diarias + total_ajustes;
+
+  return {
+    membro: {
+      id: String(m.id), nome: m.nome, cpf: m.cpf,
+      cargo: m.funcao, vinculo: m.tipo_contrato,
+      valor_dia: valorDia,
+      cidade: m.endereco_cidade, estado: m.endereco_estado,
+    },
+    periodo,
+    dias,
+    obras,
+    ajustes,
+    totais: {
+      qtd_dias, valor_diarias,
+      descontos, adiantamentos, bonus, horas_extras,
+      total_ajustes, total_liquido,
+    },
+  };
+}
+
+// ── Snapshot persistido + hash ──────────────────────────────────────────────
+function gerarHash(payload: object): string {
+  return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+}
+
+interface EmitidoRow extends RowDataPacket {
+  hash: string;
+  membro_id: number; periodo: string;
+  total_dias: string; valor_diarias: string; total_ajustes: string; total_liquido: string;
+  snapshot_json: string | object;
+  emitido_em: Date;
+}
+
+async function persistirSnapshot(data: ReciboData): Promise<{ hash: string; emitidoEm: Date }> {
+  // Snapshot sem timestamp dinâmico pra hash ser estável quando dados não mudam
+  const snapshot = {
+    v: 1,
+    membro_id: data.membro.id,
+    periodo: data.periodo.codigo,
+    membro: data.membro,
+    dias: data.dias,
+    obras: data.obras,
+    ajustes: data.ajustes.map(a => ({
+      id: a.id, tipo: a.tipo, valor: a.valor, descricao: a.descricao,
+    })),
+    totais: data.totais,
+  };
+  const hash = gerarHash(snapshot);
+
+  // Se já existe emissão com mesmo hash, retorna ela (idempotente)
+  const [existe] = await pool.execute<EmitidoRow[]>(
+    'SELECT * FROM recibos_quinzena_emitidos WHERE hash = ? LIMIT 1', [hash]
+  );
+  if (existe.length) return { hash, emitidoEm: existe[0].emitido_em };
+
+  await pool.execute<ResultSetHeader>(
+    `INSERT INTO recibos_quinzena_emitidos
+       (hash, membro_id, periodo, total_dias, valor_diarias, total_ajustes, total_liquido, snapshot_json)
+     VALUES (?,?,?,?,?,?,?,?)`,
+    [
+      hash, Number(data.membro.id), data.periodo.codigo,
+      data.totais.qtd_dias.toFixed(1),
+      data.totais.valor_diarias.toFixed(2),
+      data.totais.total_ajustes.toFixed(2),
+      data.totais.total_liquido.toFixed(2),
+      JSON.stringify(snapshot),
+    ]
+  );
+  return { hash, emitidoEm: new Date() };
+}
+
+export async function buscarReciboPorHash(hash: string): Promise<ReciboData | null> {
+  const [rows] = await pool.execute<EmitidoRow[]>(
+    'SELECT * FROM recibos_quinzena_emitidos WHERE hash = ? LIMIT 1', [hash]
+  );
+  if (!rows.length) return null;
+  const r = rows[0];
+  const snap = typeof r.snapshot_json === 'string' ? JSON.parse(r.snapshot_json) : r.snapshot_json;
+  return {
+    ...snap,
+    periodo: parsePeriodo(snap.periodo),
+  } as ReciboData;
+}
+
+// ── PDF ────────────────────────────────────────────────────────────────────
+export async function gerarReciboQuinzenalPdf(input: {
+  membro_id: string; periodo: string; baseUrl?: string;
+}): Promise<{ buffer: Buffer; hash: string; data: ReciboData }> {
+  const data = await coletarDadosRecibo(input.membro_id, input.periodo);
+  const { hash } = await persistirSnapshot(data);
+
+  const t = await getTenantSettings(1).catch(() => null);
+  const brand   = t?.brand_name || 'Romatec Consultoria Imobiliária';
+  const corHex  = t?.primary_color || '#10b981';
+
+  const doc = new PDFDocument({ size: 'A4', margin: 48, info: {
+    Title: `Recibo Quinzenal — ${data.membro.nome} — ${data.periodo.label}`,
+    Author: brand,
+    Subject: `Recibo de pagamento ${data.periodo.label}`,
+  }});
+  const chunks: Buffer[] = [];
+  doc.on('data', (c: Buffer) => chunks.push(c));
+
+  // Logo
+  const logoFile = path.join(__dirname, '..', 'public', LOGO_RELATORIO.replace(/^\//, ''));
+  if (fs.existsSync(logoFile)) {
+    try { doc.image(logoFile, { fit: [120, 60], align: 'center' }); }
+    catch { /* ignore */ }
+  } else {
+    doc.fontSize(16).fillColor(corHex).text(brand, { align: 'center' });
+  }
+  doc.moveDown(0.5);
+  doc.strokeColor(corHex).lineWidth(2).moveTo(48, doc.y).lineTo(547, doc.y).stroke();
+  doc.moveDown(0.6);
+
+  // Título
+  doc.fontSize(15).fillColor('#111').text('RECIBO DE PAGAMENTO QUINZENAL', { align: 'center', characterSpacing: 1 });
+  doc.fontSize(10).fillColor('#444').text(data.periodo.label, { align: 'center' });
+  doc.fontSize(9).fillColor('#666').text(
+    `Período: ${data.periodo.dataInicio.split('-').reverse().join('/')} a ${data.periodo.dataFim.split('-').reverse().join('/')}`,
+    { align: 'center' }
+  );
+  doc.moveDown(0.8);
+
+  // Identificação
+  doc.fontSize(11).fillColor(corHex).text('Identificação do Colaborador');
+  doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+  doc.fontSize(10).fillColor('#111');
+  doc.text(`Nome: ${data.membro.nome}`);
+  if (data.membro.cpf)    doc.text(`CPF: ${data.membro.cpf}`);
+  if (data.membro.cargo)  doc.text(`Cargo: ${data.membro.cargo}`);
+  if (data.membro.vinculo) doc.text(`Vínculo: ${data.membro.vinculo}`);
+  doc.text(`Valor diária: ${formatBRL(data.membro.valor_dia)}`);
+  doc.moveDown(0.5);
+
+  // Obras trabalhadas
+  if (data.obras.length) {
+    doc.fontSize(11).fillColor(corHex).text('Obras na Quinzena');
+    doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+    doc.fontSize(10).fillColor('#111');
+    for (const o of data.obras) doc.text(`• ${o.nome}`);
+    doc.moveDown(0.5);
+  }
+
+  // Tabela dia-a-dia
+  doc.fontSize(11).fillColor(corHex).text('Detalhamento Dia-a-Dia');
+  doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+
+  const colDia = { data: 48, tipo: 130, obra: 200, valor: 480 };
+  const headerY = doc.y;
+  doc.fontSize(9).fillColor('#444').font('Helvetica-Bold');
+  doc.text('Data',  colDia.data,  headerY, { width: 80 });
+  doc.text('Tipo',  colDia.tipo,  headerY, { width: 65 });
+  doc.text('Obra',  colDia.obra,  headerY, { width: 270 });
+  doc.text('Valor', colDia.valor, headerY, { width: 67, align: 'right' });
+  doc.font('Helvetica');
+  doc.moveDown(0.3);
+  doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor('#888').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+
+  let cursorY = doc.y;
+  doc.fontSize(9).fillColor('#111');
+  if (!data.dias.length) {
+    doc.text('Sem dias trabalhados na quinzena.', 48, cursorY, { width: 499, align: 'center' });
+    cursorY += 20;
+  } else {
+    for (const d of data.dias) {
+      const lineHeight = 14;
+      if (cursorY + lineHeight > 760) {
+        doc.addPage();
+        cursorY = doc.y;
+      }
+      const tipoLabel = d.tipo === 'integral' ? 'Integral' : d.tipo === 'manha' ? 'Manhã' : 'Tarde';
+      doc.text(d.data,                colDia.data,  cursorY, { width: 80 });
+      doc.text(tipoLabel,             colDia.tipo,  cursorY, { width: 65 });
+      doc.text(d.obra_nome ?? '-',    colDia.obra,  cursorY, { width: 270 });
+      doc.text(formatBRL(d.valor),    colDia.valor, cursorY, { width: 67, align: 'right' });
+      cursorY += lineHeight;
+    }
+  }
+  doc.moveTo(48, cursorY + 2).lineTo(547, cursorY + 2).strokeColor('#888').lineWidth(0.5).stroke();
+  cursorY += 8;
+  doc.fontSize(10).font('Helvetica-Bold').fillColor('#111')
+     .text(`Subtotal diárias (${data.totais.qtd_dias.toLocaleString('pt-BR', { maximumFractionDigits: 1 })} dia[s]): ${formatBRL(data.totais.valor_diarias)}`,
+            48, cursorY, { width: 499, align: 'right' });
+  doc.font('Helvetica');
+  cursorY += 20;
+  doc.x = 48; doc.y = cursorY;
+
+  // Ajustes
+  if (data.ajustes.length) {
+    doc.fontSize(11).fillColor(corHex).text('Ajustes');
+    doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.3);
+    doc.fontSize(9).fillColor('#111');
+    for (const a of data.ajustes) {
+      const sinal = (a.tipo === 'desconto' || a.tipo === 'adiantamento') ? '−' : '+';
+      const cor   = (a.tipo === 'desconto' || a.tipo === 'adiantamento') ? '#b91c1c' : '#15803d';
+      doc.fillColor('#444').text(`${tipoAjusteLabel(a.tipo)}${a.descricao ? ' — ' + a.descricao : ''}`, { continued: true, width: 400 });
+      doc.fillColor(cor).text(`  ${sinal} ${formatBRL(a.valor)}`, { align: 'right' });
+    }
+    doc.fillColor('#111');
+    doc.moveDown(0.3);
+    doc.fontSize(10).font('Helvetica-Bold')
+       .text(`Total ajustes: ${data.totais.total_ajustes >= 0 ? '+ ' : '− '}${formatBRL(Math.abs(data.totais.total_ajustes))}`, { align: 'right' });
+    doc.font('Helvetica');
+    doc.moveDown(0.5);
+  }
+
+  // Total líquido
+  doc.moveTo(48, doc.y).lineTo(547, doc.y).strokeColor(corHex).lineWidth(1).stroke();
+  doc.moveDown(0.4);
+  doc.fontSize(14).font('Helvetica-Bold').fillColor('#111')
+     .text(`TOTAL LÍQUIDO: ${formatBRL(data.totais.total_liquido)}`, 48, doc.y, { width: 499, align: 'right' });
+  doc.font('Helvetica');
+  doc.moveDown(0.6);
+
+  doc.fontSize(9).fillColor('#444').text('Forma de pagamento: PIX (chave informada após confirmação).');
+  doc.moveDown(1.5);
+
+  // Assinatura + QR
+  const sigY = doc.y > 680 ? (doc.addPage(), doc.y) : doc.y;
+  // Linha pra assinatura
+  doc.fontSize(9).fillColor('#111');
+  doc.moveTo(48, sigY + 30).lineTo(360, sigY + 30).strokeColor('#666').lineWidth(0.6).stroke();
+  doc.text(data.membro.nome, 48, sigY + 34, { width: 312 });
+  if (data.membro.cpf) doc.fillColor('#666').text(`CPF: ${data.membro.cpf}`, 48, sigY + 47);
+  doc.fillColor('#111');
+
+  // QR-code com link de validação
+  const baseUrl = (input.baseUrl || '').replace(/\/$/, '');
+  const validateUrl = `${baseUrl}/recibos/validar/${hash}`;
+  try {
+    const qrBuf = await QRCode.toBuffer(validateUrl, { width: 110, margin: 0 });
+    doc.image(qrBuf, 440, sigY, { fit: [105, 105] });
+    doc.fontSize(7).fillColor('#666')
+       .text('Validar autenticidade:', 405, sigY + 110, { width: 140, align: 'center' });
+    doc.fontSize(6.5).fillColor('#888')
+       .text(hash.slice(0, 16) + '...', 405, sigY + 121, { width: 140, align: 'center' });
+  } catch (err) {
+    console.warn('[recibo-pdf] gerar QR-code falhou:', (err as Error).message);
+  }
+
+  // Footer
+  doc.fontSize(8).fillColor('#888')
+     .text(`Recibo gerado por ZAYRA — ${brand}`, 48, 800, { width: 499, align: 'center' });
+  doc.fontSize(7).fillColor('#aaa')
+     .text(`Hash de validação (SHA-256): ${hash}`, 48, 812, { width: 499, align: 'center' });
+
+  doc.end();
+  await new Promise<void>(resolve => doc.on('end', () => resolve()));
+  return { buffer: Buffer.concat(chunks), hash, data };
+}
+
+function tipoAjusteLabel(t: TipoAjuste): string {
+  return t === 'desconto'      ? 'Desconto'
+       : t === 'adiantamento'  ? 'Adiantamento'
+       : t === 'bonus'         ? 'Bônus'
+       :                         'Horas extras';
+}
+
+// ── Página HTML pública de validação (mostra dados do snapshot) ─────────────
+export async function gerarHtmlValidacao(hash: string): Promise<string> {
+  const data = await buscarReciboPorHash(hash);
+  if (!data) {
+    return `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Recibo não encontrado</title></head>
+<body style="font-family:sans-serif; text-align:center; padding:40px; color:#b91c1c;">
+<h1>⚠️ Recibo não encontrado</h1>
+<p>O hash informado não corresponde a nenhum recibo emitido.</p>
+</body></html>`;
+  }
+
+  const t = await getTenantSettings(1).catch(() => null);
+  const brand = t?.brand_name || 'Romatec Consultoria Imobiliária';
+  const cor   = t?.primary_color || '#10b981';
+
+  const diasRows = data.dias.map(d => `
+    <tr>
+      <td>${d.data}</td>
+      <td>${d.tipo === 'integral' ? 'Integral' : d.tipo === 'manha' ? 'Manhã' : 'Tarde'}</td>
+      <td>${d.obra_nome ?? '-'}</td>
+      <td style="text-align:right;">${formatBRL(d.valor)}</td>
+    </tr>
+  `).join('');
+
+  const ajustesRows = data.ajustes.map(a => {
+    const sinal = (a.tipo === 'desconto' || a.tipo === 'adiantamento') ? '−' : '+';
+    const cor   = (a.tipo === 'desconto' || a.tipo === 'adiantamento') ? '#b91c1c' : '#15803d';
+    return `<tr>
+      <td>${tipoAjusteLabel(a.tipo)}${a.descricao ? ' — ' + a.descricao : ''}</td>
+      <td style="text-align:right; color:${cor};">${sinal} ${formatBRL(a.valor)}</td>
+    </tr>`;
+  }).join('');
+
+  return `<!DOCTYPE html><html lang="pt-BR"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Validação — ${data.membro.nome} — ${data.periodo.label}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width:760px; margin:0 auto; padding:24px; color:#111; line-height:1.5; }
+  .header { text-align:center; border-bottom:3px solid ${cor}; padding-bottom:14px; margin-bottom:18px; }
+  .badge-ok { display:inline-block; background:#dcfce7; color:#15803d; padding:6px 14px; border-radius:20px; font-weight:600; font-size:13px; }
+  h1 { font-size:18px; margin:14px 0 8px; }
+  h2 { font-size:14px; color:${cor}; border-bottom:1px solid #ddd; padding-bottom:4px; margin-top:18px; }
+  table { width:100%; border-collapse:collapse; margin-top:8px; font-size:13px; }
+  th, td { padding:6px 8px; border-bottom:1px solid #e5e5e5; }
+  th { background:#f3f4f6; text-align:left; font-size:12px; }
+  .total-box { margin-top:14px; padding:12px 16px; background:#f9fafb; border-left:4px solid ${cor};
+               display:flex; justify-content:space-between; font-weight:600; font-size:15px; }
+  .hash { font-family:monospace; font-size:10px; color:#888; word-break:break-all; }
+</style>
+</head><body>
+  <div class="header">
+    <p class="badge-ok">✓ Recibo autêntico</p>
+    <h1>${brand}</h1>
+    <p style="margin:4px 0; color:#666;">Validação de Recibo Quinzenal</p>
+  </div>
+
+  <h2>Colaborador</h2>
+  <p><strong>${data.membro.nome}</strong>${data.membro.cpf ? ' · CPF ' + data.membro.cpf : ''}<br>
+  ${data.membro.cargo ?? ''}${data.membro.vinculo ? ' · ' + data.membro.vinculo : ''}</p>
+
+  <h2>Período</h2>
+  <p>${data.periodo.label}<br>
+  ${data.periodo.dataInicio.split('-').reverse().join('/')} a ${data.periodo.dataFim.split('-').reverse().join('/')}</p>
+
+  ${data.obras.length ? `<h2>Obras</h2><ul>${data.obras.map(o => `<li>${o.nome}</li>`).join('')}</ul>` : ''}
+
+  <h2>Detalhamento Dia-a-Dia</h2>
+  <table>
+    <thead><tr><th>Data</th><th>Tipo</th><th>Obra</th><th style="text-align:right;">Valor</th></tr></thead>
+    <tbody>${diasRows || '<tr><td colspan="4" style="text-align:center; color:#999;">Sem dias.</td></tr>'}</tbody>
+  </table>
+  <p style="text-align:right; margin-top:8px;"><strong>Subtotal diárias (${data.totais.qtd_dias} dia[s]):</strong> ${formatBRL(data.totais.valor_diarias)}</p>
+
+  ${data.ajustes.length ? `
+    <h2>Ajustes</h2>
+    <table><tbody>${ajustesRows}</tbody></table>
+    <p style="text-align:right; margin-top:8px;"><strong>Total ajustes:</strong> ${data.totais.total_ajustes >= 0 ? '+' : '−'} ${formatBRL(Math.abs(data.totais.total_ajustes))}</p>
+  ` : ''}
+
+  <div class="total-box">
+    <span>TOTAL LÍQUIDO</span>
+    <span>${formatBRL(data.totais.total_liquido)}</span>
+  </div>
+
+  <h2>Autenticidade</h2>
+  <p style="font-size:12px; color:#666;">Este recibo foi gerado pela ZAYRA e o hash abaixo corresponde a um snapshot imutável armazenado no banco da Romatec.</p>
+  <p class="hash">${hash}</p>
+
+  <hr style="margin-top:30px; border:none; border-top:1px solid #ddd;">
+  <p style="text-align:center; font-size:11px; color:#888;">${brand} — gerado por ZAYRA</p>
+</body></html>`;
+}


### PR DESCRIPTION
## Resumo
Primeira sub-PR do fluxo de recibos quinzenais via ZAYRA (briefing CEO). Cria a infra de **geração e gerenciamento** dos recibos. Sem envio Z-API ainda — PR B.2 plugará isso em fluxo de envio em massa.

Independente, baixo risco. Você pode mergear, validar visualmente o PDF gerado, ajustar layout/campos antes de eu começar B.2.

## Migrations idempotentes
- `recibos_ajustes` — descontos / adiantamentos / bônus / horas extras por colaborador/período (`YYYY-MM-1` ou `YYYY-MM-2`).
- `recibos_quinzena_emitidos` — snapshot imutável com hash SHA-256 único. Re-emissão cria registro novo com novo hash, preservando recibos antigos válidos.

## Service `src/services/recibosQuinzena.ts`
- `parsePeriodo` / `calcularPeriodoAtual` (formato `YYYY-MM-{1|2}`)
- CRUD de ajustes
- `coletarDadosRecibo`: junta `romatec_obra_funcionario_dias` + equipe + obras + ajustes; calcula totais (qtd_dias com integral=1.0/meia=0.5, valor_diarias, descontos/adiantamentos/bonus/horas_extras com sinal correto, total_liquido).
- `gerarReciboQuinzenalPdf`: PDFKit A4 com 9 seções:
  1. Header logo + título
  2. Identificação completa (nome, CPF, cargo, vínculo, valor diária)
  3. Obras trabalhadas
  4. **Tabela dia-a-dia** (data, tipo Integral/Manhã/Tarde, obra, valor) + subtotal
  5. **Ajustes** detalhados (cor verde/vermelha por tipo) + total
  6. **TOTAL LÍQUIDO** em destaque
  7. Linha pra assinatura física + nome/CPF
  8. **QR-code (110px)** com link de validação + hash truncado
  9. Footer com hash SHA-256 completo
- `persistirSnapshot`: hash estável (sem timestamp), idempotente.
- `buscarReciboPorHash` + `gerarHtmlValidacao`: página pública com badge `✓ Recibo autêntico`.

## Endpoints REST
- `GET    /api/recibos/ajustes?membro_id=X&periodo=Y`
- `POST   /api/recibos/ajustes` (CEO_TOKEN)
- `DELETE /api/recibos/ajustes/:id` (CEO_TOKEN)
- `GET    /api/recibos/quinzena/:membro_id/pdf?periodo=YYYY-MM-1`
- `GET    /recibos/validar/:hash` (página pública)

## UI (aba Marcar Dias)
- Botão `💰 Recibo` ao lado de `📅 Marcar dias` em cada card.
- Modal: select de período (6 últimos), lista de ajustes (com remover), form pra adicionar (tipo + valor + descrição), botão `📄 Gerar PDF`.

## Dependências
- `+ qrcode ^1.5.x`
- `+ @types/qrcode`

## Test plan
- [ ] Após merge + deploy: aba Marcar Dias → clicar 💰 Recibo num colaborador
- [ ] Selecionar período `2026-05-1` (ou anterior se já tiver dias marcados)
- [ ] Adicionar 2 ajustes (1 desconto, 1 bônus) — validar lista
- [ ] Clicar `📄 Gerar PDF` → abre preview com header, identificação, tabela dia-a-dia, ajustes coloridos, total líquido, QR-code
- [ ] Escanear QR-code com celular → abre página de validação web mostrando os mesmos dados
- [ ] Re-gerar mesmo recibo → hash idêntico (idempotente) → não duplica em recibos_quinzena_emitidos
- [ ] Adicionar/remover ajuste e re-gerar → novo hash, snapshot anterior continua acessível

## Próximo (PR B.2)
Lote `recibos_envios_lotes` + tool ZAYRA `disparar_recibos_quinzena` + envio Z-API + state inicial `enviado_aguardando_confirmacao`. Aguardando merge + validação visual desta PR antes.

Generated with Claude Code