### PR TITLE
feat(v3.0.3): botao Re-assinar no card do laudo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.0.2',
+  version: '3.0.3',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -13408,7 +13408,8 @@ function renderLaudosLista(v) {
           </div>
           <div style="display:flex; gap:4px; flex-wrap:wrap;">
             ${l.assinado_em
-              ? `<button data-laudo-pdf-sig="${l.id}" title="PDF assinado digitalmente" style="flex:1; background:#1F5C3A22; color:#1F5C3A; border:1px solid #1F5C3A55;">🔏 Assinado</button>`
+              ? `<button data-laudo-pdf-sig="${l.id}" title="Baixar PDF assinado digitalmente" style="flex:1; background:#1F5C3A22; color:#1F5C3A; border:1px solid #1F5C3A55;">🔏 Assinado</button>
+                 <button data-laudo-sig="${l.id}" data-laudo-resign="1" title="Re-assinar — sobrescreve o PDF atual com a versão atualizada do laudo" style="flex:1; background:transparent; color:var(--text-muted); border:1px dashed var(--border); font-size:12px;">🔁 Re-assinar</button>`
               : `<button data-laudo-sig="${l.id}" title="Assinar digitalmente (PAdES ICP-Brasil)" style="flex:1; background:transparent; color:var(--text-muted); border:1px dashed var(--border);">🔏 Assinar</button>`}
             ${l.recibo_id
               ? `<button data-laudo-recibo-ver="${l.recibo_id}" title="Ver recibo gerado" style="flex:1; background:#f59e0b22; color:#f59e0b; border:1px solid #f59e0b55;">🧾 Recibo</button>`
@@ -13461,7 +13462,12 @@ function renderLaudosLista(v) {
     window.open('/api/laudos-demarcacao/' + b.dataset.laudoPdfSig + '/pdf-assinado', '_blank');
   });
   v.querySelectorAll('[data-laudo-sig]').forEach(b => b.onclick = async () => {
-    if (!confirm('Assinar digitalmente este laudo (PAdES ICP-Brasil)?')) return;
+    // v3.0.3: distingue re-assinar (laudo já assinado) de assinar novo
+    const isResign = b.dataset.laudoResign === '1';
+    const confirmMsg = isResign
+      ? 'Re-assinar este laudo?\n\nO PDF assinado atual sera SOBRESCRITO com a versao mais nova do laudo (incluindo a caixa visual ICP-Brasil, secao de precificacao INCRA se aplicavel, etc).\n\nVoce vai precisar digitar a senha do certificado novamente.'
+      : 'Assinar digitalmente este laudo (PAdES ICP-Brasil)?';
+    if (!confirm(confirmMsg)) return;
     // v2.10.3: lista certificados ativos antes de pedir senha. Se houver
     // mais de um (PF + PJ), pergunta qual usar.
     let perfil = 'pj'; // default
@@ -13503,8 +13509,9 @@ function renderLaudosLista(v) {
         body: JSON.stringify({ senha, perfil }),
         headers: { 'Content-Type': 'application/json' },
       });
+      if (isResign) alert('✅ Laudo re-assinado! O PDF foi atualizado com a versao mais nova.');
       await render();
-    } catch (err) { alert('Erro ao assinar: '+err.message); }
+    } catch (err) { alert('Erro ao ' + (isResign ? 're-assinar' : 'assinar') + ': '+err.message); }
   });
   v.querySelectorAll('[data-laudo-recibo]').forEach(b => b.onclick = async () => {
     if (!confirm('Gerar recibo a partir deste laudo?')) return;

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.0.2';
+const CACHE = 'zayra-v3.0.3';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
UX bug pre-existente: depois de assinar um laudo, o botao "🔏 Assinar" virava "🔏 Assinado" (read-only, so baixa). Sem opcao de re-assinar pela UI — o blob salvo no banco ficava congelado na versao do PDF naquele momento.

Problema concreto: laudos assinados antes da v2.11.0 (caixa visual ICP) e v3.0.0 (secao 12 PRECIFICACAO INCRA) ficavam sem essas features visuais para sempre.

Fix: adiciona botao "🔁 Re-assinar" ao lado do "🔏 Assinado" quando o laudo ja esta assinado. Reusa o mesmo handler data-laudo-sig com flag data-laudo-resign="1" — confirm message diferente avisa que o PDF vai ser sobrescrito, alert de sucesso diferenciado.

O endpoint POST /api/laudos-demarcacao/:id/assinar ja aceitava re-assinar (sem guard contra assinado_em populado) — apenas faltava expor na UI.

Bump 3.0.2 -> 3.0.3.