### PR TITLE
v1.65.17: conflito de datas — exceção pra cargos de gestão

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.16",
+  "version": "1.65.17",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.16',
+  version: '1.65.17',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/services/recibosQuinzena.ts
+++ b/src/services/recibosQuinzena.ts
@@ -673,6 +673,22 @@ function chaveDuplicacao(nome: string, telefone: string | null | undefined): str
   return `${nomeCanon}|${telKey}`;
 }
 
+// v1.65.17: cargos de gestão podem legitimamente estar marcados integral em
+// múltiplas obras no mesmo dia (cada obra paga sua diária pelo serviço de
+// gestão — o profissional supervisiona/visita as duas, divide o tempo, mas
+// cada uma reconhece o dia integral). Para esses, "conflito" não bloqueia.
+// Operacionais (pedreiro/servente/etc) NÃO podem — fisicamente impossível —
+// e o conflito continua sendo bloqueio.
+const CARGOS_GESTAO_PADRAO = [
+  'engenheir', 'arquitet', 'mestre', 'técnico', 'tecnico',
+  'encarregado', 'coordenador', 'supervisor', 'gestor', 'fiscal',
+];
+function isCargoGestao(funcao: string | null): boolean {
+  if (!funcao) return false;
+  const f = funcao.toLowerCase();
+  return CARGOS_GESTAO_PADRAO.some(c => f.includes(c));
+}
+
 function gerarNumeroLote(periodo: Periodo): string {
   return `QUINZ-${periodo.ano}-${String(periodo.mes).padStart(2, '0')}-${periodo.quinzena}`;
 }
@@ -796,7 +812,14 @@ export async function previewLoteQuinzena(input: { periodo?: string } = {}): Pro
 
     // 3ª passada: detecta CONFLITO real — mesmo colaborador (vários
     // cadastros) marcou o mesmo dia + periodo em obras diferentes.
-    // Isso é operacionalmente impossível (alguém marcou errado).
+    // Para OPERACIONAIS é impossível e bloqueia. Para cargos de GESTÃO
+    // (Mestre/Eng./Téc./Encarregado) é prática legítima — cada obra paga
+    // sua diária pelo serviço de supervisão; pulamos a detecção.
+    const todosGestao = group.every(g => isCargoGestao(g.funcao));
+    if (todosGestao) {
+      // só log, não cria conflito_datas no item, não bloqueia disparo
+      continue;
+    }
     const memberIds = ids.map(Number);
     const [diasRows] = await pool.execute<RowDataPacket[]>(
       `SELECT d.funcionario_id, d.data, d.periodo, d.obra_id, o.nome AS obra_nome


### PR DESCRIPTION
## Caso real
Leonardo (Mestre de Obra, 2 cadastros: GBOX + Posto Chapadão) marcado integral nos dias 27/28/29/30/04 nas duas obras simultaneamente. Sistema bloqueou disparo do lote QUINZ-2026-04-2.

CEO esclareceu: cargos de gestão (Mestre/Eng./Arquiteto/Téc./Encarregado/Coordenador/Supervisor/Gestor/Fiscal) podem **legitimamente** estar marcados integral em múltiplas obras no mesmo dia. Cada obra paga sua diária pelo serviço de supervisão; o profissional divide o tempo mas as duas reconhecem o dia integral.

## Fix
- Reintroduz `isCargoGestao()` (lista padrão de 9 termos).
- Detector de conflitos: antes de cruzar registros, verifica se TODOS os cadastros do grupo são gestão. Se sim → pula a detecção (não bloqueia). Se algum é operacional → mantém bloqueio.

## Comportamento
| Caso | Antes (1.65.16) | Agora (1.65.17) |
|---|---|---|
| Mestre Leonardo, 2 obras, mesmo dia integral | 🔴 BLOQUEAVA | ✅ Permite — cada cadastro envia seu PDF |
| Pedreiro X, 2 obras, mesmo dia integral | 🔴 Bloqueava | 🔴 Continua bloqueando (erro físico) |
| Misto: 1 mestre + 1 pedreiro com mesmo nome+tel | 🔴 Bloqueava | 🔴 Continua bloqueando (não-gestão presente) |

## Test plan
- [ ] Após merge + deploy, retomar comando *"ZAYRA, dispara recibos da quinzena 16-30/04"*
- [ ] Leonardo (Mestre × 2 cadastros) deve passar como `👥 multi-cadastro` sem bloqueio
- [ ] Disparo prossegue normalmente, ele recebe 2 PDFs (1 por obra) com dia-a-dia consistente em cada
- [ ] Se algum operacional realmente tiver conflito, continua bloqueando (regressão protegida)

Generated with Claude Code