### PR TITLE
fix(v3.0.5): preview visual do croqui na aba dedicada

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.0.4',
+  version: '3.0.5',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -15709,6 +15709,10 @@ function renderLaudoTabPontos(c) {
 
 function renderLaudoTabCroqui(c) {
   const l = state.laudoAtual;
+  // v3.0.5: cache-bust pra forcar reload do croqui depois de upload/reset
+  const cacheBust = Date.now();
+  const numPontos = (l.pontos || []).length;
+  const temPontos = numPontos >= 3;
   c.innerHTML = `
     <div class="card">
       <h3 style="margin-top:0;">🗺️ Croqui</h3>
@@ -15726,6 +15730,17 @@ function renderLaudoTabCroqui(c) {
           ℹ️ O croqui automático é gerado a partir dos pontos importados (norte, escala, distâncias).
           Se preferir um croqui customizado (CAD/Google Earth), faça upload de uma imagem.
         </p>
+      </div>
+      <div style="margin-top:12px; background:#fff; border:1px solid var(--border); border-radius:4px; min-height:420px; overflow:hidden; display:flex; align-items:center; justify-content:center; padding:8px;">
+        ${l.croqui_tipo === 'UPLOAD' || temPontos
+          ? `<img src="/api/laudos-demarcacao/${l.id}/croqui?_t=${cacheBust}"
+                  alt="Croqui do laudo ${escape(l.numero_laudo)}"
+                  style="max-width:100%; max-height:600px; display:block;"
+                  onerror="this.parentElement.innerHTML='<p style=\\'color:#888; font-size:13px; text-align:center; padding:24px;\\'>⚠️ Falha ao carregar o croqui. Tente recarregar a página ou substituir por upload.</p>'">`
+          : `<p style="color:#888; font-size:13px; text-align:center; padding:24px; max-width:400px;">
+              ⚙️ O croqui automático precisa de pelo menos <strong>3 pontos</strong> importados (atualmente: ${numPontos}).
+              <br><br>Vá na aba <strong>📍 Pontos / Vértices</strong> pra adicionar pontos, OU envie uma imagem customizada acima.
+            </p>`}
       </div>
     </div>
   `;

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.0.4';
+const CACHE = 'zayra-v3.0.5';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
Bug: a aba "Croqui" do laudo (renderLaudoTabCroqui) renderizava so texto + botoes (tipo atual, pre-visualizar PDF, file picker, upload). Nao mostrava o croqui em si — area grande ficava em branco. Usuario precisava abrir o PDF inteiro pra ver o croqui ou ir ate a aba Pontos pra ver o preview lateral.

Fix: adiciona <div> com <img src="/api/laudos-demarcacao/{id}/croqui">
abaixo dos controles. O endpoint ja retorna SVG (auto, gerado dos pontos) ou imagem (upload) com Content-Type apropriado — funciona em <img> direto.

Casos cobertos:
- UPLOAD: mostra a imagem enviada
- AUTO com >=3 pontos: mostra SVG gerado
- AUTO com <3 pontos: mostra mensagem orientando ir pra aba Pontos ou enviar imagem
- onerror no <img>: mostra fallback com instrucao de recarregar

Cache busting via ?_t={timestamp} pra forcar reload depois de upload/reset (sem precisar Ctrl+F5).

Bump 3.0.3 -> 3.0.5 (pula 3.0.4 que esta em PR pendente fix/laudo-pdf-paginas-vazias — features paralelas).