### PR TITLE
v1.65.20: modal Recibo Quinzenal — LEDs de status + envio manual individual

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "1.65.19",
+  "version": "1.65.20",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '1.65.19',
+  version: '1.65.20',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -2664,6 +2664,17 @@ async function abrirModalReciboQuinzena(membroId, nome) {
       </label>
       <button id="rqVerPdf" title="Visualizar PDF preview">📄 Gerar PDF</button>
     </div>
+
+    <!-- v1.65.20: LEDs de status do envio + ações manuais -->
+    <div id="rqStatusBox" style="border:1px solid var(--border-strong); border-radius:8px; padding:10px; margin-bottom:10px; background:var(--surface-1);">
+      <p style="margin:0 0 6px; font-size:12px; color:var(--text-muted);">Status do envio (WhatsApp)</p>
+      <div id="rqStatusLeds" style="display:flex; gap:8px; flex-wrap:wrap; align-items:center; font-size:12px;">
+        <span style="color:var(--text-muted);">Carregando…</span>
+      </div>
+      <div id="rqStatusInfo" style="margin-top:6px; font-size:11px; color:var(--text-muted);"></div>
+      <div id="rqStatusAcoes" style="display:flex; gap:6px; flex-wrap:wrap; margin-top:8px;"></div>
+    </div>
+
     <p class="section-title" style="margin:8px 0 4px; font-size:13px;">Ajustes deste período</p>
     <div id="rqAjustesLista" style="font-size:12px;">
       <p style="color:var(--text-muted); text-align:center; padding:12px;">Carregando…</p>
@@ -2723,7 +2734,158 @@ async function abrirModalReciboQuinzena(membroId, nome) {
     }
   };
 
-  document.getElementById('rqPeriodo').onchange = recarregarAjustes;
+  // v1.65.20: status box com LEDs + ações manuais
+  const ESTADOS = [
+    { st: 'enviado_aguardando_confirmacao', label: 'Enviado',     dot: '🟡' },
+    { st: 'confirmado_aguardando_pix',      label: 'Confirmou',   dot: '🟢' },
+    { st: 'pix_recebido',                   label: 'PIX recebido', dot: '🔵' },
+    { st: 'pago',                           label: 'PAGO',        dot: '✅' },
+  ];
+  const recarregarStatus = async () => {
+    const periodo = document.getElementById('rqPeriodo').value;
+    const ledsEl   = document.getElementById('rqStatusLeds');
+    const infoEl   = document.getElementById('rqStatusInfo');
+    const acoesEl  = document.getElementById('rqStatusAcoes');
+    try {
+      const r = await api(`/api/recibos/envio-status?membro_id=${membroId}&periodo=${periodo}`);
+      const env = r.envio;
+
+      if (!env) {
+        ledsEl.innerHTML = `<span style="color:var(--text-muted);">⚪ ainda não enviado neste período</span>`;
+        infoEl.textContent = '';
+        acoesEl.innerHTML = `
+          <button id="rqDispararIndiv" class="btn-primary" style="background:var(--success); color:#fff; border-color:var(--success);">📤 Enviar agora via WhatsApp</button>
+        `;
+        document.getElementById('rqDispararIndiv').onclick = async () => {
+          const ok = await confirmarAcao({
+            titulo: 'Enviar recibo individual',
+            mensagem: `Enviar agora o recibo via WhatsApp para ${escape(nome)} referente a ${escape(periodoLabel(periodo))}?<br><br><small>Será criado um lote individual e o PDF disparado.</small>`,
+            textoConfirmar: 'Enviar', perigoso: false,
+          });
+          if (!ok) return;
+          const btn = document.getElementById('rqDispararIndiv');
+          btn.disabled = true; btn.textContent = '⏳ Enviando…';
+          try {
+            const out = await api('/api/recibos/disparar-individual', {
+              method: 'POST',
+              body: JSON.stringify({ membro_id: membroId, periodo }),
+            });
+            alert('✅ ' + (out.message || 'Disparado.'));
+            await recarregarStatus();
+          } catch (e) { mostrarErroApi(e); btn.disabled = false; btn.textContent = '📤 Enviar agora via WhatsApp'; }
+        };
+        return;
+      }
+
+      // Renderiza linha de LEDs (1 ativo conforme status atual)
+      const idxAtual = ESTADOS.findIndex(e => e.st === env.status);
+      const isContestado = env.status === 'contestado';
+      const isExpirado   = env.status === 'expirado';
+      const isFalha      = env.status === 'falha_envio' || env.status === 'pulado_sem_telefone';
+
+      let ledsHtml;
+      if (isContestado) {
+        ledsHtml = `<span style="color:var(--danger); font-weight:600;">🔴 CONTESTADO</span>`;
+      } else if (isExpirado) {
+        ledsHtml = `<span style="color:var(--warning); font-weight:600;">⏰ EXPIRADO (sem resposta 48h+)</span>`;
+      } else if (isFalha) {
+        ledsHtml = `<span style="color:var(--danger);">❌ ${escape(env.status)}</span>`;
+      } else {
+        ledsHtml = ESTADOS.map((e, i) => {
+          const ativo = i <= idxAtual;
+          return `<span style="opacity:${ativo ? 1 : 0.25}; ${i===idxAtual ? 'font-weight:600;' : ''}">${e.dot} ${e.label}</span>`;
+        }).join(' <span style="color:var(--text-muted);">→</span> ');
+      }
+      ledsEl.innerHTML = ledsHtml;
+
+      const partes = [];
+      partes.push(`Lote ${escape(env.lote_numero)} · ID#${env.id}`);
+      partes.push(`Valor: ${fmt(Number(env.valor))}`);
+      if (env.telefone) partes.push(`Tel: ${escape(env.telefone)}`);
+      if (env.tentativas_envio) partes.push(`${env.tentativas_envio} tentativa(s)`);
+      if (env.enviado_em)        partes.push(`Enviado: ${new Date(env.enviado_em).toLocaleString('pt-BR')}`);
+      if (env.confirmado_em)     partes.push(`Confirmado: ${new Date(env.confirmado_em).toLocaleString('pt-BR')}`);
+      if (env.pago_em)           partes.push(`Pago: ${new Date(env.pago_em).toLocaleString('pt-BR')}`);
+      if (env.chave_pix)         partes.push(`PIX (${escape(env.tipo_chave_pix||'?')}): ${escape(env.chave_pix)}`);
+      if (env.contestacao_motivo)partes.push(`<span style="color:var(--danger);">Motivo: ${escape(env.contestacao_motivo)}</span>`);
+      if (env.ultimo_erro)       partes.push(`<span style="color:var(--danger);">Erro: ${escape(env.ultimo_erro)}</span>`);
+      infoEl.innerHTML = partes.join(' · ');
+
+      // Botões de ação manual conforme estado
+      const btns = [];
+      // Sempre permite reenviar (gera novo PDF + texto + link)
+      btns.push(`<button id="rqReenviar" title="Reenvia o recibo + texto via WhatsApp">📤 Reenviar</button>`);
+      if (env.status === 'enviado_aguardando_confirmacao') {
+        btns.push(`<button id="rqMarcarConfirmou" style="background:#15803d; color:#fff; border-color:#15803d;">✅ Marcar Confirmou</button>`);
+        btns.push(`<button id="rqMarcarContestou" class="btn-danger">⚠️ Marcar Contestou</button>`);
+      }
+      if (['enviado_aguardando_confirmacao','confirmado_aguardando_pix'].includes(env.status)) {
+        btns.push(`<button id="rqMarcarPixRec" style="background:#1d4ed8; color:#fff; border-color:#1d4ed8;">💳 Marcar PIX recebido</button>`);
+      }
+      if (['enviado_aguardando_confirmacao','confirmado_aguardando_pix','pix_recebido'].includes(env.status)) {
+        btns.push(`<button id="rqMarcarPago" style="background:var(--success); color:#fff; border-color:var(--success);">💰 Marcar como PAGO</button>`);
+      }
+      if (env.token_confirmacao) {
+        btns.push(`<a href="${API}/recibos/confirmar/${escape(env.token_confirmacao)}" target="_blank" style="text-decoration:none;"><button>🔗 Abrir link de confirmação</button></a>`);
+      }
+      acoesEl.innerHTML = btns.join('');
+
+      // Wire buttons
+      const rebind = async (statusNovo, motivo) => {
+        const ok = await confirmarAcao({
+          titulo: `Marcar como ${statusNovo}`,
+          mensagem: `Forçar status do envio do ${escape(nome)} para <strong>${statusNovo}</strong>?<br><br><small>Sem mandar nenhuma mensagem ao colaborador.</small>`,
+          textoConfirmar: 'Marcar', perigoso: statusNovo === 'contestado',
+        });
+        if (!ok) return;
+        try {
+          await api(`/api/recibos/envio/${env.id}/status-manual`, {
+            method: 'POST',
+            body: JSON.stringify({ envio_id: String(env.id), status: statusNovo, motivo, marcador: 'CEO via UI Marcar Dias' }),
+          });
+          await recarregarStatus();
+        } catch (e) { mostrarErroApi(e); }
+      };
+      const reenvBtn = document.getElementById('rqReenviar');
+      if (reenvBtn) reenvBtn.onclick = async () => {
+        const ok = await confirmarAcao({
+          titulo: 'Reenviar recibo',
+          mensagem: `Vai gerar novo PDF e mandar de novo via WhatsApp para ${escape(nome)}.`,
+          textoConfirmar: 'Reenviar', perigoso: false,
+        });
+        if (!ok) return;
+        try {
+          await api('/api/recibos/reenviar', {
+            method: 'POST',
+            body: JSON.stringify({
+              lote_id: String(env.lote_id),
+              status_alvo: env.status,
+              horas_minimas: 0,
+              confirm: true,
+            }),
+          });
+          await recarregarStatus();
+        } catch (e) { mostrarErroApi(e); }
+      };
+      const map = {
+        rqMarcarConfirmou: 'confirmado_aguardando_pix',
+        rqMarcarContestou: 'contestado',
+        rqMarcarPixRec:    'pix_recebido',
+        rqMarcarPago:      'pago',
+      };
+      for (const [id, st] of Object.entries(map)) {
+        const el = document.getElementById(id);
+        if (el) el.onclick = () => rebind(st);
+      }
+    } catch (e) {
+      ledsEl.innerHTML = `<span style="color:var(--danger);">Erro: ${escape(e.message)}</span>`;
+      infoEl.textContent = ''; acoesEl.innerHTML = '';
+    }
+  };
+
+  document.getElementById('rqPeriodo').onchange = async () => {
+    await Promise.all([recarregarAjustes(), recarregarStatus()]);
+  };
   document.getElementById('rqAddAjuste').onclick = async () => {
     const periodo = document.getElementById('rqPeriodo').value;
     const tipo    = document.getElementById('rqTipo').value;
@@ -2745,7 +2907,7 @@ async function abrirModalReciboQuinzena(membroId, nome) {
     window.open(API + `/api/recibos/quinzena/${membroId}/pdf?periodo=${periodo}`, '_blank');
   };
 
-  await recarregarAjustes();
+  await Promise.all([recarregarAjustes(), recarregarStatus()]);
 }
 
 function abrirEditarTransacao(t) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -771,6 +771,30 @@ app.post('/api/recibos/expirar', requireCeoToken, apiHandle(async (args) => {
   return m.expirarRecibosAntigos(args as Parameters<typeof m.expirarRecibosAntigos>[0]);
 }));
 
+// v1.65.20: controle manual individual no modal Recibo (aba Marcar Dias)
+// GET status do envio mais recente do colaborador no período
+app.get('/api/recibos/envio-status', apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.buscarStatusEnvioColaborador(args as { membro_id: string; periodo: string });
+}));
+// POST disparar individual (mini-lote de 1)
+app.post('/api/recibos/disparar-individual', requireCeoToken, async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/recibosQuinzena');
+    const proto = (req.get('x-forwarded-proto') as string | undefined)?.split(',')[0]?.trim() || 'https';
+    const baseUrl = `${proto}://${req.get('host')}`.replace(/\/$/, '');
+    const out = await m.dispararEnvioIndividual({ ...req.body, baseUrl });
+    res.json(out);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+// POST avançar status manualmente
+app.post('/api/recibos/envio/:envio_id/status-manual', requireCeoToken, apiHandle(async (args) => {
+  const m = await import('./services/recibosQuinzena');
+  return m.alterarStatusManual(args as Parameters<typeof m.alterarStatusManual>[0]);
+}));
+
 // v1.65.19 — Confirmação web por token (link clicável → vira botão no WhatsApp)
 app.get('/recibos/confirmar/:token', async (req: Request, res: Response) => {
   try {

--- a/src/services/recibosQuinzena.ts
+++ b/src/services/recibosQuinzena.ts
@@ -2033,7 +2033,10 @@ export async function reenviarRecibos(input: ReenviarInput): Promise<{
   message: string;
 }> {
   const status = input.status_alvo || 'enviado_aguardando_confirmacao';
-  const horas = Number(input.horas_minimas ?? (status === 'enviado_aguardando_confirmacao' ? 24 : 0));
+  // v1.65.20: se CEO especificou lote_id, ele já escolheu — sem proteção anti-spam.
+  // Default 24h só vale pra reenvio "geral" (sem lote). Filtrado por lote → 0h.
+  const defaultHoras = (status === 'enviado_aguardando_confirmacao' && !input.lote_id) ? 24 : 0;
+  const horas = Number(input.horas_minimas ?? defaultHoras);
 
   let where = `v.status = ?`;
   const params: (string | number)[] = [status];
@@ -2241,4 +2244,199 @@ export function startExpiracaoRecibosTicker(): void {
       })
       .catch(err => console.warn('[recibos] ticker expiração falhou:', (err as Error).message));
   }, ms);
+}
+
+// ╔═════════════════════════════════════════════════════════════════════════╗
+// ║ v1.65.20 — Controle MANUAL individual no modal Recibo (CEO)              ║
+// ║ Endpoints pra:                                                            ║
+// ║   1) buscar status do envio mais recente desse colaborador no período    ║
+// ║   2) disparar mini-lote só pra UM colaborador (sem precisar quinzena    ║
+// ║      inteira)                                                             ║
+// ║   3) avançar status manualmente sem passar pelo fluxo do colaborador      ║
+// ╚═════════════════════════════════════════════════════════════════════════╝
+
+interface EnvioStatusRow extends RowDataPacket {
+  id: number; lote_id: number; lote_numero: string;
+  membro_id: number; telefone: string | null;
+  valor: string; status: string;
+  enviado_em: Date | null; confirmado_em: Date | null;
+  pix_recebido_em: Date | null; pago_em: Date | null;
+  chave_pix: string | null; tipo_chave_pix: string | null;
+  contestacao_motivo: string | null;
+  tentativas_envio: number; ultimo_erro: string | null;
+  recibo_hash: string | null; token_confirmacao: string | null;
+}
+
+export async function buscarStatusEnvioColaborador(input: {
+  membro_id: string; periodo: string;
+}): Promise<{ envio: EnvioStatusRow | null; mensagens: Array<{ direcao: string; tipo: string; conteudo: string; enviado_em: Date }> }> {
+  const [rows] = await pool.execute<EnvioStatusRow[]>(
+    `SELECT v.*, l.numero AS lote_numero
+       FROM recibos_envios v
+       JOIN recibos_envios_lotes l ON l.id = v.lote_id
+      WHERE v.membro_id = ? AND l.periodo = ?
+      ORDER BY v.criado_em DESC LIMIT 1`,
+    [Number(input.membro_id), input.periodo]
+  );
+  const envio = rows[0] ?? null;
+  if (!envio) return { envio: null, mensagens: [] };
+
+  const [msgs] = await pool.execute<RowDataPacket[]>(
+    `SELECT direcao, tipo, conteudo, enviado_em
+       FROM recibos_envios_mensagens
+      WHERE envio_id = ? ORDER BY enviado_em ASC LIMIT 30`,
+    [envio.id]
+  );
+  return {
+    envio,
+    mensagens: msgs.map(r => ({
+      direcao: String(r.direcao), tipo: String(r.tipo),
+      conteudo: String(r.conteudo ?? ''), enviado_em: r.enviado_em as Date,
+    })),
+  };
+}
+
+// Cria mini-lote de 1 colaborador e dispara (sem preview prévio).
+// Útil pro CEO mandar recibo individual de quem ele quiser.
+export async function dispararEnvioIndividual(input: {
+  membro_id: string; periodo: string;
+  telefone_override?: string;  // se quiser usar outro número que não o cadastrado
+  baseUrl?: string;
+  criado_por?: string;
+}): Promise<{
+  ok: true; lote_id: string; envio_id: string; status: string; message: string;
+}> {
+  const periodo = parsePeriodo(input.periodo);
+
+  // Coleta dados (valida que tem dias/ajustes no período)
+  const data = await coletarDadosRecibo(input.membro_id, periodo.codigo);
+  if (data.totais.qtd_dias === 0 && data.totais.total_ajustes === 0) {
+    throw new Error('Colaborador sem dias trabalhados ou ajustes no período — nada pra cobrar.');
+  }
+
+  // Telefone: usa override se passou, senão valor_dia do cadastro
+  const [memRows] = await pool.execute<RowDataPacket[]>(
+    `SELECT telefone FROM romatec_obra_equipe WHERE id = ?`, [Number(input.membro_id)]
+  );
+  const telefoneRaw = input.telefone_override || (memRows[0]?.telefone as string | undefined) || '';
+  const telefoneNorm = telefoneRaw.replace(/\D/g, '');
+  if (telefoneNorm.length < 10) {
+    throw new Error(`Telefone inválido: "${telefoneRaw}". Cadastre o telefone do colaborador ou informe um override.`);
+  }
+
+  // Cria lote dedicado (numero com sufixo "IND-" + timestamp)
+  const numeroLote = `QUINZ-${periodo.ano}-${String(periodo.mes).padStart(2, '0')}-${periodo.quinzena}-IND-${Date.now().toString(36).slice(-5)}`;
+  const [r] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO recibos_envios_lotes
+       (numero, periodo, periodo_inicio, periodo_fim, total_colaboradores, total_valor, status, criado_por)
+     VALUES (?,?,?,?,?,?,?,?)`,
+    [
+      numeroLote, periodo.codigo, periodo.dataInicio, periodo.dataFim,
+      1, data.totais.total_liquido.toFixed(2),
+      'aguardando_confirmacao_ceo', input.criado_por ?? 'envio-individual',
+    ]
+  );
+  const loteId = r.insertId;
+
+  const token = gerarToken();
+  const [r2] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO recibos_envios (lote_id, membro_id, telefone, valor, status, token_confirmacao)
+     VALUES (?,?,?,?,?,?)`,
+    [loteId, Number(input.membro_id), telefoneNorm, data.totais.total_liquido.toFixed(2),
+     'pendente_envio', token]
+  );
+  const envioId = r2.insertId;
+
+  // Dispara (gera PDF + manda WhatsApp + atualiza status)
+  await dispararLote({ lote_id: String(loteId), baseUrl: input.baseUrl });
+
+  // Re-lê status final
+  const [vRows] = await pool.execute<RowDataPacket[]>(
+    `SELECT status FROM recibos_envios WHERE id = ?`, [envioId]
+  );
+  const finalStatus = String(vRows[0]?.status ?? '?');
+
+  return {
+    ok: true,
+    lote_id: String(loteId),
+    envio_id: String(envioId),
+    status: finalStatus,
+    message: finalStatus === 'enviado_aguardando_confirmacao'
+      ? `Recibo enviado pra ${telefoneNorm}. Aguardando confirmação.`
+      : `Disparo concluído com status ${finalStatus}.`,
+  };
+}
+
+// Avança status manualmente (CEO marca direto, sem passar pelo fluxo do colaborador)
+type StatusManual =
+  | 'enviado_aguardando_confirmacao'
+  | 'confirmado_aguardando_pix'
+  | 'pix_recebido'
+  | 'pago'
+  | 'contestado'
+  | 'expirado';
+
+export async function alterarStatusManual(input: {
+  envio_id: string;
+  status: StatusManual;
+  motivo?: string;
+  marcador?: string;
+  notificar_ceo?: boolean;
+}): Promise<{ ok: true; status: string; message: string }> {
+  const id = Number(input.envio_id);
+  if (!id) throw new Error('envio_id inválido');
+
+  const [rows] = await pool.execute<EnvioStatusRow[]>(
+    `SELECT v.*, l.numero AS lote_numero, e.nome
+       FROM recibos_envios v
+       LEFT JOIN recibos_envios_lotes l ON l.id = v.lote_id
+       LEFT JOIN romatec_obra_equipe e ON e.id = v.membro_id
+      WHERE v.id = ?`, [id]
+  );
+  const envio = rows[0];
+  if (!envio) throw new Error(`envio ${id} não encontrado`);
+
+  // Monta SET dinâmico — preserva timestamps + adiciona o novo
+  const sets: string[] = ['status = ?'];
+  const params: (string | number | null)[] = [input.status];
+  if (input.status === 'confirmado_aguardando_pix') {
+    sets.push("confirmado_em = COALESCE(confirmado_em, NOW())");
+    sets.push("confirmacao_resposta = COALESCE(confirmacao_resposta, ?)");
+    params.push(`[MANUAL] ${input.marcador ?? 'CEO'} marcou via UI`);
+  }
+  if (input.status === 'pix_recebido') {
+    sets.push("confirmado_em = COALESCE(confirmado_em, NOW())");
+    sets.push("pix_recebido_em = COALESCE(pix_recebido_em, NOW())");
+  }
+  if (input.status === 'pago') {
+    sets.push("confirmado_em = COALESCE(confirmado_em, NOW())");
+    sets.push("pix_recebido_em = COALESCE(pix_recebido_em, NOW())");
+    sets.push("pago_em = COALESCE(pago_em, NOW())");
+  }
+  if (input.status === 'contestado') {
+    sets.push("contestacao_motivo = COALESCE(contestacao_motivo, ?)");
+    params.push(input.motivo ?? '[MANUAL] marcado pelo CEO');
+    sets.push("contestacao_repassada_ceo_em = COALESCE(contestacao_repassada_ceo_em, NOW())");
+  }
+  params.push(id);
+
+  await pool.execute(
+    `UPDATE recibos_envios SET ${sets.join(', ')} WHERE id = ?`, params
+  );
+
+  await logarMensagemEnvio(id, 'saida', 'aviso',
+    `[MANUAL] status alterado para "${input.status}"${input.motivo ? ' — motivo: ' + input.motivo : ''}${input.marcador ? ' por ' + input.marcador : ''}`,
+    null);
+
+  if (input.notificar_ceo === false) {
+    // ignore
+  } else {
+    // Não re-notifica CEO (foi ele mesmo que marcou)
+  }
+
+  return {
+    ok: true,
+    status: input.status,
+    message: `Envio ${id} (${envio.nome}): status atualizado para ${input.status}.`,
+  };
 }


### PR DESCRIPTION
## Resumo
CEO pediu ampliar o modal **💰 Recibo Quinzenal** (na aba Marcar Dias) com:
1. **LEDs visuais do status** do envio do colaborador
2. Botão pra **disparar individualmente** (sem precisar de quinzena inteira)
3. **Botões manuais** pra avançar status (auto vs manual)

## Service `src/services/recibosQuinzena.ts`
- `buscarStatusEnvioColaborador({ membro_id, periodo })`: envio mais recente + últimas 30 mensagens.
- `dispararEnvioIndividual({ membro_id, periodo, telefone_override?, baseUrl })`: cria mini-lote (`QUINZ-YYYY-MM-N-IND-<hash>`) com 1 envio, gera token, dispara via `dispararLote` (PDF + WhatsApp).
- `alterarStatusManual({ envio_id, status, motivo?, marcador? })`: força status sem fluxo do colaborador. Preserva timestamps anteriores via COALESCE.
- **Bonus**: `reenviarRecibos` default `horas_minimas=0` quando `lote_id` está presente (CEO já escolheu — sem proteção anti-spam). Antes era 24h sempre.

## Endpoints REST
- `GET  /api/recibos/envio-status?membro_id=X&periodo=Y`
- `POST /api/recibos/disparar-individual` (CEO_TOKEN)
- `POST /api/recibos/envio/:envio_id/status-manual` (CEO_TOKEN)

## UI (`obras.html` — modal Recibo)
Seção nova `Status do envio (WhatsApp)`:
- **Não enviado**: LED ⚪ + botão grande verde **📤 Enviar agora via WhatsApp**
- **Enviado**: linha de LEDs com etapa atual destacada
  ```
  🟡 Enviado → 🟢 Confirmou → 🔵 PIX → ✅ PAGO
  ```
- **Estados especiais**: `🔴 CONTESTADO`, `⏰ EXPIRADO`, `❌ falha_envio`
- **Info**: lote, ID, valor, telefone, tentativas, timestamps, chave PIX, motivo de contestação, último erro
- **Botões de ação manual** (variáveis por estado):
  - `📤 Reenviar` (sempre)
  - `✅ Marcar Confirmou`
  - `⚠️ Marcar Contestou`
  - `💳 Marcar PIX recebido`
  - `💰 Marcar como PAGO`
  - `🔗 Abrir link de confirmação` (se tem token)

## Test plan
- [ ] Após merge + deploy: aba Marcar Dias → 💰 Recibo de qualquer colaborador
- [ ] Selecionar período sem envio → vê **⚪ ainda não enviado** + botão **📤 Enviar agora**
- [ ] Clicar enviar → confirma → PDF chega no WhatsApp dele + LED vira **🟡 Enviado**
- [ ] Clicar **💰 Marcar como PAGO** direto (sem esperar resposta) → status pula pra pago, LEDs preenchem todos
- [ ] Selecionar período do lote QUINZ-2026-04-2 → vê os LEDs do estado real (Leonardo Chapadão = 🔵 PIX recebido; outros = 🟡 Enviado)
- [ ] **📤 Reenviar** o Vinicius → recebe nova mensagem com link clicável
- [ ] Acompanhar status enquanto Vinicius interage pelo link

Generated with Claude Code