### PR TITLE
feat(v3.0.2): polish UI INCRA — caption, dirty state, lock visual, st…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.0.1',
+  version: '3.0.2',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -15914,6 +15914,9 @@ function renderLaudoTabArt(c) {
         <input id="incraQtd" type="number" step="0.0001" placeholder="Quantidade" style="flex:1 1 140px; min-width:0;">
       </div>
 
+      <p style="font-size:11px; color:var(--text-muted); margin:0 0 6px;">
+        Ajuste a nota (1–10) ou selecione o nível diretamente — os dois ficam sincronizados.
+      </p>
       <div id="incraCriterios" style="display:grid; grid-template-columns: 1fr; gap:8px;">
         <!-- preenchido por setupIncraBlock -->
       </div>
@@ -15946,9 +15949,9 @@ function renderLaudoTabArt(c) {
         <strong id="incraValorFinal" style="font-size:18px; color:#10b981;">—</strong>
       </div>
 
-      <div style="margin-top:8px; display:flex; gap:8px;">
+      <div style="margin-top:8px; display:flex; gap:8px; align-items:center;">
         <button class="btn-primary" id="incraSalvar">💾 Salvar precificação</button>
-        <span id="incraStatus" style="color:var(--text-muted); font-size:12px;"></span>
+        <span id="incraStatus" style="color:var(--text-muted); font-size:12px; min-height:1.2em;"></span>
       </div>
     </div>
     <div class="card">
@@ -16053,6 +16056,33 @@ async function setupIncraBlock(laudoId) {
   }
   setQuantidadeDefault();
 
+  // v3.0.2: helpers de UX (feedback "nao salvo" + lock visual do valor_servico)
+  let isDirty = false;
+  function applyDirtyVisual() {
+    const btn = document.getElementById('incraSalvar');
+    if (!btn) return;
+    btn.style.boxShadow = isDirty ? '0 0 0 2px var(--gold)' : '';
+  }
+  function markValorServicoLocked(locked) {
+    const valSrv = document.getElementById('la-valor');
+    if (!valSrv) return;
+    valSrv.disabled = locked;
+    let hint = document.getElementById('la-valor-incra-hint');
+    if (locked) {
+      valSrv.title = 'Calculado pela precificacao INCRA — para alterar, recalcule acima';
+      if (!hint) {
+        hint = document.createElement('small');
+        hint.id = 'la-valor-incra-hint';
+        hint.style.cssText = 'grid-column: 1 / -1; color:#10b981; font-size:11px; display:block;';
+        hint.textContent = '🔒 Calculado pela precificação INCRA — recalcule acima para alterar.';
+        valSrv.parentElement?.appendChild(hint);
+      }
+    } else {
+      valSrv.removeAttribute('title');
+      if (hint) hint.remove();
+    }
+  }
+
   // Listeners
   document.querySelectorAll('input[name="incraUnidade"]').forEach(r => r.addEventListener('change', () => { setQuantidadeDefault(); recalc(); }));
   document.querySelectorAll('[data-incra-criterio]').forEach(i => i.addEventListener('input', recalc));
@@ -16080,6 +16110,8 @@ async function setupIncraBlock(laudoId) {
 
   let recalcTimer = null;
   function recalc() {
+    isDirty = true;
+    applyDirtyVisual();
     clearTimeout(recalcTimer);
     recalcTimer = setTimeout(doRecalc, 300);
   }
@@ -16137,11 +16169,14 @@ async function setupIncraBlock(laudoId) {
       status.textContent = '✓ Salvo (R$ ' + r.valorFinal.toFixed(2).replace('.', ',') + ')';
       // Trava o campo valor_servico do bloco financeiro
       const valSrv = document.getElementById('la-valor');
-      if (valSrv) {
-        valSrv.value = r.valorFinal;
-        valSrv.disabled = true;
-        valSrv.title = 'Calculado pela precificacao INCRA — para alterar, recalcule acima';
-      }
+      if (valSrv) valSrv.value = r.valorFinal;
+      markValorServicoLocked(true);
+      isDirty = false;
+      applyDirtyVisual();
+      // v3.0.2: limpa msg de sucesso depois de 5s pra nao poluir tela
+      setTimeout(() => {
+        if (status.textContent.startsWith('✓')) status.textContent = '';
+      }, 5000);
     } catch (err) {
       status.textContent = '✗ ' + err.message;
     }
@@ -16150,13 +16185,9 @@ async function setupIncraBlock(laudoId) {
   // Calculo inicial
   doRecalc();
 
-  // Se o laudo ja tinha precificacao salva, trava o campo de valor_servico de saida
+  // Se o laudo ja tinha precificacao salva, trava o campo de valor_servico
   if (laudo.precificacao_calculada_em) {
-    const valSrv = document.getElementById('la-valor');
-    if (valSrv) {
-      valSrv.disabled = true;
-      valSrv.title = 'Calculado pela precificacao INCRA — para alterar, recalcule acima';
-    }
+    markValorServicoLocked(true);
   }
 }
 

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.0.1';
+const CACHE = 'zayra-v3.0.2';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
…atus timeout

Aplica os Important + Polish do final review do cli-ui-designer:

I2: Caption acima do grid de critérios (explica que stepper e dropdown
    estão sincronizados — antes parecia 2 controles independentes).

I3: btn-dirty — botão "Salvar precificação" ganha box-shadow gold
    quando ha mudanças não salvas. Limpa após save bem-sucedido.
    Closure `isDirty` marcada em qualquer recalc (pos-load).

I4: Hint visual abaixo do campo "Valor do serviço" quando travado pela
    INCRA: '🔒 Calculado pela precificação INCRA — recalcule acima
    para alterar.' (small em verde, grid-column 1 / -1). Antes só
    havia tooltip que não aparece em mobile.

P1: min-height:1.2em no #incraStatus pra eliminar layout shift quando
    aparece/desaparece "Salvando..." / "✓ Salvo".

Microcopy: status de sucesso some sozinho após 5s (era persistente).

Helpers em closure de setupIncraBlock: applyDirtyVisual() + markValorServicoLocked(locked) — DRY com 2 chamadas (success do save + load se já tem precificação).

Sem mudancas de logica de calculo; apenas UI/UX. Bump 3.0.1 -> 3.0.2.