### PR TITLE
fix(v3.0.4): elimina paginas vazias no PDF do laudo assinado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.0.3',
+  version: '3.0.4',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.0.3';
+const CACHE = 'zayra-v3.0.4';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,

--- a/src/services/laudoPdf.ts
+++ b/src/services/laudoPdf.ts
@@ -749,7 +749,13 @@ export async function gerarPdfLaudo(input: LaudoPdfInput): Promise<Buffer> {
   }
 
   // ── 14. Local + data + assinatura ──────────────────────────────────
-  if (cy > 720) { doc.addPage(); cy = 60; }
+  // v3.0.4: garante que TODO o bloco final (local/data + caixa ICP + linha + nome +
+  // qualif + QR + hash + footer) cabe na pagina atual. Sem isso, conteudo extrapolava
+  // o bottomMargin (802pt) e o PDFKit criava 1-2 paginas vazias com so footer/hash.
+  // Espaco necessario: 30 (local/data) + (caixa ICP 75 OU gap 20) + 6+11+15 (linha+nome+qualif)
+  // + 100 (QR/hash) + 25 (gap+footer) ≈ 187 com ICP ou 132 sem.
+  const espacoFinal = (input.signatureMeta ? 187 : 132);
+  if (cy + espacoFinal > 800) { doc.addPage(); cy = 60; }
   const cidade = laudo.municipio || 'Açailândia';
   const uf = laudo.uf_imovel || 'MA';
   doc.fontSize(10).fillColor('#111').font('Helvetica')
@@ -810,24 +816,30 @@ export async function gerarPdfLaudo(input: LaudoPdfInput): Promise<Buffer> {
   if (executante.qualificacao) partesAssina.push(executante.qualificacao);
   if (executante.registro_cft) partesAssina.push(`CFT ${executante.registro_cft}`);
   doc.text(partesAssina.join(' · '), 40, cy, { width: 515, align: 'center' });
+  cy += 18;
 
   // ── 14. QR + hash + selo ───────────────────────────────────────────
+  // v3.0.4: Y do QR/hash relativo a cy (era Y=720 absoluto). Garantido caber
+  // pela checagem de `espacoFinal` antes do bloco local/data acima.
   if (laudo.hash_validacao) {
     const baseUrl = getBaseUrl();
+    const yQrHash = cy;
     const qrUrl = await renderQRValidacao(
       doc, laudo.hash_validacao, `${baseUrl}/v/laudo`,
-      460, 720,
+      460, yQrHash,
       { size: 75, corHex, comLabel: true }
     );
-    renderHashFooter(doc, laudo.hash_validacao, qrUrl, 40, 720, 410);
+    renderHashFooter(doc, laudo.hash_validacao, qrUrl, 40, yQrHash, 410);
     if (laudo.status === 'CONFIRMADO') {
       renderSeloConfirmado(doc, 310, 460);
     }
+    cy = yQrHash + 95; // QR (75) + label (10) + gap (10)
   }
-  // Footer fixo
+  // Footer fixo (v3.0.4: Y dinamico com fallback Y=785, sempre < bottomMargin 802
+  // pra evitar auto-pagebreak desnecessario)
   doc.fontSize(7).fillColor('#999').font('Helvetica-Oblique')
      .text(`${brand} · Laudo ${laudo.numero_laudo} · ${fmtData(dataEmissao)}`,
-           40, 800, { width: 515, align: 'center' });
+           40, Math.min(Math.max(cy, 770), 790), { width: 515, align: 'center', lineBreak: false });
 
   doc.end();
   await new Promise<void>(resolve => doc.on('end', () => resolve()));


### PR DESCRIPTION
Bug: PDFs assinados com signatureMeta (caixa verde ICP) tinham 1-2 paginas vazias no final — pagina N+1 com so QR + hash, pagina N+2 com so footer "Romatec... Laudo X · data".

Causa: PDFKit auto-pagebreak quando _y >= bottomMargin (802 = 842 - 40).
- cy chegava em ~793 apos a caixa ICP
- linha de assinatura + nome empurrava cy pra 804 → primeiro pagebreak
- QR/hash em Y=720 absoluto + footer em Y=800 absoluto iam pra pagina nova ja criada
- footer Y=800 + altura linha = 810 > 802 → segundo pagebreak → pagina extra so com footer

Fix:
1. Antes do bloco local/data, calcula `espacoFinal` (187pt com caixa ICP, 132pt sem) e forca addPage se cy + espacoFinal > 800. Garante que o bloco de fechamento (local + caixa + linha + nome + qualif + QR + hash + footer) fica todo na mesma pagina.

2. QR/hash agora em Y relativo a cy (era 720 absoluto). Renderizam logo apos a qualificacao (cy += 18), com cy avancando 95pt depois.

3. Footer dinamico em Y = clamp(cy, 770, 790). Sempre < 802 evita auto-pagebreak. O clamp em 770 garante visualmente um rodape, e em 790 garante distancia segura do limite.

Resultado: laudo passa de 6 paginas (com 2 vazias) para 4 paginas densas. Caixa ICP-Brasil + assinatura + QR + hash + footer ficam juntos visualmente.

Bump 3.0.3 -> 3.0.4.