### PR TITLE
v1.65.16 (PR B.4): Recibo Quinzenal — comandos CEO + expiração automática

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.15",
+  "version": "1.65.16",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.15',
+  version: '1.65.16',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1454,6 +1454,44 @@ const _allToolDefinitions: Anthropic.Tool[] = [
       },
     },
   },
+  // ── PR B.4 — Comandos de gerenciamento do lote ──
+  {
+    name: 'marcar_recibo_pago',
+    description: 'Marca recibos como pagos (status pix_recebido → pago). Use envio_id pra um único colaborador, lote_id pra todos os PIX recebidos de um lote, ou todos_pix_recebidos:true pra marcar TODOS sem filtro (cuidado, requer ordem explícita do Chefe). Não pode marcar como pago quem ainda não enviou PIX.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        envio_id: { type: 'string', description: 'ID do envio individual (mais seguro)' },
+        lote_id:  { type: 'string', description: 'ID do lote — marca todos pix_recebido daquele lote' },
+        todos_pix_recebidos: { type: 'boolean', description: 'true marca TODOS os pix_recebidos de qualquer lote — cuidado' },
+        pago_por: { type: 'string', description: 'Quem marcou (ex: "CEO Romário via WhatsApp"). Default null.' },
+      },
+    },
+  },
+  {
+    name: 'reenviar_recibos_lote',
+    description: 'Reenvia recibos pendentes ou expirados — gera novo PDF + texto e dispara via Z-API. SEMPRE chamar primeiro sem confirm:true para gerar PREVIEW (lista quem será reenviado). Após Chefe confirmar verbalmente, chamar com confirm:true. Por padrão pega envios com status enviado_aguardando_confirmacao parados há mais de 24h. Pode filtrar por lote_id, status_alvo específico (enviado_aguardando_confirmacao, confirmado_aguardando_pix, falha_envio, expirado) ou horas_minimas customizadas.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        lote_id: { type: 'string' },
+        status_alvo: { type: 'string', enum: ['enviado_aguardando_confirmacao','confirmado_aguardando_pix','falha_envio','expirado'] },
+        horas_minimas: { type: 'number', description: 'Mínimo de horas desde o envio. Default 24h.' },
+        confirm: { type: 'boolean' },
+      },
+    },
+  },
+  {
+    name: 'expirar_recibos_antigos',
+    description: 'Marca como expirados os recibos enviados há mais de N horas (default 48) sem confirmação do colaborador. Útil pra limpar o painel antes de decidir reenviar/contato direto. Notifica o Chefe via WhatsApp com a lista, a menos de notificar_ceo:false.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        horas: { type: 'number', description: 'Default 48' },
+        notificar_ceo: { type: 'boolean', description: 'Default true — manda WhatsApp pro CEO com a lista' },
+      },
+    },
+  },
   {
     name: 'criar_membro_equipe',
     description: 'Adiciona membro à equipe de obras. Confirm exigido.',
@@ -2888,6 +2926,21 @@ export async function executeTool(name: string, input: Record<string, unknown>):
       case 'status_lote_recibos':
         data = await recibos.statusLote(
           input as Parameters<typeof recibos.statusLote>[0]
+        );
+        break;
+      case 'marcar_recibo_pago':
+        data = await recibos.marcarReciboPago(
+          input as Parameters<typeof recibos.marcarReciboPago>[0]
+        );
+        break;
+      case 'reenviar_recibos_lote':
+        data = await recibos.reenviarRecibos(
+          input as Parameters<typeof recibos.reenviarRecibos>[0]
+        );
+        break;
+      case 'expirar_recibos_antigos':
+        data = await recibos.expirarRecibosAntigos(
+          input as Parameters<typeof recibos.expirarRecibosAntigos>[0]
         );
         break;
       case 'criar_membro_equipe':

--- a/src/server.ts
+++ b/src/server.ts
@@ -737,6 +737,26 @@ app.get('/api/recibos/lote-do-periodo/:periodo', requireCeoToken, apiHandle(asyn
   return m.statusLote({ periodo: (args as { periodo: string }).periodo });
 }));
 
+// v1.65.16 — PR B.4: comandos de gerenciamento (marcar pago / reenviar / expirar)
+app.post('/api/recibos/marcar-pago', requireCeoToken, apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.marcarReciboPago(args as Parameters<typeof m.marcarReciboPago>[0]);
+}));
+app.post('/api/recibos/reenviar', requireCeoToken, async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/recibosQuinzena');
+    const proto = (req.get('x-forwarded-proto') as string | undefined)?.split(',')[0]?.trim() || 'https';
+    const baseUrl = `${proto}://${req.get('host')}`.replace(/\/$/, '');
+    res.json(await m.reenviarRecibos({ ...req.body, baseUrl }));
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+app.post('/api/recibos/expirar', requireCeoToken, apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.expirarRecibosAntigos(args as Parameters<typeof m.expirarRecibosAntigos>[0]);
+}));
+
 // Página pública acessada via QR-code (validação)
 app.get('/recibos/validar/:hash', async (req: Request, res: Response) => {
   try {
@@ -908,6 +928,8 @@ app.listen(PORT, () => {
     .then(() => loadSessionFromDb())
     .then(() => import('./services/whatsappDrafts'))
     .then(m => m.startDraftCleanup())
+    .then(() => import('./services/recibosQuinzena'))
+    .then(m => m.startExpiracaoRecibosTicker()) // v1.65.16: expira recibos sem resposta há mais de 48h (ticker a cada 6h)
     .catch(err => console.warn('[Memory] Init failed (continuing without DB):', err));
 
   // v1.39.1: sync contatos CRM → memória ZAYRA (1x ao boot + 1x/dia 04:00 BRT)

--- a/src/services/recibosQuinzena.ts
+++ b/src/services/recibosQuinzena.ts
@@ -1556,3 +1556,282 @@ export async function processarRespostaRecibo(input: {
   // Status inesperado — não toca, deixa fluxo normal seguir
   return { handled: false };
 }
+
+// ╔═════════════════════════════════════════════════════════════════════════╗
+// ║ PR B.4 — COMANDOS DO CEO (gerenciar lote em curso)                       ║
+// ║   - marcar_recibo_pago: status pix_recebido → pago                       ║
+// ║   - reenviar_recibos_lote: refaz disparo dos pendentes / expirados       ║
+// ║   - expirar_recibos_antigos: status → expirado se mais de N horas sem    ║
+// ║     resposta (também roda em ticker automático a cada 6h)                ║
+// ╚═════════════════════════════════════════════════════════════════════════╝
+
+interface MarcarPagoInput {
+  envio_id?: string;          // marca apenas 1
+  lote_id?: string;           // todos pix_recebidos do lote
+  todos_pix_recebidos?: boolean; // todos pix_recebidos sem filtro de lote (cuidado!)
+  pago_por?: string;          // ex: 'CEO Romário via WhatsApp'
+}
+export async function marcarReciboPago(input: MarcarPagoInput): Promise<{
+  ok: true; total: number; envios: Array<{ id: string; nome: string; valor: number }>; message: string;
+}> {
+  let where = '';
+  const params: (string | number)[] = [];
+
+  if (input.envio_id) {
+    where = 'id = ?';
+    params.push(Number(input.envio_id));
+  } else if (input.lote_id) {
+    where = "lote_id = ? AND status = 'pix_recebido'";
+    params.push(Number(input.lote_id));
+  } else if (input.todos_pix_recebidos) {
+    where = "status = 'pix_recebido'";
+  } else {
+    throw new Error('informe envio_id, lote_id ou todos_pix_recebidos:true');
+  }
+
+  // Lista os envios afetados antes do UPDATE pra retornar nomes
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT v.id, v.valor, e.nome
+       FROM recibos_envios v
+       LEFT JOIN romatec_obra_equipe e ON e.id = v.membro_id
+      WHERE ${where}
+        AND v.status IN ('pix_recebido', 'pago')`,
+    params
+  );
+  if (!rows.length) {
+    return { ok: true, total: 0, envios: [], message: 'Nenhum envio elegível encontrado (precisa estar em pix_recebido ou pago).' };
+  }
+
+  await pool.execute(
+    `UPDATE recibos_envios
+        SET status = 'pago',
+            pago_em = COALESCE(pago_em, NOW())
+      WHERE ${where}
+        AND status = 'pix_recebido'`,
+    params
+  );
+
+  const envios = rows.map(r => ({
+    id: String(r.id), nome: String(r.nome ?? '(removido)'), valor: Number(r.valor),
+  }));
+
+  // Auditoria: registra "pago" como mensagem do tipo aviso
+  for (const e of envios) {
+    await logarMensagemEnvio(Number(e.id), 'saida', 'aviso',
+      `Marcado como pago${input.pago_por ? ' por ' + input.pago_por : ''}`, null);
+  }
+
+  return {
+    ok: true,
+    total: envios.length,
+    envios,
+    message: `${envios.length} envio(s) marcado(s) como pago.`,
+  };
+}
+
+// Re-dispara recibos pendentes (sem confirmação) ou expirados.
+// Por padrão pega os com status enviado_aguardando_confirmacao há mais de 24h.
+// CEO pode forçar status_alvo específico ou horas mínimas customizadas.
+interface ReenviarInput {
+  lote_id?: string;
+  status_alvo?: 'enviado_aguardando_confirmacao' | 'confirmado_aguardando_pix' | 'falha_envio' | 'expirado';
+  horas_minimas?: number;
+  baseUrl?: string;
+  confirm?: boolean;          // sem confirm → preview
+}
+export async function reenviarRecibos(input: ReenviarInput): Promise<{
+  modo: 'preview' | 'reenviado';
+  candidatos?: Array<{ id: string; nome: string; status: string; tentativas: number; horas_desde_envio: number }>;
+  total?: number; sucesso?: number; falhas?: number;
+  message: string;
+}> {
+  const status = input.status_alvo || 'enviado_aguardando_confirmacao';
+  const horas = Number(input.horas_minimas ?? (status === 'enviado_aguardando_confirmacao' ? 24 : 0));
+
+  let where = `v.status = ?`;
+  const params: (string | number)[] = [status];
+  if (input.lote_id) {
+    where += ` AND v.lote_id = ?`;
+    params.push(Number(input.lote_id));
+  }
+  if (horas > 0) {
+    where += ` AND v.enviado_em IS NOT NULL AND v.enviado_em < (NOW() - INTERVAL ? HOUR)`;
+    params.push(horas);
+  }
+
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT v.id, v.lote_id, v.membro_id, v.telefone, v.valor, v.status,
+            v.tentativas_envio, v.enviado_em, e.nome,
+            TIMESTAMPDIFF(HOUR, v.enviado_em, NOW()) AS horas_desde_envio
+       FROM recibos_envios v
+       LEFT JOIN romatec_obra_equipe e ON e.id = v.membro_id
+      WHERE ${where}
+      ORDER BY v.enviado_em ASC`,
+    params
+  );
+
+  const candidatos = rows.map(r => ({
+    id: String(r.id),
+    nome: String(r.nome ?? '(removido)'),
+    status: String(r.status),
+    tentativas: Number(r.tentativas_envio ?? 0),
+    horas_desde_envio: Number(r.horas_desde_envio ?? 0),
+  }));
+
+  if (!input.confirm) {
+    return {
+      modo: 'preview',
+      candidatos,
+      message: candidatos.length === 0
+        ? `Nenhum envio elegível para reenvio (status=${status}${horas ? `, parado há mais de ${horas}h` : ''}).`
+        : `[PREVIEW REENVIO] ${candidatos.length} envio(s) candidato(s):\n` +
+          candidatos.slice(0, 30).map(c => `• ${c.nome} — status ${c.status} há ${c.horas_desde_envio}h (${c.tentativas} tentativa[s])`).join('\n') +
+          `\n\nReenvie com confirm:true pra disparar de novo.`,
+    };
+  }
+
+  // Re-dispara: gera PDF + manda novamente. Reusa lógica de dispararLote
+  // mas iterando manualmente porque dispararLote pega só status='pendente_envio'.
+  let sucesso = 0, falhas = 0;
+  for (const c of candidatos) {
+    try {
+      const [vRows] = await pool.execute<EnvioRow[]>(
+        `SELECT * FROM recibos_envios WHERE id = ?`, [Number(c.id)]
+      );
+      const v = vRows[0];
+      if (!v?.telefone) { falhas++; continue; }
+
+      const [loteRows] = await pool.execute<LoteRow[]>(
+        `SELECT * FROM recibos_envios_lotes WHERE id = ?`, [v.lote_id]
+      );
+      const lote = loteRows[0];
+      const periodo = parsePeriodo(lote.periodo);
+
+      const pdf = await gerarReciboQuinzenalPdf({
+        membro_id: String(v.membro_id), periodo: periodo.codigo, baseUrl: input.baseUrl,
+      });
+
+      const [mRows2] = await pool.execute<RowDataPacket[]>(
+        `SELECT e.nome, c.tratamento, c.tom
+           FROM romatec_obra_equipe e
+           LEFT JOIN contacts c ON c.id = e.contact_id
+          WHERE e.id = ?`, [v.membro_id]
+      );
+      const m = mRows2[0] || { nome: 'Colaborador', tratamento: null, tom: null };
+
+      const fileName = `Recibo_${String(m.nome).replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30)}_${periodo.codigo}.pdf`;
+      const docRes = await sendDocument(v.telefone, pdf.buffer.toString('base64'), fileName);
+      const txt = montarMensagemEnvio({
+        nome: String(m.nome),
+        tratamento: m.tratamento as string | null,
+        tom: m.tom as string | null,
+        periodo,
+        valor: Number(v.valor),
+      }) + `\n\n_(reenvio — caso já tenha respondido, ignore)_`;
+      const txtRes = await sendReply(v.telefone, txt);
+
+      await pool.execute(
+        `UPDATE recibos_envios
+            SET status = 'enviado_aguardando_confirmacao',
+                enviado_em = NOW(),
+                tentativas_envio = tentativas_envio + 1,
+                recibo_hash = ?,
+                ultimo_erro = NULL
+          WHERE id = ?`,
+        [pdf.hash, v.id]
+      );
+      await logarMensagemEnvio(v.id, 'saida', 'pdf_recibo', `[REENVIO] ${fileName}`, docRes.messageId ?? null);
+      await logarMensagemEnvio(v.id, 'saida', 'solicitacao_confirmacao', txt, txtRes.messageId ?? null);
+      sucesso++;
+    } catch (err) {
+      falhas++;
+      console.warn(`[recibos] reenvio falhou pro envio ${c.id}:`, (err as Error).message);
+    }
+  }
+
+  return {
+    modo: 'reenviado',
+    candidatos,
+    total: candidatos.length,
+    sucesso, falhas,
+    message: `Reenvio concluído: ${sucesso} sucesso(s), ${falhas} falha(s) de ${candidatos.length} candidato(s).`,
+  };
+}
+
+// Marca como expirado quem está em enviado_aguardando_confirmacao há mais
+// de N horas (default 48) e notifica o CEO. Roda manualmente ou via ticker.
+export async function expirarRecibosAntigos(input: { horas?: number; notificar_ceo?: boolean } = {}): Promise<{
+  ok: true; total_expirados: number;
+  expirados: Array<{ id: string; nome: string; valor: number; horas: number; lote_numero: string }>;
+}> {
+  const horas = Number(input.horas ?? 48);
+
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT v.id, v.valor, v.lote_id,
+            TIMESTAMPDIFF(HOUR, v.enviado_em, NOW()) AS horas,
+            e.nome, l.numero AS lote_numero
+       FROM recibos_envios v
+       LEFT JOIN romatec_obra_equipe e ON e.id = v.membro_id
+       LEFT JOIN recibos_envios_lotes l ON l.id = v.lote_id
+      WHERE v.status = 'enviado_aguardando_confirmacao'
+        AND v.enviado_em IS NOT NULL
+        AND v.enviado_em < (NOW() - INTERVAL ? HOUR)
+      ORDER BY v.enviado_em ASC`,
+    [horas]
+  );
+  if (!rows.length) return { ok: true, total_expirados: 0, expirados: [] };
+
+  const expirados = rows.map(r => ({
+    id: String(r.id),
+    nome: String(r.nome ?? '(removido)'),
+    valor: Number(r.valor),
+    horas: Number(r.horas),
+    lote_numero: String(r.lote_numero ?? '?'),
+  }));
+
+  await pool.execute(
+    `UPDATE recibos_envios
+        SET status = 'expirado'
+      WHERE status = 'enviado_aguardando_confirmacao'
+        AND enviado_em IS NOT NULL
+        AND enviado_em < (NOW() - INTERVAL ? HOUR)`,
+    [horas]
+  );
+
+  for (const e of expirados) {
+    await logarMensagemEnvio(Number(e.id), 'saida', 'aviso',
+      `Expirado automaticamente após ${e.horas}h sem confirmação`, null);
+  }
+
+  if (input.notificar_ceo !== false) {
+    await notificarCeo(
+      `⏰ ${expirados.length} recibo(s) expirado(s) sem resposta após ${horas}h:\n\n` +
+      expirados.slice(0, 30).map(e =>
+        `• ${e.nome} — ${formatBRL(e.valor)} (lote ${e.lote_numero}, ${e.horas}h sem resposta)`
+      ).join('\n') +
+      `\n\nQuer que eu reenvie? Diga "ZAYRA, reenvia os recibos expirados".`
+    );
+  }
+
+  return { ok: true, total_expirados: expirados.length, expirados };
+}
+
+// Ticker automático: roda a cada 6h e expira recibos com mais de 48h.
+// Iniciado em src/server.ts no boot. Silencioso em DEV (sem CEO_WHATSAPP_PHONE).
+let _expiracaoTickerStarted = false;
+export function startExpiracaoRecibosTicker(): void {
+  if (_expiracaoTickerStarted) return;
+  _expiracaoTickerStarted = true;
+  const HOURS = 6;
+  const ms = HOURS * 60 * 60 * 1000;
+  console.log(`[recibos] ticker de expiração iniciado (a cada ${HOURS}h, limite 48h sem resposta)`);
+  setInterval(() => {
+    expirarRecibosAntigos({ horas: 48 })
+      .then(r => {
+        if (r.total_expirados > 0) {
+          console.log(`[recibos] ${r.total_expirados} envio(s) expirado(s) automaticamente`);
+        }
+      })
+      .catch(err => console.warn('[recibos] ticker expiração falhou:', (err as Error).message));
+  }, ms);
+}


### PR DESCRIPTION
## Resumo
Quarta e última sub-PR do fluxo de recibos. Adiciona ferramentas pra **CEO gerenciar lote em curso** (após disparo B.2 + respostas B.3) + **expiração automática** de envios sem resposta há mais de 48h.

## Service

### `marcarReciboPago({ envio_id? | lote_id? | todos_pix_recebidos?, pago_por? })`
Status `pix_recebido` → `pago`. 3 modos:
- `envio_id`: marca apenas 1
- `lote_id`: marca todos `pix_recebido` daquele lote
- `todos_pix_recebidos`: marca TODOS sem filtro (requer ordem explícita)

### `reenviarRecibos({ lote_id?, status_alvo?, horas_minimas?, confirm? })`
Sem `confirm` → preview com candidatos (nome, status, horas desde envio, tentativas). Com `confirm` → re-gera PDF + manda novamente. Default: `enviado_aguardando_confirmacao` parado há mais de 24h. Mensagem ganha sufixo `(reenvio — caso já tenha respondido, ignore)`.

### `expirarRecibosAntigos({ horas?, notificar_ceo? })`
Marca como `expirado` os `enviado_aguardando_confirmacao` com mais de N horas (default 48). Notifica CEO via WhatsApp.

### `startExpiracaoRecibosTicker()`
setInterval que roda a cada 6h chamando `expirarRecibosAntigos(48)`. Iniciado no boot, depois do `initDb()`.

## Tools ZAYRA (3 novas)
- `marcar_recibo_pago`
- `reenviar_recibos_lote`
- `expirar_recibos_antigos`

## Endpoints REST (CEO_TOKEN)
- `POST /api/recibos/marcar-pago`
- `POST /api/recibos/reenviar`
- `POST /api/recibos/expirar`

## Test plan
- [ ] Após merge + deploy: validar log `[recibos] ticker de expiração iniciado (a cada 6h, limite 48h)`
- [ ] Conversar com ZAYRA: *"ZAYRA, marca o pagamento do João como pago"* → ela chama `marcar_recibo_pago` (envio_id ou lote_id)
- [ ] *"ZAYRA, reenvia os recibos pendentes"* → preview, depois confirma e dispara
- [ ] *"ZAYRA, expira os recibos antigos"* → ela chama `expirar_recibos_antigos` e você recebe WhatsApp com a lista
- [ ] Validar que após 48h, recibos viram `expirado` automaticamente sem ação manual

## Fluxo completo do Recibos via ZAYRA está fechado
- B.1 ✅ — gerador PDF + ajustes + QR
- B.2 ✅ — disparo via Z-API (preview → confirm → envio)
- B.3 ✅ — webhook de respostas (1/2/PIX/ambíguo)
- B.4 ✅ — comandos de gerenciamento + expiração 48h

Generated with Claude Code