### PR TITLE
fix(v3.0.1): UI INCRA — overflow mobile + tap targets WCAG (code review)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.0.0',
+  version: '3.0.1',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -15899,19 +15899,19 @@ function renderLaudoTabArt(c) {
       </div>
     </div>
     <div class="card">
-      <h3 style="margin-top:0;">💰 Precificação INCRA (Portaria 12/2025)</h3>
+      <h3 style="margin-top:0;">📐 Precificação INCRA (Portaria 12/2025)</h3>
 
-      <div style="display:flex; gap:12px; margin-bottom:8px; flex-wrap:wrap;">
-        <label style="display:flex; gap:4px; align-items:center;">
+      <div style="display:flex; gap:8px; margin-bottom:8px; flex-wrap:wrap;">
+        <label style="display:flex; gap:6px; align-items:center; padding:6px 8px; cursor:pointer;">
           <input type="radio" name="incraUnidade" value="km" id="incraUniKm"> km linear
         </label>
-        <label style="display:flex; gap:4px; align-items:center;">
+        <label style="display:flex; gap:6px; align-items:center; padding:6px 8px; cursor:pointer;">
           <input type="radio" name="incraUnidade" value="hectare" id="incraUniHa" checked> Hectare
         </label>
-        <label style="display:flex; gap:4px; align-items:center;">
+        <label style="display:flex; gap:6px; align-items:center; padding:6px 8px; cursor:pointer;">
           <input type="radio" name="incraUnidade" value="lote" id="incraUniLote"> Lote
         </label>
-        <input id="incraQtd" type="number" step="0.0001" placeholder="Quantidade" style="flex:1; min-width:140px;">
+        <input id="incraQtd" type="number" step="0.0001" placeholder="Quantidade" style="flex:1 1 140px; min-width:0;">
       </div>
 
       <div id="incraCriterios" style="display:grid; grid-template-columns: 1fr; gap:8px;">
@@ -15925,12 +15925,18 @@ function renderLaudoTabArt(c) {
         <div style="font-size:13px; color:var(--text-muted); margin-top:4px;"><span id="incraFormula">—</span></div>
       </div>
 
-      <div style="margin-top:10px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+      <div style="margin-top:10px; display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
         <span style="color:var(--text-muted); font-size:12px;">Desconto:</span>
-        <label><input type="radio" name="incraDescTipo" value="nenhum" id="incraDescNenhum" checked> Nenhum</label>
-        <label><input type="radio" name="incraDescTipo" value="percentual" id="incraDescPct"> %</label>
-        <label><input type="radio" name="incraDescTipo" value="fixo" id="incraDescFixo"> R$</label>
-        <input id="incraDescValor" type="number" step="0.01" placeholder="0" style="width:120px;" disabled>
+        <label style="display:inline-flex; gap:6px; align-items:center; padding:6px 8px; cursor:pointer;">
+          <input type="radio" name="incraDescTipo" value="nenhum" id="incraDescNenhum" checked> Nenhum
+        </label>
+        <label style="display:inline-flex; gap:6px; align-items:center; padding:6px 8px; cursor:pointer;">
+          <input type="radio" name="incraDescTipo" value="percentual" id="incraDescPct"> %
+        </label>
+        <label style="display:inline-flex; gap:6px; align-items:center; padding:6px 8px; cursor:pointer;">
+          <input type="radio" name="incraDescTipo" value="fixo" id="incraDescFixo"> R$
+        </label>
+        <input id="incraDescValor" type="number" step="0.01" placeholder="0" style="flex:1 1 80px; min-width:0; max-width:120px;" disabled>
       </div>
 
       <div id="incraAvisos" style="margin-top:8px; color:#d97706; font-size:12px;"></div>
@@ -16004,10 +16010,10 @@ async function setupIncraBlock(laudoId) {
       const maxP = n.maxPonto;
       return `<option value="${minP}-${maxP}">${n.rotulo} (${minP}-${maxP})</option>`;
     }).join('');
-    return `<div style="display:grid; grid-template-columns: 130px 90px 1fr; gap:8px; align-items:center;">
-      <label>${def.label}:</label>
-      <input type="number" min="1" max="10" value="5" data-incra-criterio="${k}" style="width:80px;">
-      <select data-incra-faixa="${k}">${niveisOpts}</select>
+    return `<div style="display:grid; grid-template-columns: 80px 1fr; gap:4px 8px; align-items:center;">
+      <label style="grid-column: 1 / -1; font-size:12px; color:var(--text-muted);">${def.label}</label>
+      <input type="number" min="1" max="10" value="5" data-incra-criterio="${k}" style="width:100%; min-width:0;">
+      <select data-incra-faixa="${k}" style="width:100%; min-width:0;">${niveisOpts}</select>
     </div>`;
   }).join('');
 

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.0.0';
+const CACHE = 'zayra-v3.0.1';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
3 fixes do final review do cli-ui-designer (severity Critical):

C1: Grid dos critérios de 130px+90px+1fr (~228px fixos) → 80px+1fr
    com label em cima (grid-column 1/-1). Não estoura mais em iPhone SE
    (375px). Em qualquer tela: label, depois input + select stackeados
    horizontalmente.

C2: Tap targets dos radios (unidade + desconto) sem padding violavam
    WCAG 2.5.8 (alvo de toque <24px em mobile). Adicionado padding 6px 8px
    em todos os labels com radio. Agora ~32px de altura — aceitável
    pra dedo em mobile.

C3: input de desconto com width:120px fixo causava layout inconsistente
    quando flex-wrap quebrava. Trocado pra flex:1 1 80px; min-width:0;
    max-width:120px.

Bonus (Important I1): emoji do bloco INCRA mudou de 💰 para 📐 pra não colidir visualmente com o card 💰 Financeiro logo abaixo.

Branch separada (fix/incra-mobile-overflow) — não modifica nenhuma logica de cálculo, apenas estilos CSS inline. Sem riscos pra v3.0.0.

Bump: package.json/identity.ts/sw.js 3.0.0 → 3.0.1.