### PR TITLE
Feat/mobile foundation v3.3.0

### DIFF
--- a/docs/superpowers/plans/2026-05-10-mobile-foundation.md
+++ b/docs/superpowers/plans/2026-05-10-mobile-foundation.md
@@ -1,0 +1,1192 @@
+# v3.3.0 Mobile Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tornar `src/public/obras.html` totalmente operacional em viewports mobile (≤768px) através de CSS utility classes + safety net, sem mexer em backend.
+
+**Architecture:** Três camadas: (1) utility classes `.lp-grid-2/3/4/5/auto` que colapsam para 1 coluna em ≤768px e para 2 colunas em 769-900px para grids de 4-5; (2) refactor incremental de inline grids para essas classes, view por view; (3) safety net global `[style*="grid-template-columns"]:not([data-keep-grid])` que força 1 coluna para qualquer inline grid não migrado. Calendário e tabelas legítimas multi-coluna usam opt-out `data-keep-grid`.
+
+**Tech Stack:** Vanilla HTML/CSS dentro de `obras.html` (~16k linhas), Service Worker (`sw.js`) para cache-busting, sem novas dependências.
+
+**Estratégia de PRs:** 3 PRs sequenciais (PR1 foundation, PR2 refactor view-by-view, PR3 modais + patches). **Ordem dos commits do PR1 é crítica** — bump de CACHE em `sw.js` é o ÚLTIMO commit, garantindo que CSS novo já está nos arquivos antes de invalidar o cache.
+
+**Spec:** [docs/superpowers/specs/2026-05-10-mobile-foundation-design.md](../specs/2026-05-10-mobile-foundation-design.md)
+
+---
+
+## File Structure
+
+**Modified files (apenas frontend, zero backend):**
+- `src/public/obras.html` — adiciona `<style>` foundation + refactora inline grids view-a-view
+- `src/public/sw.js` — bump de `CACHE` constant
+- `package.json` — bump version
+- `src/agent/identity.ts` — bump version (sincroniza com package.json)
+
+**No new files.** No tests files (sem testes automatizados — validação visual em viewports).
+
+---
+
+## DOR (Definition of Ready) — Antes de começar
+
+- [ ] Branch criada: `git checkout -b feat/mobile-foundation-v3.3.0` a partir de `main` atualizado
+- [ ] `npm run typecheck` passa em `main` antes do trabalho começar
+- [ ] Chrome DevTools aberto com Device Toolbar (Ctrl+Shift+M) — vai ser usado em todas as tasks
+
+---
+
+## DOD (Definition of Done) — Critério universal de cada task de refactor visual
+
+**TODA task que mexe em layout DEVE terminar com este teste manual:**
+
+1. Abrir `http://localhost:PORT/obras` no Chrome
+2. Abrir DevTools → Device Toolbar → escolher **Pixel 7** (412×915) → percorrer a view modificada → confirmar **sem scroll horizontal**
+3. Trocar viewport para **iPhone SE / Galaxy A** equivalente (360×800) → repetir → confirmar **sem scroll horizontal**
+4. Trocar viewport para **Desktop** (1280×800) → confirmar que **nada quebrou acima do breakpoint**
+
+**Se aparecer scroll horizontal em qualquer um dos dois viewports mobile → task NÃO está done.** Investigar (provavelmente sobrou inline grid não-migrado OU input com width fixo OU tabela sem overflow).
+
+---
+
+# PR1 — Foundation (ordem dos commits é crítica)
+
+**Objetivo:** estabelecer base CSS + bump de versão SEM invalidar cache enquanto código novo não está completo no arquivo. Bump do `CACHE` em `sw.js` é o **último** commit.
+
+**Branch:** `feat/mobile-foundation-v3.3.0` (continua no PR2 e PR3 também, ou abre PRs separados — decisão de governança).
+
+**Tempo estimado:** ~30min
+
+---
+
+### Task 1.1: Adicionar utility classes ao `<style>` global
+
+**Files:**
+- Modify: `src/public/obras.html` — após linha 105 (após `@media (max-width:600px) { .form-grid... }`)
+
+- [ ] **Step 1: Localizar âncora de inserção**
+
+Run: usar Grep com pattern `@media \(max-width: 600px\) { \.form-grid` em `obras.html`.
+Expected: deve achar linha ~105.
+
+- [ ] **Step 2: Inserir bloco de utility classes após linha 105**
+
+Adicionar este bloco logo após `@media (max-width: 600px) { .form-grid { grid-template-columns: 1fr; } }`:
+
+```css
+  /* === LP-GRID: utility classes responsivas (v3.3.0) === */
+  .lp-grid-auto {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 8px;
+  }
+  .lp-grid-2 { display: grid; grid-template-columns: 1fr 1fr;        gap: 8px; }
+  .lp-grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr;    gap: 8px; }
+  .lp-grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+  .lp-grid-5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
+
+  @media (max-width: 768px) {
+    .lp-grid-auto, .lp-grid-2, .lp-grid-3, .lp-grid-4, .lp-grid-5 {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 900px) and (min-width: 769px) {
+    .lp-grid-4, .lp-grid-5 { grid-template-columns: 1fr 1fr; }
+  }
+```
+
+- [ ] **Step 3: Verificar typecheck e que página carrega**
+
+Run: `npm run typecheck` (não toca em TS, mas confirma que nada quebrou).
+Expected: PASS.
+
+Abrir `http://localhost:PORT/obras` no Chrome → confirmar que a página carrega normalmente em desktop. Nada usa as classes novas ainda, então não deve haver mudança visual.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): add lp-grid utility classes for responsive layout"
+```
+
+---
+
+### Task 1.2: Adicionar safety net catch-all
+
+**Files:**
+- Modify: `src/public/obras.html` — após o bloco da Task 1.1
+
+- [ ] **Step 1: Inserir safety net logo após as utility classes**
+
+Adicionar este bloco imediatamente após o `@media (max-width: 900px)` da Task 1.1:
+
+```css
+  /* === SAFETY NET: força 1 coluna em qualquer inline grid não migrado === */
+  @media (max-width: 768px) {
+    [style*="grid-template-columns"]:not([data-keep-grid]) {
+      grid-template-columns: 1fr !important;
+    }
+  }
+```
+
+- [ ] **Step 2: Smoke test em 360×800 — DEVE quebrar visivelmente em vários lugares e funcionar em outros**
+
+Abrir `http://localhost:PORT/obras` no Chrome, DevTools → Device Toolbar → Pixel 5/Galaxy A (360×800).
+
+Percorrer Painel, Obras, Despesas: a maioria dos grids inline agora deve estar empilhada em 1 coluna. Pode haver problemas estéticos (gap inconsistente, alinhamentos esquisitos) — **isso é esperado** e será resolvido no PR2 com a migração para utility classes. O que importa neste smoke test é:
+
+- ✅ Scroll horizontal sumiu na maioria das telas
+- ✅ Nenhum elemento ficou totalmente quebrado/invisível
+- ✅ Calendário (se acessar) provavelmente quebrou — vai ser fixado com `data-keep-grid` no PR3 Task 3.7
+
+**Se aparecer crash de JS ou tela totalmente em branco → safety net está atingindo algo que não devia. Revisar seletor.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): add safety net forcing 1-col grid below 768px"
+```
+
+---
+
+### Task 1.3: Bump de versão em `package.json` e `identity.ts`
+
+**Files:**
+- Modify: `package.json:3` (version field)
+- Modify: `src/agent/identity.ts:4` (version field)
+
+- [ ] **Step 1: Bumpar package.json**
+
+Editar `package.json` linha 3, trocar `"version": "3.2.0"` por `"version": "3.3.0"`.
+
+- [ ] **Step 2: Bumpar identity.ts**
+
+Editar `src/agent/identity.ts` linha 4, trocar `version: '3.2.0',` por `version: '3.3.0',`.
+
+- [ ] **Step 3: Verificar consistência**
+
+Run:
+```bash
+grep -E "3\.[23]\.0" package.json src/agent/identity.ts src/public/sw.js
+```
+Expected:
+- `package.json: "version": "3.3.0"`
+- `identity.ts: version: '3.3.0',`
+- `sw.js: const CACHE = 'zayra-v3.2.0';` (ainda 3.2.0 — será bumpado no último commit do PR1)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json src/agent/identity.ts
+git commit -m "chore(v3.3.0): bump package.json and identity.ts to 3.3.0"
+```
+
+---
+
+### Task 1.4: Bump do `CACHE` em `sw.js` — ÚLTIMO COMMIT DO PR1
+
+**⚠️ ORDEM CRÍTICA:** Este commit é o ÚLTIMO do PR1. Razão: o bump de CACHE força clients abertos a baixar HTML/CSS novo. Se este commit for antes dos commits 1.1-1.3, clients que abrirem entre commits pegam uma versão inconsistente (CSS novo sem utility classes ainda definidas, ou versão bumpada com SW ainda apontando pra cache antigo).
+
+**Files:**
+- Modify: `src/public/sw.js:4`
+
+- [ ] **Step 1: Bumpar constante CACHE**
+
+Editar `src/public/sw.js` linha 4, trocar `const CACHE = 'zayra-v3.2.0';` por `const CACHE = 'zayra-v3.3.0';`.
+
+- [ ] **Step 2: Verificar que SW continua íntegro**
+
+Abrir `src/public/sw.js` e confirmar visualmente que:
+- Linha 4: `const CACHE = 'zayra-v3.3.0';`
+- Linha 33: ainda tem `.then(() => self.skipWaiting())` no install
+- Linha 42: ainda tem `await self.clients.claim();` no activate
+- Linha 86-99: ainda tem o bloco network-first para HTML
+
+Nenhum outro código no SW muda. Apenas a constante.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/public/sw.js
+git commit -m "chore(v3.3.0): bump SW cache to zayra-v3.3.0 (last commit of PR1)"
+```
+
+- [ ] **Step 4: Push branch e abrir PR1**
+
+```bash
+git push -u origin feat/mobile-foundation-v3.3.0
+gh pr create --title "v3.3.0 PR1: Mobile foundation (utility classes + safety net + cache bump)" --body "$(cat <<'EOF'
+## Summary
+- Adiciona utility classes `.lp-grid-auto`/`.lp-grid-2/3/4/5` para grids responsivos
+- Adiciona safety net que força 1-col em qualquer inline grid em viewport ≤768px (opt-out via `data-keep-grid`)
+- Bump 3.2.0 → 3.3.0 em package.json, identity.ts e sw.js (CACHE)
+
+**Ordem dos commits crítica:** CACHE bump em sw.js é o ÚLTIMO commit — garante que utility classes + safety net já estão no HTML antes de invalidar cache.
+
+PRs seguintes (PR2 view-by-view refactor, PR3 modais + patches) continuam o trabalho.
+
+Spec: docs/superpowers/specs/2026-05-10-mobile-foundation-design.md
+
+## Test plan
+- [x] `npm run typecheck` passa
+- [x] Smoke test em 360×800: safety net colapsa grids visivelmente, sem crashes
+- [x] Smoke test em desktop: nada quebrou acima do breakpoint
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+# PR2 — Refactor View-by-View (uma task por área navegacional)
+
+**Objetivo:** substituir inline grids por utility classes view por view. Tasks **agrupadas por área navegacional** (não por tipo de mudança) — isso permite testar incrementalmente em viewport ao terminar cada task.
+
+**Branch:** continua em `feat/mobile-foundation-v3.3.0` OU abre branch separada `feat/mobile-pr2-views` (governança do CEO decide).
+
+**Tempo estimado:** ~7-10h total. Cada task ~20-45min.
+
+**Padrão de mapeamento (consultar em todas as tasks):**
+
+| Inline atual | Classe |
+|---|---|
+| `display:grid; grid-template-columns:1fr 1fr` | `class="lp-grid-2"` |
+| `display:grid; grid-template-columns:1fr 1fr 1fr` ou `repeat(3,1fr)` | `class="lp-grid-3"` |
+| `display:grid; grid-template-columns:repeat(4,1fr)` | `class="lp-grid-4"` |
+| `display:grid; grid-template-columns:repeat(5,1fr)` | `class="lp-grid-5"` |
+| `display:grid; grid-template-columns:1fr 2fr` (e outros proporcionais) | `class="lp-grid-auto"` |
+| `display:grid; grid-template-columns:repeat(auto-fit, minmax(...))` | **MANTER inline** — já é responsivo |
+| Calendário, tabelas que devem permanecer grid em mobile | Adicionar `data-keep-grid` ao elemento |
+
+**Preservar:** `gap`, `margin-top`, `margin-bottom`, `align-items`, `padding` e outras propriedades inline que não sejam relacionadas a `grid-template-columns`/`display:grid`. Exemplo de transformação:
+
+Antes:
+```html
+<div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-top:6px;">
+```
+
+Depois:
+```html
+<div class="lp-grid-2" style="margin-top:6px;">
+```
+
+(o `gap:8px` está incluído na classe; outras propriedades inline preservadas)
+
+---
+
+### Task 2.1: Refatorar Painel (área header + cards de obra ativa)
+
+**Files:**
+- Modify: `src/public/obras.html` linhas ~1700-1818 (região do Painel — entre header global e `function renderObras()`)
+
+- [ ] **Step 1: Listar inline grids no range 1700-1818**
+
+Run: usar Grep `grid-template-columns` em `obras.html` com `-n` true, filtrar manualmente linhas 1700-1818.
+
+Linhas esperadas (verificar exatamente quais aparecem):
+- Linha ~1707: `repeat(auto-fit, minmax(280px, 1fr))` — **MANTER** (já responsivo)
+
+Se não houver outros, esta task é trivial.
+
+- [ ] **Step 2: Aplicar mapeamento (se houver não-auto-fit)**
+
+Para cada grid não-auto-fit encontrado, aplicar a tabela de mapeamento acima.
+
+- [ ] **Step 3: Validar em 360×800 (DOD)**
+
+Chrome DevTools → Device Toolbar → 360×800 → abrir Painel.
+- ✅ Cards de obra ativa empilhados verticalmente
+- ✅ Sem scroll horizontal
+- ✅ Botões com ≥44px de altura tocável
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+Trocar viewport para 412×915 → repetir checklist do step 3.
+
+- [ ] **Step 5: Validar em desktop 1280×800**
+
+Confirmar que nada quebrou acima do breakpoint.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor Painel view to lp-grid utility classes"
+```
+
+---
+
+### Task 2.2: Refatorar `renderObras()` (lista de obras + form)
+
+**Files:**
+- Modify: `src/public/obras.html` — função `renderObras()` em ~linha 1819 até início de `renderFinanceiro()` em ~2823
+
+- [ ] **Step 1: Listar inline grids no range 1819-2823**
+
+Run: Grep `grid-template-columns` em `obras.html` filtrando linhas 1819-2823.
+
+- [ ] **Step 2: Aplicar mapeamento conforme tabela**
+
+Para cada grid encontrado, aplicar transformação. Casos especiais:
+- Se encontrar `grid-template-columns:repeat(auto-fit, minmax(Npx, 1fr))` com N ≥ 200 → MANTER inline (já é responsivo, e o minmax garante que vira 1-col em mobile naturalmente)
+- Se encontrar `1fr 70px 100px 30px` ou similar (tabelas inline) → **NÃO converter** — adicionar `data-keep-grid` SE for legítimo manter grid em mobile, caso contrário deixar a safety net colapsar
+
+- [ ] **Step 3: Validar em 360×800 (DOD)**
+
+DevTools 360×800 → percorrer lista de Obras → criar/editar uma obra → confirmar:
+- ✅ Sem scroll horizontal
+- ✅ Form de cadastro completável
+- ✅ Botões tocáveis
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+Trocar viewport, repetir.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderObras to lp-grid utility classes"
+```
+
+---
+
+### Task 2.3: Refatorar `renderFinanceiro()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderFinanceiro()` em ~linha 2824 até início de `renderEquipe()` em ~2951
+
+- [ ] **Step 1: Listar inline grids no range 2824-2951**
+
+Run: Grep filtrando essas linhas.
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+- [ ] **Step 3: Validar em 360×800 (DOD)**
+
+DevTools 360×800 → aba Financeiro → confirmar sem scroll horizontal. Atenção a tabelas/cards de receita/despesa que tendem a ter colunas fixas.
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderFinanceiro to lp-grid utility classes"
+```
+
+---
+
+### Task 2.4: Refatorar `renderEquipe()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderEquipe()` em ~linha 2952 até início de `renderDespesasExtras()` em ~3161
+
+- [ ] **Step 1: Listar inline grids no range 2952-3161**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Equipe → confirmar listagem de membros legível, ações tocáveis
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderEquipe to lp-grid utility classes"
+```
+
+---
+
+### Task 2.5: Refatorar `renderDespesasExtras()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderDespesasExtras()` em ~linha 3162 até início de `renderMateriais()` em ~3769
+
+- [ ] **Step 1: Listar inline grids no range 3162-3769**
+
+Pelo Grep prévio, sei que linhas 3259, 3465, 3473, 3492, 3534 têm grids. Conferir e mapear cada uma.
+
+Notar especialmente linhas 3492 e 3534 que têm `1fr 70px 100px 30px` — provável tabela inline. Avaliar se deve virar `data-keep-grid` ou deixar a safety net colapsar (decisão depende se a leitura em 1-col faz sentido).
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Despesas Extras → adicionar despesa, listar despesas, confirmar sem scroll horizontal
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderDespesasExtras to lp-grid utility classes"
+```
+
+---
+
+### Task 2.6: Refatorar `renderMateriais()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderMateriais()` em ~linha 3770 até `renderMarcarDias()` em ~3945
+
+- [ ] **Step 1: Listar inline grids no range 3770-3945**
+- [ ] **Step 2: Aplicar mapeamento**
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Materiais
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderMateriais to lp-grid utility classes"
+```
+
+---
+
+### Task 2.7: Refatorar `renderMarcarDias()` + `renderFolha()` + `renderFolhaSaldoHTML()`
+
+**Files:**
+- Modify: `src/public/obras.html` — linhas ~3946 a ~4613 (três funções correlatas — agendamento e folha mensal)
+
+- [ ] **Step 1: Listar inline grids no range 3946-4613**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+⚠️ **Atenção especial ao Calendário:** se houver grid `repeat(7, 1fr)` para dias da semana → **NÃO converter**, **adicionar `data-keep-grid`** ao elemento. Calendário deve permanecer 7 colunas mesmo em mobile (UX padrão de calendário).
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — Marcar Dias + Folha Mensal → calendário continua 7-col, listas de horários empilhadas
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor MarcarDias/Folha views to lp-grid utility classes"
+```
+
+---
+
+### Task 2.8: Refatorar `renderVto()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderVto()` em ~linha 4614 até `renderPropostasLista()` em ~4935
+
+- [ ] **Step 1: Listar inline grids no range 4614-4935**
+- [ ] **Step 2: Aplicar mapeamento**
+- [ ] **Step 3: Validar em 360×800 (DOD)** — Vistoria → form de vistoria, checklist, fotos
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderVto to lp-grid utility classes"
+```
+
+---
+
+### Task 2.9: Refatorar `renderPropostasLista()` + `renderPropostaEditor()`
+
+**Files:**
+- Modify: `src/public/obras.html` — linhas ~4936 a ~9099 (duas funções grandes do módulo Proposta; ~4000 linhas no total)
+
+⚠️ **Esta é a maior task do PR2.** Considerar dividir em 2 sub-commits: lista primeiro, editor depois.
+
+- [ ] **Step 1a: Listar inline grids no range 4936-7292 (Lista)**
+
+Pelo Grep prévio, sei que há ~10 grids entre 5346 e 5947. Mapear cada.
+
+- [ ] **Step 2a: Aplicar mapeamento (Lista)**
+
+- [ ] **Step 3a: Validar em 360×800 (DOD) - Lista** — abrir aba Propostas, ver lista de propostas existentes
+
+- [ ] **Step 4a: Commit intermediário**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderPropostasLista to lp-grid utility classes"
+```
+
+- [ ] **Step 1b: Listar inline grids no range 7293-9099 (Editor)**
+
+Há ~15+ grids entre 7118 e 8058. Mapear cada.
+
+- [ ] **Step 2b: Aplicar mapeamento (Editor)**
+
+- [ ] **Step 3b: Validar em 360×800 (DOD) - Editor** — criar/editar uma proposta, percorrer todas as seções do editor
+
+- [ ] **Step 4b: Validar em 412×915 (DOD) - Editor**
+
+- [ ] **Step 5b: Commit final da task**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderPropostaEditor to lp-grid utility classes"
+```
+
+---
+
+### Task 2.10: Refatorar `renderRecibos()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderRecibos()` em ~linha 9100 até `renderNotas()` em ~10670
+
+- [ ] **Step 1: Listar inline grids no range 9100-10670**
+
+Pelo Grep prévio, sei das linhas 9196, 9521, 9543, 9561, 9572. Mapear.
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+⚠️ Linha 9521 tem `minmax(0, 3fr) minmax(0, 2fr)` — é o split do editor de recibo. Avaliar se em mobile faz sentido empilhar (provavelmente sim — o painel de preview do PDF abaixo do form é mais usável que lado-a-lado em mobile).
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Recibos → criar recibo, gerar PDF, enviar WhatsApp
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderRecibos to lp-grid utility classes"
+```
+
+---
+
+### Task 2.11: Refatorar `renderNotas()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderNotas()` em ~linha 10671 até `renderCalculos()` em ~11109
+
+- [ ] **Step 1: Listar inline grids no range 10671-11109**
+- [ ] **Step 2: Aplicar mapeamento**
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Notas Fiscais → emitir nota, listar notas
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderNotas to lp-grid utility classes"
+```
+
+---
+
+### Task 2.12: Refatorar `renderCalculos()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderCalculos()` em ~linha 11110 até `renderLaudoTabCadastros()` em ~14095
+
+⚠️ **Range grande (~3000 linhas)** — pode ter calculadoras múltiplas (ITBI, IPTU, comissão, etc). Considerar dividir em sub-commits por calculadora.
+
+- [ ] **Step 1: Listar inline grids no range 11110-14095**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Cálculos → percorrer cada calculadora disponível, preencher inputs, verificar resultado
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit (ou múltiplos commits se dividir por calculadora)**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderCalculos to lp-grid utility classes"
+```
+
+---
+
+### Task 2.13: Refatorar `renderLaudoTabCadastros()` (aba "Cadastros" do laudo, ≈ Registral do spec)
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLaudoTabCadastros()` em ~linha 14096 até `renderLaudoTabDados()` em ~14361
+
+- [ ] **Step 1: Listar inline grids no range 14096-14361**
+- [ ] **Step 2: Aplicar mapeamento**
+- [ ] **Step 3: Validar em 360×800 (DOD)** — abrir um laudo → aba Cadastros → preencher campos do cabeçalho/registral
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo tab Cadastros to lp-grid utility classes"
+```
+
+---
+
+### Task 2.14: Refatorar `renderLaudoTabDados()` (aba "Dados" do laudo)
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLaudoTabDados()` em ~linha 14362 até `renderLaudoTabPontos()` em ~14655
+
+⚠️ **Esta é a aba que o CEO mostrou nos screenshots — é o caso de uso primário.** Atenção redobrada à grid de Medida/Confrontante (era a que estava cortando "Confro...").
+
+- [ ] **Step 1: Listar inline grids no range 14362-14655**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+Especificamente:
+- Linha ~15081: `grid-template-columns: 1fr 2fr` (Medida/Confrontante) → `class="lp-grid-auto"` (vai virar 1-col em mobile naturalmente)
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — abrir laudo → aba Dados → confirmar que **"Confrontante" aparece completo** sem ser cortado, **"Medida (m)" tem largura adequada**
+
+- [ ] **Step 4: Validar em 412×915 (DOD)** — repetir com Pixel 7
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo tab Dados to lp-grid utility classes"
+```
+
+---
+
+### Task 2.15: Refatorar `renderLaudoTabPontos()` (aba "Pontos" — vértices e medidas)
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLaudoTabPontos()` em ~linha 14656 até `renderLaudoTabCroqui()` em ~15879
+
+⚠️ **TAMBÉM é uma aba que o CEO usa em campo no rugged GNSS.** Atenção especial ao grid de vértices (linha ~15005):
+
+```html
+<div style="display:grid; grid-template-columns: repeat(${cols}, 1fr); gap:6px; margin-top:6px;">
+```
+
+Esse `${cols}` é dinâmico (2 ou 3 dependendo de UTM+LatLng). A safety net JÁ vai colapsar isso em mobile (porque é inline). Mesmo assim, vale converter para `class="lp-grid-auto"` (preservando o `gap:6px; margin-top:6px;` inline) para consistência.
+
+- [ ] **Step 1: Listar inline grids no range 14656-15879**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+Cuidados:
+- Grids de pontos UTM/LatLng (vértices) → `class="lp-grid-auto"` (substituir o `repeat(${cols}, 1fr)`)
+- Grid Medida/Confrontante por lado → `class="lp-grid-auto"`
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — abrir laudo → aba Pontos → confirmar que cada ponto (P1, P2, P3, P4) e cada lado (Frente, Lateral Direita, etc) ficam empilhados verticalmente, sem corte
+
+- [ ] **Step 4: Validar em 412×915 (DOD)** — repetir com Pixel 7
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo tab Pontos to lp-grid utility classes"
+```
+
+---
+
+### Task 2.16: Refatorar `renderLaudoTabCroqui()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLaudoTabCroqui()` em ~linha 15880 até `renderLaudoTabFotos()` em ~15943
+
+- [ ] **Step 1: Listar inline grids no range 15880-15943**
+- [ ] **Step 2: Aplicar mapeamento**
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Croqui → preview do croqui legível, controles tocáveis
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo tab Croqui to lp-grid utility classes"
+```
+
+---
+
+### Task 2.17: Refatorar `renderLaudoTabFotos()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLaudoTabFotos()` em ~linha 15944 até `renderLaudoTabArt()` em ~16079
+
+- [ ] **Step 1: Listar inline grids no range 15944-16079**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+Atenção: galeria de fotos provavelmente usa `repeat(auto-fit, minmax(150px, 1fr))` ou similar — MANTER se for o caso.
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Fotos → upload, galeria, edição de legenda
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo tab Fotos to lp-grid utility classes"
+```
+
+---
+
+### Task 2.18: Refatorar `renderLaudoTabArt()` (aba ART + Precificação INCRA + Assinatura)
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLaudoTabArt()` em ~linha 16080 até `renderLoteamentos()` em ~16434
+
+⚠️ Esta aba contém o bloco grande de Precificação INCRA (v3.0.0) + ART/TRT + Responsabilidade Técnica + Assinatura. Atenção a:
+- 6 steppers de critérios INCRA — provavelmente `grid-template-columns:repeat(6,1fr)` ou similar
+- Bloco "Valor aplicado" + "Desconto" + "VALOR FINAL"
+- Caixa de assinatura
+
+- [ ] **Step 1: Listar inline grids no range 16080-16434**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba ART → preencher critérios INCRA, ver valor calculado, área de assinatura tocável
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo tab Art to lp-grid utility classes"
+```
+
+---
+
+### Task 2.19: Refatorar `renderLoteamentos()`
+
+**Files:**
+- Modify: `src/public/obras.html` — `renderLoteamentos()` em ~linha 16435 até fim do bloco de funções de render
+
+- [ ] **Step 1: Listar inline grids no range 16435-EOF (das funções de render)**
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+⚠️ Loteamentos tem autocompletes encadeados (Loteamento→Quadra→Lote). Verificar se grids do autocomplete são `repeat(auto-fit, minmax(...))` (manter) ou fixos.
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — aba Loteamentos → autocomplete Loteamento → Quadra → Lote → preencher dados de lote
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor renderLoteamentos to lp-grid utility classes"
+```
+
+---
+
+### Task 2.20: Push PR2
+
+- [ ] **Step 1: Conferir que todas as 19 tasks acima estão concluídas e validadas**
+
+Rodar checagem manual: `git log --oneline feat/mobile-foundation-v3.3.0..HEAD` — deve listar ~19 commits de refactor (mais os 4 do PR1 se PR2 está na mesma branch).
+
+- [ ] **Step 2: QA spot-check em 360×800 e 412×915 — viewport mobile primário**
+
+Abrir cada view (Painel, Obras, Financeiro, Equipe, Despesas, Materiais, MarcarDias, Folha, Vto, Propostas, Recibos, Notas, Calculos, Laudo todas abas, Loteamentos) em 360×800 → confirmar **nenhuma** tem scroll horizontal.
+
+- [ ] **Step 3: Push e abrir PR2**
+
+```bash
+git push origin feat/mobile-foundation-v3.3.0
+gh pr create --title "v3.3.0 PR2: Refactor view-by-view (inline grids → lp-grid classes)" --body "$(cat <<'EOF'
+## Summary
+Substitui inline grids (`style="display:grid; grid-template-columns: ..."`) por utility classes (`class="lp-grid-X"`) em todas as 17+ views principais.
+
+Tasks executadas (uma por área navegacional, conforme governança):
+- Painel, Obras, Financeiro, Equipe, Despesas Extras, Materiais
+- Marcar Dias + Folha, Vto
+- Propostas (Lista + Editor)
+- Recibos, Notas, Cálculos
+- Laudo: Cadastros, Dados, Pontos, Croqui, Fotos, Art
+- Loteamentos
+
+Cada commit corresponde a uma view completa — permite rollback granular se necessário.
+
+## Test plan
+Validado em 360×800 (Galaxy A baseline) e 412×915 (Pixel 7) para CADA view:
+- [x] Sem scroll horizontal
+- [x] Botões tocáveis ≥44px
+- [x] Formulários completam normalmente
+- [x] Nada quebrou em desktop 1280×800
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+# PR3 — Modais + Patches Secundários
+
+**Objetivo:** fechar gaps remanescentes — modais (que muitas vezes têm CSS isolado), inputs/botões com problemas específicos, tabelas problemáticas.
+
+**Tempo estimado:** ~2-3h
+
+---
+
+### Task 3.1: Refatorar modal "Editar Obra" (`#editModal`)
+
+**Files:**
+- Modify: `src/public/obras.html` — bloco do `#editModal` em ~linha 687-855
+
+- [ ] **Step 1: Listar inline grids no range 687-855**
+
+Já sei que linha 864 tem `<div style="display:grid; grid-template-columns:1fr 2fr; gap:10px;">` — converter para `class="lp-grid-auto"`.
+
+- [ ] **Step 2: Aplicar mapeamento**
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — clicar em editar uma obra → modal abre, form usável
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor modal Editar Obra to lp-grid utility classes"
+```
+
+---
+
+### Task 3.2: Refatorar modal Calendário (`.cal-modal`) — com `data-keep-grid`
+
+**Files:**
+- Modify: `src/public/obras.html` — bloco do calendário, especialmente `<div class="cal-grid">` em região ~242-249 (CSS) e ~3946+ (uso)
+
+- [ ] **Step 1: Verificar onde o `.cal-grid` é renderizado e adicionar `data-keep-grid`**
+
+Localizar o elemento `<div class="cal-grid">` (provavelmente dentro de `renderMarcarDias()` ou função do calendário).
+
+Adicionar atributo `data-keep-grid`:
+```html
+<div class="cal-grid" data-keep-grid>
+```
+
+⚠️ A classe `.cal-grid` já define `grid-template-columns: repeat(7, ...)` no CSS global (linha 243) — não é inline. Mas a safety net não atinge classes do CSS global, apenas inline. Então o `data-keep-grid` aqui é DEFENSIVO — caso alguém futuramente migre essa classe para inline ou adicione inline override.
+
+**Alternativa:** adicionar regra explícita no CSS para manter o calendário em 7 colunas mesmo em mobile (mais robusta):
+
+```css
+@media (max-width: 768px) {
+  .cal-grid { grid-template-columns: repeat(7, minmax(0, 1fr)) !important; }
+}
+```
+
+Adicionar isso no `<style>` global, no bloco `@media (max-width: 768px)` existente perto da linha 327.
+
+- [ ] **Step 2: Validar em 360×800 (DOD)** — abrir calendário → confirmar 7 colunas de dias da semana mantidas, dias clicáveis tocáveis (≥44px)
+
+- [ ] **Step 3: Validar em 412×915 (DOD)**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): preserve calendar 7-col grid in mobile via explicit rule"
+```
+
+---
+
+### Task 3.3: Refatorar modal Cartão de Visitas (`#cartaoModal` ou similar)
+
+**Files:**
+- Modify: `src/public/obras.html` — bloco do cartão (procurar por "cartao" ou `Z-CARD`)
+
+- [ ] **Step 1: Localizar bloco do cartão**
+
+Run: Grep `data-cartao|cartaoModal|#cartao` em `obras.html`.
+
+- [ ] **Step 2: Listar inline grids no bloco encontrado**
+
+- [ ] **Step 3: Aplicar mapeamento**
+
+- [ ] **Step 4: Validar em 360×800 (DOD)** — abrir modal cartão → preview do cartão legível, form usável
+
+- [ ] **Step 5: Validar em 412×915 (DOD)**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor cartao modal to lp-grid utility classes"
+```
+
+---
+
+### Task 3.4: Refatorar painel ZAYRA chat (`.zayra-modal`)
+
+**Files:**
+- Modify: `src/public/obras.html` — bloco do chat ZAYRA em ~linha 175-212 (CSS) e em qualquer uso inline
+
+- [ ] **Step 1: Verificar CSS já existente do `.zayra-modal`**
+
+Já tem `@media (max-width: 600px)` na linha 172 que ajusta o `.zayra-cam-fab`. Conferir se o `.zayra-modal` também tem ajuste mobile (parece ter na linha 396 `.zayra-modal { bottom: 80px; right: 16px; left: 16px; max-height: 60vh; }`).
+
+- [ ] **Step 2: Listar inline grids dentro do modal ZAYRA (se houver)**
+
+Run: Grep dentro do bloco do chat.
+
+- [ ] **Step 3: Aplicar mapeamento (se houver)**
+
+- [ ] **Step 4: Validar em 360×800 (DOD)** — clicar no FAB ZAYRA → modal abre, input acessível com teclado mobile
+
+- [ ] **Step 5: Validar em 412×915 (DOD)**
+
+- [ ] **Step 6: Commit (se houver mudança)**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor ZAYRA chat modal to lp-grid utility classes"
+```
+
+---
+
+### Task 3.5: Refatorar autocomplete cartórios (v3.2.0)
+
+**Files:**
+- Modify: `src/public/obras.html` — dropdown do autocomplete cartórios em `setupCartorioAutocomplete()`
+
+- [ ] **Step 1: Localizar dropdown do autocomplete**
+
+Run: Grep `setupCartorioAutocomplete|ld-cartorio-sugestoes` em `obras.html`.
+
+- [ ] **Step 2: Verificar layout dos itens do dropdown**
+
+Cada item provavelmente tem `denominação + cidade/UF + CNS + responsável` — verificar se está usando inline grid ou flex column.
+
+- [ ] **Step 3: Aplicar mapeamento se necessário**
+
+- [ ] **Step 4: Validar em 360×800 (DOD)** — abrir laudo → campo Cartório → digitar 3+ letras → dropdown abre, itens legíveis, clicáveis
+
+- [ ] **Step 5: Validar em 412×915 (DOD)**
+
+- [ ] **Step 6: Commit (se houver mudança)**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): adjust cartorio autocomplete dropdown for mobile"
+```
+
+---
+
+### Task 3.6: Refatorar modal de Clonagem de Laudo (v3.1.0)
+
+**Files:**
+- Modify: `src/public/obras.html` — bloco do modal de clonagem (procurar por "clonar" ou "clonagem")
+
+- [ ] **Step 1: Localizar modal de clonagem**
+
+Run: Grep `clonar|clonagem|data-clone` em `obras.html`.
+
+- [ ] **Step 2: Listar inline grids no bloco**
+
+- [ ] **Step 3: Aplicar mapeamento**
+
+- [ ] **Step 4: Validar em 360×800 (DOD)** — abrir laudo → clonar → modal/fluxo de clonagem usável
+
+- [ ] **Step 5: Validar em 412×915 (DOD)**
+
+- [ ] **Step 6: Commit (se houver mudança)**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): refactor laudo clone modal to lp-grid utility classes"
+```
+
+---
+
+### Task 3.7: Fix inputs com `width: 170px` (e similares)
+
+**Files:**
+- Modify: `src/public/obras.html` — qualquer inline `style="width: 170px"`, `width: 200px`, etc
+
+- [ ] **Step 1: Listar todos os inputs com width fixo**
+
+Run: Grep `style="[^"]*width: ?[0-9]+px` em `obras.html` (sem `max-`).
+
+Notar: a regra de não confundir com `max-width: 170px` (que já está OK).
+
+- [ ] **Step 2: Para cada um, decidir se converter**
+
+Critério:
+- ✅ Converter se for input/select de form (largura inadequada em mobile)
+- ❌ NÃO converter se for ícone fixo, imagem com dimensão exata, ou contexto onde 170px é OK
+
+Conversão:
+```html
+<!-- Antes -->
+<input style="width: 170px">
+<!-- Depois -->
+<input style="width: 100%; max-width: 170px">
+```
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — inputs convertidos esticam até o pai sem ultrapassar 170px no desktop
+
+- [ ] **Step 4: Validar em desktop 1280×800** — inputs convertidos continuam aparentando 170px (porque o pai é mais largo)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): convert fixed-width inputs to width:100%/max-width pattern"
+```
+
+---
+
+### Task 3.8: Fix botões com padding < 44px
+
+**Files:**
+- Modify: `src/public/obras.html` — botões com `padding: 2px 8px`, `padding: 3px 6px`, etc
+
+- [ ] **Step 1: Listar botões com padding pequeno**
+
+Run: Grep `<button[^>]*style="[^"]*padding: ?[12345]px` em `obras.html`.
+
+- [ ] **Step 2: Avaliar cada um**
+
+Botões inline com padding pequeno tendem a ser ações secundárias (lixeira, fechar, ícone). A regra global `@media (max-width: 768px) { button { min-height: 44px } }` já força 44px mesmo com padding pequeno — então essa task pode ser **bem pequena ou nula** se a regra global está pegando todos.
+
+**Verificar primeiro no DevTools 360×800:** se algum botão visualmente está < 44px de altura, INVESTIGAR por que a regra global não está pegando (provavelmente specificity de inline `min-height` ou similar).
+
+- [ ] **Step 3: Aplicar fix nos casos identificados**
+
+- [ ] **Step 4: Validar em 360×800 (DOD)** — todos os botões da app tocáveis (44×44px mínimo)
+
+- [ ] **Step 5: Commit (se houver mudança)**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): ensure all buttons reach 44px touch target"
+```
+
+---
+
+### Task 3.9: Fix tabelas que extrapolam viewport
+
+**Files:**
+- Modify: `src/public/obras.html` — `<table>` que estouram em mobile
+
+- [ ] **Step 1: Identificar tabelas problemáticas**
+
+Run: Grep `<table` em `obras.html`. Pra cada uma encontrada, conferir em DevTools 360×800 se causa scroll horizontal.
+
+- [ ] **Step 2: Para cada tabela problemática, envolver em wrapper**
+
+```html
+<!-- Antes -->
+<table>...</table>
+
+<!-- Depois -->
+<div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
+  <table>...</table>
+</div>
+```
+
+Já existe regra `@media (max-width:768px) { .card table, .cal-modal table { font-size: 11px; }` (linha 422) que reduz tamanho da fonte. O wrapper de overflow é complementar — garante que o usuário pode rolar horizontalmente DENTRO da tabela sem afetar o resto da página.
+
+- [ ] **Step 3: Validar em 360×800 (DOD)** — cada tabela acessível, sem fazer a página inteira rolar horizontal
+
+- [ ] **Step 4: Validar em 412×915 (DOD)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/public/obras.html
+git commit -m "feat(mobile): wrap wide tables in overflow-x scroll containers"
+```
+
+---
+
+### Task 3.10: QA completo final + push PR3
+
+- [ ] **Step 1: Roteiro completo de QA em 7 viewports**
+
+Abrir Chrome DevTools → Device Toolbar. Para cada viewport abaixo, percorrer o roteiro completo:
+
+| Viewport | Modo |
+|---|---|
+| 360 × 800 | Portrait |
+| 412 × 915 | Portrait |
+| 414 × 896 | Portrait |
+| 768 × 1024 | Portrait (breakpoint exato) |
+| 915 × 412 | **Landscape** |
+| 1024 × 600 | **Landscape** |
+| 1280 × 800 | Desktop |
+
+Roteiro em cada viewport:
+1. Login + Painel
+2. Lista de Obras → criar obra
+3. Despesas Extras + Materiais
+4. Financeiro
+5. Recibos → criar recibo → gerar PDF
+6. Notas Fiscais
+7. Equipe + Folha
+8. Cálculos
+9. **Laudo completo:** criar → preencher Cadastros, Dados, Pontos, Croqui, Fotos, ART → clonar → gerar PDF
+10. Loteamentos: autocomplete encadeado
+11. Modais: editar obra, calendário, cartão, ZAYRA chat, autocomplete cartórios
+
+Checklist por viewport (marcar):
+- [ ] 360 × 800 OK
+- [ ] 412 × 915 OK
+- [ ] 414 × 896 OK
+- [ ] 768 × 1024 OK
+- [ ] 915 × 412 (landscape) OK
+- [ ] 1024 × 600 (landscape) OK
+- [ ] 1280 × 800 (desktop) OK
+
+- [ ] **Step 2: Push branch e abrir PR3**
+
+```bash
+git push origin feat/mobile-foundation-v3.3.0
+gh pr create --title "v3.3.0 PR3: Modais + patches secundários (inputs/botões/tabelas)" --body "$(cat <<'EOF'
+## Summary
+Finaliza v3.3.0 com:
+- Modais: Editar Obra, Calendário (preservado 7-col com regra explícita), Cartão, ZAYRA chat, Autocomplete cartórios, Clonagem de laudo
+- Inputs com `width:170px` fixo → `width:100%; max-width:170px`
+- Botões com padding < 44px → ajustados para target tátil
+- Tabelas problemáticas → wrapper com `overflow-x: auto`
+
+QA completo em 7 viewports (incluindo 2 landscape).
+
+## Test plan
+- [x] 360×800 OK em todas as views
+- [x] 412×915 OK em todas as views
+- [x] 414×896 OK em todas as views
+- [x] 768×1024 OK (transição do breakpoint)
+- [x] 915×412 landscape OK
+- [x] 1024×600 landscape OK
+- [x] 1280×800 desktop sem regressão
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+# Pós-Merge — Validação em Campo (Métrica de Sucesso da v3.3.0)
+
+**Após mergear PR3:**
+
+- [ ] **Step 1: Confirmar deploy do Railway**
+
+Verificar no painel do Railway que v3.3.0 fez deploy com sucesso. Conferir logs:
+- ✅ `ZAYRA v3.3.0 rodando`
+- ✅ Cache do SW rotacionou para `zayra-v3.3.0`
+
+- [ ] **Step 2: Validação com técnico em campo**
+
+Pedir pro técnico (ou o próprio CEO) abrir o app no rugged GNSS / celular pessoal e executar:
+
+1. Login
+2. Selecionar uma obra
+3. Abrir laudo → preencher Dados → Pontos → tirar foto → assinar
+4. Gerar PDF do laudo
+5. Enviar via WhatsApp
+
+Checklist da métrica de sucesso (do spec):
+- [ ] Executou fluxo completo de laudo sem scroll horizontal?
+- [ ] Tocou todos os botões de primeira (sem dedo escorregar)?
+- [ ] Carrossel de fotos navegável?
+- [ ] Inputs aceitam teclado mobile sem travar?
+
+**Se sim para todas → v3.3.0 está pronta, atualizar changelog Obsidian.**
+**Se aparecerem regressões → criar branch `fix/mobile-v3.3.1` e patchear imediato.**
+
+- [ ] **Step 3: Atualizar changelog Obsidian (memória do projeto)**
+
+Criar arquivo `06-Changelog/v3.3.0-mobile-foundation.md` no vault Obsidian (mesma estrutura dos changelogs anteriores como v3.0.0-precificacao-incra.md e v3.2.0-cartorios-nacional.md).

--- a/docs/superpowers/specs/2026-05-10-mobile-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-10-mobile-foundation-design.md
@@ -1,0 +1,359 @@
+# v3.3.0 — Mobile Foundation (Responsividade do `obras.html`)
+
+**Data:** 2026-05-10
+**Tipo:** Feature aditiva (sem breaking changes)
+**Escopo:** `src/public/obras.html` apenas (frontend, zero backend)
+**Bump de versão:** 3.2.0 → 3.3.0 (minor)
+
+---
+
+## 1. Contexto e Motivação
+
+O `src/public/obras.html` (~16k linhas) acumulou ao longo do tempo muitos grids inline (`style="display:grid; grid-template-columns: ..."`) que **não respeitam viewports mobile**. Em telas de 360-414px (celulares dos técnicos em campo, incluindo aparelhos rugged GNSS), o conteúdo extrapola horizontalmente, força scroll lateral e quebra a UX de campo.
+
+**Tipologia do problema identificado:**
+- Grids inline com 2-5 colunas que não colapsam em mobile
+- Formulários com proporções `1fr 2fr` que apertam o segundo campo
+- Inputs com `width: 170px` fixo (em vez de `max-width: 170px`)
+- Botões com `padding: 2px 8px` que driblam a regra global de `min-height: 44px`
+- Modais que extrapolam viewport
+
+**Constatação que motivou o trabalho:** screenshot do CEO em campo, aparelho rugged GNSS abrindo o painel via Chrome PWA — coluna "Confrontante" cortada em "Confro…", impossibilitando leitura do conteúdo durante demarcação real.
+
+**Objetivo:** estabelecer uma **fundação responsiva** (CSS utility classes + safety net) que resolva o problema sistemicamente, sem precisar varrer 16k linhas de uma vez. A safety net garante que mesmo grids não-migrados se comportem em mobile.
+
+---
+
+## 2. Arquitetura em 3 Camadas
+
+A estratégia é **progressiva**: cada camada já entrega valor sozinha, e camadas seguintes potencializam as anteriores.
+
+### Camada 1 — Utility classes (CSS foundation)
+
+Adicionar no `<style>` global do `obras.html` 5 classes utilitárias responsivas:
+
+```css
+/* === LP-GRID: utility classes responsivas (v3.3.0) === */
+
+.lp-grid-auto {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.lp-grid-2 { display: grid; grid-template-columns: 1fr 1fr;        gap: 8px; }
+.lp-grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr;    gap: 8px; }
+.lp-grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+.lp-grid-5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
+
+/* Mobile (≤768px): todos colapsam para 1 coluna */
+@media (max-width: 768px) {
+  .lp-grid-auto,
+  .lp-grid-2,
+  .lp-grid-3,
+  .lp-grid-4,
+  .lp-grid-5 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Tablet pequeno (769-900px): grids de 4 e 5 colapsam para 2 colunas
+   (transição suave — evita quebra abrupta) */
+@media (max-width: 900px) and (min-width: 769px) {
+  .lp-grid-4, .lp-grid-5 {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+```
+
+**Notas de design:**
+- `minmax(140px, 1fr)` (em vez de 160px) é mais permissivo, evita órfãos em viewports intermediários
+- `.lp-grid-4` / `.lp-grid-5` explícitas para painéis de estatísticas e dashboards
+- Faixa 769-900px evita salto brusco de 4-col → 1-col em tablets
+
+### Camada 2 — Refactor de inline grids (incremental, view-by-view)
+
+Substituir progressivamente `style="display:grid; grid-template-columns: ..."` por `class="lp-grid-X"`. **Mapeamento de padrões:**
+
+| Padrão inline atual | Classe equivalente |
+|---|---|
+| `repeat(2, 1fr)` ou `1fr 1fr` | `.lp-grid-2` |
+| `repeat(3, 1fr)` ou `1fr 1fr 1fr` | `.lp-grid-3` |
+| `repeat(4, 1fr)` | `.lp-grid-4` |
+| `repeat(5, 1fr)` | `.lp-grid-5` |
+| `1fr 2fr`, `2fr 1fr`, `1fr 1fr 2fr` (proporcionais) | `.lp-grid-auto` (uniformiza) |
+| `repeat(auto-fit, minmax(...))` (já responsivo) | Manter inline (já está OK) |
+
+**Casos especiais — NÃO converter:**
+Grids legítimos que devem permanecer multi-coluna mesmo em mobile:
+- Calendário mensal (7 colunas fixas)
+- Tabelas de horários
+- Qualquer grid onde a versão 1-coluna **piora** a UX
+
+Marcar esses com atributo `data-keep-grid` (ver Camada 3).
+
+### Camada 3 — Safety net (catch-all)
+
+Regra global de defesa para qualquer inline grid que sobre após o refactor ou apareça no futuro:
+
+```css
+@media (max-width: 768px) {
+  /* Catch-all: força 1 coluna em qualquer elemento com inline grid,
+     EXCETO os marcados explicitamente como "manter grid em mobile". */
+  [style*="grid-template-columns"]:not([data-keep-grid]) {
+    grid-template-columns: 1fr !important;
+  }
+}
+```
+
+**Opt-out explícito** via `data-keep-grid`:
+```html
+<div data-keep-grid style="display:grid; grid-template-columns: repeat(7, 1fr)">
+  <!-- Calendário mensal, 7 colunas fixas mesmo em mobile -->
+</div>
+```
+
+**Por que `!important` é justificado:** inline style sobrescreve qualquer CSS externo SEM `!important`. Como a safety net é a última linha de defesa para HTML que ainda não foi migrado, ela precisa ganhar do inline.
+
+---
+
+## 3. Patches Secundários (não-grid)
+
+Detectados na auditoria, aplicar conforme aparecerem durante o refactor da Camada 2:
+
+### Inputs com largura fixa
+- ❌ `style="width: 170px"` — quebra em viewport menor que 170px
+- ✅ `style="width: 100%; max-width: 170px"` — desktop fica 170px, mobile estica
+- 🔍 Se já estiver `max-width: 170px` (sem `width` fixo): está OK, não mexer
+
+### Botões fora do padrão tátil
+- ❌ `style="padding: 2px 8px"` (ou similar < 4px vertical) — driblam regra global de `min-height: 44px` (Material Design / iOS HIG)
+- ✅ `style="padding: 8px 12px; min-height: 44px"` — atinge target tátil mínimo
+
+### Tabelas que extrapolam viewport
+Wrapper com scroll horizontal:
+```html
+<div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
+  <table>...</table>
+</div>
+```
+
+---
+
+## 4. Service Worker (`sw.js`)
+
+**O SW atual (v3.2.0) já está corretamente configurado** para esta feature. Confirmação de funcionalidades existentes em `src/public/sw.js`:
+
+| Funcionalidade | Status | Linha (aprox) |
+|---|---|---|
+| Network-first para HTML | ✅ já existe | 86-99 |
+| `skipWaiting()` no install | ✅ já existe | 33 |
+| `clients.claim()` no activate | ✅ já existe | 42 |
+| Cleanup de caches antigos | ✅ já existe | 41 |
+| Broadcast `SW_UPDATED` aos clients | ✅ já existe | 46-48 |
+| Suporte a `SKIP_WAITING` postMessage | ✅ já existe | 121 |
+
+**Ação única no SW para v3.3.0:**
+
+```javascript
+// src/public/sw.js, linha 4
+const CACHE = 'zayra-v3.3.0';  // bump de v3.2.0
+```
+
+Isso é tudo. O versionamento do cache garante rotação automática em todos os clients — o resto da máquina (network-first, claim, cleanup) já está em produção e validada nos ciclos v3.0-v3.2.
+
+---
+
+## 5. Escopo de Mudanças
+
+**Apenas `src/public/obras.html`** + bump em `sw.js`/`package.json`/`identity.ts`. **Zero backend.**
+
+### Vistas principais a auditar e refatorar:
+- [ ] Painel
+- [ ] Obras (lista + form de cadastro/edição)
+- [ ] Despesas Extras
+- [ ] Materiais
+- [ ] Financeiro
+- [ ] Recibos
+- [ ] Notas Fiscais
+- [ ] Equipe
+- [ ] Marcar Dias
+- [ ] Folha Mensal
+- [ ] Vistoria (VTO)
+
+### Submódulos do Laudo de Demarcação (6 abas):
+- [ ] Aba Dados
+- [ ] Aba Registral
+- [ ] Aba Croqui
+- [ ] Aba ART
+- [ ] Aba Fotos
+- [ ] Aba Assinatura
+
+### Outros módulos:
+- [ ] Loteamentos (autocomplete, dropdowns encadeados)
+- [ ] Proposta
+- [ ] Cálculos
+
+### Modais:
+- [ ] Calendário (manter com `data-keep-grid`)
+- [ ] Editar Obra
+- [ ] Cartão (cadastro/edição)
+- [ ] ZAYRA chat
+- [ ] Autocomplete cartórios (integração CNJ da v3.2.0)
+- [ ] Confirmação genérica (delete, etc)
+- [ ] Modal de clonagem de laudo (v3.1.0)
+
+---
+
+## 6. Estratégia de Deploy — 3 PRs Independentes
+
+Mudança grande em arquivo de 16k linhas. Dividir em 3 PRs sequenciais e independentes:
+
+### PR1 — Foundation (~30min, baixo risco)
+- Adicionar Camada 1 (utility classes) no `<style>` global
+- Adicionar Camada 3 (safety net com `:not([data-keep-grid])`)
+- Bump SW: `CACHE = 'zayra-v3.3.0'`
+- Bump versão: `package.json` + `identity.ts` para 3.3.0
+- Smoke test em 1 viewport mobile (360×800) só confirmando que nada quebrou
+
+**Por que isolar:** se aparecer regressão em campo após PR1, o SW novo + safety net já protegem enquanto investiga. PRs grandes ficam reféns de rollback completa.
+
+### PR2 — Refactor de vistas + laudo (~7-10h)
+- 11 vistas principais
+- 6 abas do laudo + modal de clonagem
+- Loteamentos + Proposta + Cálculos
+
+### PR3 — Modais + patches secundários (~2-3h)
+- Modais (calendário, editar obra, cartão, ZAYRA, autocomplete cartórios, confirmação)
+- Inputs com `width` fixo → trocar para `width: 100%; max-width: ...`
+- Botões com padding < 44px → ajustar para target tátil
+- Tabelas problemáticas → wrapper com `overflow-x: auto`
+
+---
+
+## 7. Validação Manual (Sem Testes Automatizados)
+
+**ROI baixo** em snapshot tests, **zero** em unit tests para layout responsivo. Validação 100% manual via Chrome DevTools.
+
+### Viewports obrigatórios (portrait):
+
+| Viewport | Por que testar |
+|---|---|
+| **360 × 800** | Android baratos (Galaxy A-series) — base instalada brasileira |
+| **412 × 915** | Pixel 7 (referência mobile moderna) |
+| **414 × 896** | iPhone 11 (referência iOS) |
+| **768 × 1024** | iPad mini — confirmar transição exata no breakpoint |
+| **1024 × 768+** | Desktop — confirmar que nada quebra acima do breakpoint |
+
+### Viewports landscape (ponto cego clássico):
+
+| Viewport | Por que testar |
+|---|---|
+| **915 × 412** | Pixel 7 deitado — técnico vira o celular para coordenadas |
+| **1024 × 600** | Tablet barato em modo paisagem |
+
+> **Observação:** em landscape 915×412 o layout cai no modo desktop (915 > 768). Confirmar que essa transição faz sentido na UX, especialmente nas telas do laudo onde mais espaço horizontal é útil.
+
+### Roteiro de teste em cada viewport:
+
+1. Login + Painel — sem scroll horizontal
+2. Listar Obras — cards legíveis, ações tocáveis
+3. Cadastrar Obra — formulário usável
+4. Despesas Extras + Materiais + Financeiro — grids responsivos
+5. Equipe + Folha Mensal — listagens não quebram
+6. **Laudo de Demarcação (ciclo completo):**
+   - Criar laudo novo
+   - Preencher Dados → Registral → Croqui → ART → Fotos → Assinatura
+   - Clonar (testar v3.1.0)
+   - Gerar PDF
+   - Enviar WhatsApp
+7. Loteamentos — autocomplete + dropdowns encadeados
+8. Modais — abrir cada, fechar com X e clique fora
+9. ZAYRA chat — janela responsiva, input com teclado mobile aberto
+
+### Checklist por tela:
+- [ ] Sem scroll horizontal
+- [ ] Botões com target tátil ≥44×44px
+- [ ] Texto legível (≥14px body, 16px em inputs para evitar zoom do iOS)
+- [ ] Formulários completam sem dificuldade
+- [ ] Modais não extrapolam viewport
+- [ ] Tabelas com `overflow-x` quando necessário
+
+---
+
+## 8. Cuidados Importantes
+
+### 8.1 `data-keep-grid` é uma TODO list embutida
+Durante o refactor, se encontrar um inline grid que não tem tempo/contexto pra converter, **marca com `data-keep-grid` SOMENTE se ele realmente deve ficar multi-coluna em mobile**. Caso contrário, deixa sem o atributo — a safety net força 1 coluna até alguém converter para classe utility depois.
+
+### 8.2 NÃO usar `data-keep-grid` como "deixa pra depois"
+Se um grid **deveria** virar 1 coluna em mobile mas não foi convertido ainda → **deixar sem `data-keep-grid`**. A safety net cobre. O atributo é apenas para casos legítimos (calendário, tabelas compactas que precisam manter formato).
+
+### 8.3 Service Worker pode levar 1 reload pra atualizar
+Mesmo com `skipWaiting()`, alguns navegadores precisam de 1 reload completo pra ativar o SW novo. **Avisar os técnicos:** "Após o deploy, feche e abra o app uma vez". O `SW_UPDATED` postMessage do SW atual já permite mostrar toast no front (já implementado).
+
+### 8.4 PDF templates ficam intocados (nota arquitetural)
+**Estado atual:** Os PDFs do laudo, recibo, etc são gerados server-side via PDFKit em `src/services/laudoPdf.ts` e similares. Os templates HTML inline em `obras.html` (linha 2092+ etc) que parecem "modelos de PDF" são na verdade páginas standalone que renderizam em janela separada com `<style>` próprio dentro de template string — **não são alcançados pelo CSS global** do `obras.html` nem pelas regras `@media` adicionadas em v3.3.0.
+
+**Sem ação necessária agora.** Nota para o futuro: se alguém migrar geração de PDF para renderização inline (com html2canvas, jsPDF, etc), precisa lembrar que as regras de v3.3.0 vão aplicar — provavelmente OK, mas conferir.
+
+### 8.5 Breakpoint 768px não muda
+Padrão de facto (Bootstrap, Tailwind `md:`, Material Design). Mudar agora cria inconsistência futura. Se precisar de breakpoint adicional (ex: 1024px para tablets grandes), **adicionar** em vez de substituir.
+
+### 8.6 Bilateral PR review obrigatório
+Mudança em arquivo de 16k linhas exige branch + PR + review explícito antes de merge. **Não fazer push direto pra main.** Já refletido na estratégia de 3 PRs (seção 6).
+
+---
+
+## 9. Versionamento
+
+```
+package.json:    3.2.0 → 3.3.0
+identity.ts:     bump correspondente
+sw.js:           CACHE: 'zayra-v3.2.0' → 'zayra-v3.3.0'
+```
+
+**Tipo de bump:** minor (3.x.0). Feature aditiva sem breaking changes. Inline grids existentes continuam funcionando — refactor da Camada 2 é progressivo e a safety net captura qualquer um que sobre.
+
+---
+
+## 10. Critérios de Aceite
+
+- [ ] Utility classes `.lp-grid-auto`, `.lp-grid-2/3/4/5` definidas no `<style>` global
+- [ ] Safety net `[style*="grid-template-columns"]:not([data-keep-grid])` ativa em ≤768px
+- [ ] Faixa de transição 769-900px para `.lp-grid-4` e `.lp-grid-5` (2 colunas)
+- [ ] `sw.js` com `CACHE = 'zayra-v3.3.0'`
+- [ ] `package.json`, `identity.ts` em 3.3.0
+- [ ] 11 vistas principais auditadas e refatoradas
+- [ ] 6 abas do laudo + Loteamentos + Proposta + Cálculos refatorados
+- [ ] Modais responsivos em todos os 7 viewports testados
+- [ ] Sem scroll horizontal em nenhuma tela em viewports 360-768px
+- [ ] Botões com target tátil ≥44×44px
+- [ ] Inputs com largura fixa convertidos para `width:100%; max-width:Xpx`
+- [ ] Tabelas problemáticas com wrapper `overflow-x: auto`
+- [ ] PDF do laudo inalterado (templates standalone preservados)
+- [ ] 3 PRs criados, revisados e mergeados em sequência
+
+---
+
+## 11. Métrica de Sucesso
+
+Após deploy completo (3 PRs mergeados), validar com 1 técnico em campo real:
+
+- Consegue executar fluxo completo de laudo em celular sem scroll horizontal?
+- Consegue tocar todos os botões de primeira (sem dedo escorregar)?
+- Carrossel de fotos é navegável?
+- Inputs aceitam teclado mobile sem travar?
+
+**Se sim para todas → v3.3.0 está pronta.**
+**Se aparecerem regressões → patch v3.3.1 imediato.**
+
+---
+
+## 12. Próximos Passos (pós-v3.3.0)
+
+Fora do escopo desta versão, mas habilitados por ela:
+
+- **v3.4.0+** — usar classes `.lp-grid-*` em features novas como padrão (sem inline grid)
+- **Eventual** — extrair `<style>` global pra arquivo CSS dedicado se passar de ~500 linhas (hoje está OK inline)
+- **Eventual** — considerar PWA install prompt customizado (botão "Instalar app") em vez de depender do menu nativo do Chrome

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.2.0',
+  version: '3.3.0',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -14161,7 +14161,7 @@ function renderLaudoTabCadastros(c) {
         </div>
       </div>
       <div id="lec-cont-form" style="display:none; margin-top:12px; border-top:1px solid var(--border); padding-top:12px;">
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <select id="lec-c-tipo">
             <option value="PF">Pessoa Física</option>
             <option value="PJ">Pessoa Jurídica</option>
@@ -14181,7 +14181,7 @@ function renderLaudoTabCadastros(c) {
           <p style="margin:0 0 8px; font-size:12px; color:var(--text-muted);">
             👤 <strong>Representante legal</strong> (opcional)
           </p>
-          <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+          <div class="lp-grid-2">
             <input id="lec-c-rep-nome" placeholder="Nome do representante" style="grid-column:1/3;">
             <input id="lec-c-rep-cpf" placeholder="CPF do representante" maxlength="14" data-mask="cpfcnpj">
             <input id="lec-c-rep-cargo" placeholder="Cargo (Sócio, Adm, etc.)">
@@ -14224,7 +14224,7 @@ function renderLaudoTabCadastros(c) {
         </div>
       </div>
       <div id="lec-exec-form" style="display:none; margin-top:12px; border-top:1px solid var(--border); padding-top:12px;">
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <input id="lec-e-nome" placeholder="Nome completo" style="grid-column:1/3;">
           <input id="lec-e-qual" placeholder="Qualificação (Téc. em Agrimensura, etc.)" style="grid-column:1/3;">
           <input id="lec-e-cft" placeholder="CFT">

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -5757,7 +5757,7 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
         <label>Endereço / localização do imóvel rural
           <input id="geoEndereco" placeholder="Sítio/Fazenda Tal, zona rural, município-UF" style="width:100%;">
         </label>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Município
             <input id="geoMunicipio" value="Açailândia" style="width:100%;">
           </label>
@@ -5767,7 +5767,7 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
         </div>
 
         <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">📐 Levantamento</p>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Área (hectares)
             <input id="geoArea" type="number" min="0.1" step="0.01" placeholder="ex: 25.5" style="width:100%;">
           </label>
@@ -5776,7 +5776,7 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
             <span style="font-size:10px; color:var(--text-muted);">Mínimo 3 (poligonal)</span>
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Distância de deslocamento (km)
             <input id="geoDistKm" type="number" min="0" step="1" value="0" style="width:100%;">
             <span style="font-size:10px; color:var(--text-muted);">Ida+volta a partir de Açailândia</span>
@@ -5788,7 +5788,7 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
         </div>
 
         <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">💰 Valores unitários (deixe 0 pra usar tabela CONFEA)</p>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>R$/hectare
             <input id="geoValHa" type="number" min="0" step="0.01" placeholder="80.00 (default)" style="width:100%;">
           </label>
@@ -5796,7 +5796,7 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
             <input id="geoValVert" type="number" min="0" step="0.01" placeholder="200.00 (default)" style="width:100%;">
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>R$/diária
             <input id="geoValDia" type="number" min="0" step="0.01" placeholder="600.00 (default)" style="width:100%;">
           </label>
@@ -5974,7 +5974,7 @@ async function renderConsultoriaFormDesmRem(v, toggleHTML, subtipo) {
         </label>
 
         <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">📐 Dados do imóvel</p>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Área total (m²)
             <input id="dxArea" type="number" min="1" step="0.01" style="width:100%;">
             <span style="font-size:10px; color:var(--text-muted);">${isDesm ? 'Área da matriz' : 'Soma das áreas a unificar'}</span>
@@ -6153,7 +6153,7 @@ async function renderConsultoriaFormRetificacao(v, toggleHTML) {
         </label>
 
         <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">📊 Áreas (em m² ou hectares)</p>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Área atual (matrícula)
             <input id="rxAreaAtual" type="number" min="0.01" step="0.01" style="width:100%;">
             <span style="font-size:10px; color:var(--text-muted);">Como está na matrícula hoje</span>
@@ -6317,7 +6317,7 @@ async function renderConsultoriaFormPTAM(v, toggleHTML) {
         <label>Endereço do imóvel a avaliar
           <input id="ptEndereco" placeholder="Rua, nº, bairro, cidade-UF (ou descrição rural)" style="width:100%;">
         </label>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Município
             <input id="ptMunicipio" value="Açailândia" style="width:100%;">
           </label>
@@ -6336,7 +6336,7 @@ async function renderConsultoriaFormPTAM(v, toggleHTML) {
             <option value="industrial">Industrial (instalações + maquinário)</option>
           </select>
         </label>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>Área do terreno (m² ou ha)
             <input id="ptAreaTerreno" type="number" min="0" step="0.01" value="0" style="width:100%;">
           </label>
@@ -6751,7 +6751,7 @@ async function abrirNovaConsultoriaPasso1() {
     </button>`).join('');
 
   const html = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">${cards}</div>
+    <div class="lp-grid-2">${cards}</div>
   `;
   const modal = abrirModal(html, { title: 'Nova Proposta de Consultoria', subtitle: 'Selecione o tipo' });
   modal.querySelectorAll('[data-pick-subtipo]:not([disabled])').forEach(b => b.onclick = () => {
@@ -6828,7 +6828,7 @@ async function abrirCadastroClienteModal(subtipoParaVoltar) {
       <label>Nome completo / Razão Social *
         <input id="novCliNome" placeholder="Maria Ester R. Sampaio" style="width:100%;" autofocus>
       </label>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <label>CPF / CNPJ
           <input id="novCliCpf" placeholder="000.000.000-00" style="width:100%;">
         </label>
@@ -6842,7 +6842,7 @@ async function abrirCadastroClienteModal(subtipoParaVoltar) {
       <label>Endereço completo
         <input id="novCliEnd" placeholder="Rua Bom Jesus, 236, Centro" style="width:100%;">
       </label>
-      <div style="display:grid; grid-template-columns:2fr 1fr 1fr; gap:8px;">
+      <div class="lp-grid-auto">
         <label>Cidade
           <input id="novCliCidade" placeholder="Açailândia" style="width:100%;" value="Açailândia">
         </label>
@@ -6922,7 +6922,7 @@ async function abrirNovaConsultoriaPasso2(subtipo) {
       <label>Endereço do imóvel
         <input id="cnsEndereco" placeholder="Rua, número, bairro, cidade-UF" style="width:100%;">
       </label>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <label>Área construída (m²)
           <input id="cnsArea" type="number" min="1" step="0.01" style="width:100%;">
         </label>
@@ -6930,7 +6930,7 @@ async function abrirNovaConsultoriaPasso2(subtipo) {
           <input id="cnsValorVenal" type="number" min="0" step="0.01" style="width:100%;">
         </label>
       </div>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <label>
           <span style="display:flex; align-items:center; gap:4px;">Padrão construtivo
             <button type="button" id="cnsPadraoHelp" title="Como escolher" style="background:transparent; border:1px solid var(--border); color:var(--neon); border-radius:50%; width:18px; height:18px; padding:0; line-height:1; cursor:pointer; font-size:12px;">?</button>
@@ -6977,7 +6977,7 @@ async function abrirNovaConsultoriaPasso2(subtipo) {
         ⚠️ Comercial: pacote completo obrigatório (7 projetos: Mapa, Arquitetônico, Elétrico, Hidrossanitário, Estrutural, PPCI, Memorial).
       </div>` : ''}
       <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">Status atual dos documentos do cliente:</div>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:4px; font-size:12px;">
+      <div class="lp-grid-2" style="gap:4px; font-size:12px;">
         <label><input id="cnsAlvara" type="checkbox"> Já tem Alvará</label>
         <label><input id="cnsHabite" type="checkbox"> Já tem Habite-se</label>
         <label><input id="cnsIptu" type="checkbox" checked> IPTU em dia</label>

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -891,7 +891,7 @@ async function abrirModalCerts() {
             <span style="display:block; margin-bottom:4px;">Senha do certificado</span>
             <input type="password" name="senha" placeholder="Senha que você criou ao emitir" required style="width:100%;">
           </label>
-          <div style="display:grid; grid-template-columns:1fr 2fr; gap:10px;">
+          <div class="lp-grid-auto" style="gap:10px;">
             <label style="font-size:12px;">
               <span style="display:block; margin-bottom:4px;">Perfil</span>
               <select name="perfil" required style="width:100%;">

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -10906,7 +10906,7 @@ function renderFiscalConfigBox() {
             </select>
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <label>NFe.io Company ID
             <input id="cfgCompany" placeholder="UUID da empresa no NFe.io" value="${escape(c.provider_company_id||'')}" style="width:100%; font-family:monospace; font-size:12px;">
           </label>
@@ -10997,7 +10997,7 @@ function renderNFAvulsaBox() {
             <input id="nfaUf" maxlength="2" value="MA" style="width:100%; text-transform:uppercase;">
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1.5fr 1fr 1fr; gap:8px;">
+        <div class="lp-grid-auto">
           <label>Logradouro
             <input id="nfaLogr" placeholder="Av. Brasil" style="width:100%;">
           </label>
@@ -11008,7 +11008,7 @@ function renderNFAvulsaBox() {
             <input id="nfaBairro" style="width:100%;">
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px;">
+        <div class="lp-grid-3">
           <label>Valor do serviço (R$) *
             <input id="nfaValor" type="number" step="0.01" min="0.01" placeholder="0,00" style="width:100%;">
           </label>

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -11910,7 +11910,7 @@ function baixarDxfCobPlanta() {
 // ─── 2. CONCRETO ───────────────────────────────────────────────────────
 function renderCalcConcreto() {
   document.getElementById('calcContent').innerHTML = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:14px;">
+    <div class="lp-grid-2" style="gap:14px;">
       <div class="card">
         <p class="section-title">Concreto Estrutural</p>
         <div class="form-grid">
@@ -11991,7 +11991,7 @@ function renderCalcConcreto() {
 // ─── 3. ALVENARIA ──────────────────────────────────────────────────────
 function renderCalcAlvenaria() {
   document.getElementById('calcContent').innerHTML = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:14px;">
+    <div class="lp-grid-2" style="gap:14px;">
       <div class="card">
         <p class="section-title">Alvenaria</p>
         <div class="form-grid">
@@ -12062,7 +12062,7 @@ function renderCalcAlvenaria() {
 // ─── 4. ARGAMASSA ──────────────────────────────────────────────────────
 function renderCalcArgamassa() {
   document.getElementById('calcContent').innerHTML = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:14px;">
+    <div class="lp-grid-2" style="gap:14px;">
       <div class="card">
         <p class="section-title">Argamassa</p>
         <div class="form-grid">
@@ -12122,7 +12122,7 @@ function renderCalcArgamassa() {
 // ─── 5. PINTURA ────────────────────────────────────────────────────────
 function renderCalcPintura() {
   document.getElementById('calcContent').innerHTML = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:14px;">
+    <div class="lp-grid-2" style="gap:14px;">
       <div class="card">
         <p class="section-title">Pintura</p>
         <div class="form-grid">
@@ -12197,7 +12197,7 @@ function renderCalcPintura() {
 // ─── 6. RESERVATÓRIO DE ÁGUA ──────────────────────────────────────────
 function renderCalcReservatorio() {
   document.getElementById('calcContent').innerHTML = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:14px;">
+    <div class="lp-grid-2" style="gap:14px;">
       <div class="card">
         <p class="section-title">Reservatório de Água — NBR 5626</p>
         <div class="form-grid">
@@ -12303,7 +12303,7 @@ const PISOS_TIPOS = {
 
 function renderCalcPisos() {
   document.getElementById('calcContent').innerHTML = `
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:14px;">
+    <div class="lp-grid-2" style="gap:14px;">
       <div class="card">
         <p class="section-title">Pisos / Revestimentos</p>
         <div class="form-grid">
@@ -12783,7 +12783,7 @@ async function abrirZayraVisual() {
       <p style="margin:0; font-size:13px; color:var(--text-muted);">
         Capture uma imagem ou ative o modo LIVE (frames a cada 5s).
       </p>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <button id="zvCam" style="padding:14px; background:var(--bg-elev); border:1px solid var(--border); border-radius:8px; color:var(--text); cursor:pointer;">
           <div style="font-size:32px;">📱</div>
           <div style="font-size:12px; margin-top:4px;">Câmera (foto única)</div>
@@ -12795,7 +12795,7 @@ async function abrirZayraVisual() {
           <div style="font-size:10px; color:var(--text-muted); margin-top:2px;">~R$ 0,02 · Claude</div>
         </button>
       </div>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <button id="zvLiveCam" style="padding:14px; background:rgba(0,255,136,0.06); border:2px solid var(--neon); border-radius:8px; color:var(--text); cursor:pointer;">
           <div style="font-size:32px;">🎥</div>
           <div style="font-size:12px; margin-top:4px; color:var(--neon); font-weight:600;">LIVE Câmera</div>
@@ -13684,7 +13684,7 @@ function renderLaudoNovo(v) {
         <button id="ln-novo-cont">➕ Cadastrar novo</button>
       </div>
       <div id="ln-cont-form" style="display:none; margin-top:12px; border-top:1px solid var(--border); padding-top:12px;">
-        <div class="grid-2" style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <select id="ln-c-tipo">
             <option value="PF">Pessoa Física</option>
             <option value="PJ">Pessoa Jurídica</option>
@@ -13705,7 +13705,7 @@ function renderLaudoNovo(v) {
           <p style="margin:0 0 8px; font-size:12px; color:var(--text-muted);">
             👤 <strong>Representante legal</strong> (opcional — sócio/administrador que assina contratos, se aplicável)
           </p>
-          <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+          <div class="lp-grid-2">
             <input id="ln-c-rep-nome" placeholder="Nome completo do representante" style="grid-column:1/3;">
             <input id="ln-c-rep-cpf" placeholder="CPF do representante (000.000.000-00)" maxlength="14" data-mask="cpfcnpj">
             <input id="ln-c-rep-cargo" placeholder="Cargo (Sócio, Administrador, etc.)">
@@ -13727,7 +13727,7 @@ function renderLaudoNovo(v) {
         <button id="ln-novo-exec">➕ Cadastrar novo</button>
       </div>
       <div id="ln-exec-form" style="display:none; margin-top:12px; border-top:1px solid var(--border); padding-top:12px;">
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+        <div class="lp-grid-2">
           <input id="ln-e-nome" placeholder="Nome completo" style="grid-column:1/3;">
           <input id="ln-e-qual" placeholder="Qualificação (Téc. em Agrimensura, Eng. Civil, etc.)" style="grid-column:1/3;">
           <input id="ln-e-cft" placeholder="CFT (Conselho Federal Técnicos)">

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -9570,7 +9570,7 @@ function renderReciboForm(v) {
         </label>
         <!-- v1.85.0: catálogo de serviços (somente quando tipo='custom') -->
         <div id="recCatalogoBox" style="display:${f.tipo==='custom'?'block':'none'};">
-          <div style="display:grid; grid-template-columns:1fr 2fr; gap:8px;">
+          <div class="lp-grid-auto">
             <label>Categoria de serviço
               <select id="recCategoria" style="width:100%;">
                 <option value="">— Personalizado / Em branco —</option>
@@ -9607,7 +9607,7 @@ function renderReciboForm(v) {
             <input id="recEmail" type="email" placeholder="email@dominio.com" value="${escape(f.destinatario_email)}" style="width:100%;">
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 1fr 120px; gap:8px;">
+        <div class="lp-grid-auto">
           <label>Valor (R$)
             <input id="recValor" type="number" step="0.01" min="0" placeholder="0,00" value="${escape(f.valor)}" style="width:100%;">
           </label>
@@ -9629,7 +9629,7 @@ function renderReciboForm(v) {
           Após salvar, você poderá enviar pelo WhatsApp com 1 clique.
         </p>
         <!-- v1.89.0: 3 botões com fluxo separado de salvar/enviar -->
-        <div style="display:grid; grid-template-columns:1fr 1fr 2fr; gap:8px; margin-top:6px;">
+        <div class="lp-grid-auto" style="margin-top:6px;">
           <button id="recSalvarRascunho" title="Salvar como rascunho — pode editar depois, número provisório" style="background:transparent; border:1px solid #444; color:#888;">💾 Salvar rascunho</button>
           <button id="recSalvarSemEnviar" title="Emite o recibo (gera número definitivo) sem enviar agora" style="background:#1F5C3A; color:#fff; border-color:#1F5C3A;">✅ Salvar sem enviar</button>
           <button id="recSalvarEnviar" title="Salva e dispara WhatsApp imediatamente" style="background:#25D366; color:#fff; border-color:#25D366; font-weight:600;">🚀 Salvar e enviar via WhatsApp</button>
@@ -10104,7 +10104,7 @@ function abrirModalNovoCliente() {
       <fieldset style="border:1px solid var(--border); border-radius:10px; padding:12px; margin-bottom:14px;">
         <legend style="padding:0 8px; font-size:12px; color:var(--gold); font-weight:600;">DADOS PRINCIPAIS</legend>
         <div style="display:grid; gap:10px;">
-          <div style="display:grid; grid-template-columns:2fr 1fr; gap:8px;">
+          <div class="lp-grid-auto">
             <label>Nome completo / Razão Social *
               <input id="cli_nome" placeholder="Nome ou Razão Social" maxlength="150" style="width:100%;">
             </label>
@@ -10113,7 +10113,7 @@ function abrirModalNovoCliente() {
               <span id="cli_doc_status" style="font-size:10px; color:var(--text-muted);"></span>
             </label>
           </div>
-          <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px;">
+          <div class="lp-grid-3">
             <label>Celular / WhatsApp *
               <input id="cli_tel" placeholder="(99) 99999-9999" maxlength="15" style="width:100%; font-family:monospace;">
             </label>
@@ -10131,7 +10131,7 @@ function abrirModalNovoCliente() {
       <fieldset style="border:1px solid var(--border); border-radius:10px; padding:12px; margin-bottom:14px;" id="cli_fs_pessoais">
         <legend style="padding:0 8px; font-size:12px; color:var(--gold); font-weight:600;">DADOS PESSOAIS / EMPRESARIAIS</legend>
         <div style="display:grid; gap:10px;">
-          <div style="display:grid; grid-template-columns:1fr 1fr 2fr; gap:8px;">
+          <div class="lp-grid-auto">
             <label>
               <span data-cli-pf-only>Data de nascimento</span><span data-cli-pj-only style="display:none;">Data de fundação</span>
               <input id="cli_dtnasc" type="date" style="width:100%;">
@@ -10151,7 +10151,7 @@ function abrirModalNovoCliente() {
               <input id="cli_profissao" maxlength="120" style="width:100%;">
             </label>
           </div>
-          <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;" data-cli-pj-only>
+          <div class="lp-grid-2" data-cli-pj-only>
             <label>Razão Social (se diferente do nome)
               <input id="cli_razao" maxlength="150" style="width:100%;">
             </label>
@@ -10165,7 +10165,7 @@ function abrirModalNovoCliente() {
       <fieldset style="border:1px solid var(--border); border-radius:10px; padding:12px; margin-bottom:14px;">
         <legend style="padding:0 8px; font-size:12px; color:var(--gold); font-weight:600;">ENDEREÇO</legend>
         <div style="display:grid; gap:10px;">
-          <div style="display:grid; grid-template-columns:140px 2fr 80px 1fr; gap:8px;">
+          <div class="lp-grid-auto">
             <label>CEP
               <input id="cli_cep" placeholder="00000-000" maxlength="9" style="width:100%; font-family:monospace;">
               <span id="cli_cep_status" style="font-size:10px; color:var(--text-muted);"></span>
@@ -10180,7 +10180,7 @@ function abrirModalNovoCliente() {
               <input id="cli_compl" maxlength="120" style="width:100%;">
             </label>
           </div>
-          <div style="display:grid; grid-template-columns:2fr 2fr 60px; gap:8px;">
+          <div class="lp-grid-auto">
             <label>Bairro
               <input id="cli_bairro" maxlength="80" style="width:100%;">
             </label>
@@ -10526,7 +10526,7 @@ function abrirModalNF(opts) {
         Digite o CEP — endereço auto-completa via Brasil API.
       </p>
       <div style="display:grid; gap:10px;">
-        <div style="display:grid; grid-template-columns:1fr 2fr; gap:8px;">
+        <div class="lp-grid-auto">
           <label>CPF/CNPJ ${opts.ehObrigatorioDoc ? '*' : ''}
             <input id="mnfDoc" placeholder="000.000.000-00" value="${escape(p.tomador_doc || '')}" style="width:100%;">
             <span id="mnfDocStatus" style="font-size:10px; color:var(--text-muted);"></span>
@@ -10535,7 +10535,7 @@ function abrirModalNF(opts) {
             <input id="mnfNome" value="${escape(p.tomador_nome || '')}" style="width:100%;">
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 1fr 2fr; gap:8px;">
+        <div class="lp-grid-auto">
           <label>Email
             <input id="mnfEmail" type="email" value="${escape(p.tomador_email || '')}" style="width:100%;">
           </label>
@@ -10547,7 +10547,7 @@ function abrirModalNF(opts) {
             <input id="mnfLogr" value="${escape(p.logradouro || '')}" style="width:100%;">
           </label>
         </div>
-        <div style="display:grid; grid-template-columns:1fr 2fr 2fr 80px; gap:8px;">
+        <div class="lp-grid-auto">
           <label>Número
             <input id="mnfNum" value="${escape(p.numero || 'S/N')}" style="width:100%;">
           </label>

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -125,6 +125,14 @@
     .lp-grid-4, .lp-grid-5 { grid-template-columns: 1fr 1fr; }
   }
 
+  /* === SAFETY NET: força 1 coluna em qualquer inline grid não migrado === */
+  /* Opt-out: marque o elemento com data-keep-grid para preservar multi-coluna em mobile */
+  @media (max-width: 768px) {
+    [style*="grid-template-columns"]:not([data-keep-grid]) {
+      grid-template-columns: 1fr !important;
+    }
+  }
+
   input, select, textarea, button {
     font-family: inherit; font-size: 14px; padding: 8px 12px;
     border: 1px solid var(--border); border-radius: var(--radius);

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -14848,7 +14848,7 @@ function renderLaudoTabPontos(c) {
     <div class="card" style="margin-top:12px;" id="lp-preview-mobile-card">
       <details ${pontosPreview.length >= 3 ? 'open' : ''}>
         <summary style="cursor:pointer; font-weight:600;">📱 Preview + Memorial Descritivo (vai pro PDF)</summary>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:8px;">
+        <div class="lp-grid-2" style="gap:12px; margin-top:8px;">
           <div id="lp-preview-svg-mobile">
             ${gerarCroquiSvgClient(pontosPreview, ladosPreview, { larguraPx: 600, alturaPx: 600, tipoImovel: l.tipo_imovel, areaTotalM2: l.area_total_m2 ? Number(l.area_total_m2) : undefined, utmZona: pontos[0]?.utm_zona ? Number(pontos[0].utm_zona) : undefined, utmHemisferio: pontos[0]?.utm_hemisferio || 'S' })}
           </div>
@@ -15032,7 +15032,7 @@ function renderLaudoTabPontos(c) {
             <strong style="font-size:13px;">📍 Ponto P${i}</strong>
             ${isDinamico && nPontos > 3 && i === nPontos ? `<button data-fp-rm="${i}" title="Remover último ponto" style="font-size:11px; padding:2px 8px; background:transparent; color:#ef4444; border:1px solid #ef444455;">🗑️ Remover P${i}</button>` : ''}
           </div>
-          <div style="display:grid; grid-template-columns: repeat(${cols}, 1fr); gap:6px; margin-top:6px;">
+          <div class="lp-grid-auto" style="gap:6px; margin-top:6px;">
             <input data-fp-rotulo="${i}" placeholder="Rótulo (ex: P${i}, M${i})" value="${escape(p.rotulo || ('P'+i))}">
             ${showUTM ? `<input data-fp-utme="${i}" type="number" step="0.001" inputmode="decimal" placeholder="UTM Este (X)" value="${p.utm_e ?? ''}">` : ''}
             ${showUTM ? `<input data-fp-utmn="${i}" type="number" step="0.001" inputmode="decimal" placeholder="UTM Norte (Y)" value="${p.utm_n ?? ''}">` : ''}
@@ -15108,7 +15108,7 @@ function renderLaudoTabPontos(c) {
       rows += !mostrarLado ? '' : `
         <div style="padding:6px 12px; margin-left:20px; border-left:2px dashed var(--gold); font-size:11px; color:var(--text-muted);">
           ↓ <strong>${getLabelLado(i)}</strong>${memorialHtml}${badgeHtml}
-          <div style="display:grid; grid-template-columns: 1fr 2fr; gap:6px; margin-top:4px;">
+          <div class="lp-grid-auto" style="gap:6px; margin-top:4px;">
             <input data-fl-medida="${i}" type="number" step="0.01" inputmode="decimal" placeholder="Medida (m)" value="${ld.medida_manual_m ?? ''}">
             <input data-fl-confront="${i}" list="dl-confrontantes" placeholder="Confrontante" value="${escape(ld.confrontante_nome || '')}">
           </div>
@@ -15201,7 +15201,7 @@ function renderLaudoTabPontos(c) {
             </div>
             <details style="margin-top:8px;">
               <summary style="font-size:11px; cursor:pointer; color:var(--text-muted);">⚙️ Editar manualmente (retroativo)</summary>
-              <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:6px;">
+              <div class="lp-grid-2" style="gap:6px; margin-top:6px;">
                 <div>
                   <label style="font-size:10px; color:var(--text-muted); display:block;">Início manual</label>
                   <input id="lp-base-inicio" type="datetime-local" value="${baseInicioISO ? new Date(baseInicioISO).toISOString().slice(0,16) : ''}" style="width:100%;">

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -16112,7 +16112,7 @@ function renderLaudoTabArt(c) {
   c.innerHTML = `
     <div class="card">
       <h3 style="margin-top:0;">📜 ART / TRT</h3>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <label><input id="la-art" type="checkbox" ${l.usa_art?'checked':''}> Possui ART (CREA)</label>
         <input id="la-art-num" placeholder="Número da ART" value="${escape(l.numero_art||'')}">
         <label><input id="la-trt" type="checkbox" ${l.usa_trt?'checked':''}> Possui TRT (CFT)</label>
@@ -16178,7 +16178,7 @@ function renderLaudoTabArt(c) {
     </div>
     <div class="card">
       <h3 style="margin-top:0;">💰 Financeiro</h3>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         <input id="la-valor" type="number" step="0.01" placeholder="Valor do serviço (R$)" value="${l.valor_servico ?? ''}">
         <select id="la-fp">
           <option value="">— forma de pagamento —</option>

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -14404,7 +14404,7 @@ function renderLaudoTabDados(c) {
         <br>💡 <strong>Bairros/loteamentos novos</strong> são cadastrados automaticamente ao salvar (ficam no celular pra próxima).
         <a href="#" id="ld-gerenciar-cad" style="color:var(--gold); text-decoration:underline;">Gerenciar cadastros locais</a>
       </p>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+      <div class="lp-grid-2">
         ${isUrbano ? `
           <select id="ld-tipo-lote">
             <option value="">— tipo de lote —</option>
@@ -14432,12 +14432,12 @@ function renderLaudoTabDados(c) {
         ℹ️ Opcional — preencha se o imóvel já tem registro. Aplica em rural (fazenda) e urbano.
         <br>💡 v3.2.0: catálogo nacional CNJ com ~3.7k cartórios de Registro de Imóveis. Digite 3+ letras pra buscar (filtra pela UF do imóvel).
       </p>
-      <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px;">
+      <div class="lp-grid-3">
         <input id="ld-matricula" placeholder="Matrícula" value="${escape(l.matricula||'')}">
         <input id="ld-livro" placeholder="Livro (ex: 2-A)" value="${escape(l.livro||'')}">
         <input id="ld-folhas" placeholder="Folhas (ex: 123/v)" value="${escape(l.folhas||'')}">
       </div>
-      <div style="display:grid; grid-template-columns:2fr 1fr; gap:8px; margin-top:8px;">
+      <div class="lp-grid-auto" style="margin-top:8px;">
         <div style="position:relative;">
           <input id="ld-cartorio-nome" placeholder="Cartório (digite cidade, nome ou responsável)" value="${escape(l.cartorio_nome||'')}" autocomplete="off">
           <div id="ld-cartorio-sugestoes" style="display:none; position:absolute; top:100%; left:0; right:0; background:#1a1a1a; border:1px solid var(--gold); border-top:none; max-height:280px; overflow-y:auto; z-index:1000; box-shadow:0 4px 12px rgba(0,0,0,0.6); font-size:12px;"></div>
@@ -14450,7 +14450,7 @@ function renderLaudoTabDados(c) {
         <h3 style="margin:0;">Confrontantes</h3>
         <button id="ld-cf-swap-fb" type="button" title="Trocar valores entre Frente e Fundo" style="font-size:11px; padding:3px 8px;">🔄 Trocar Frente↔Fundo</button>
       </div>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-top:8px;">
+      <div class="lp-grid-2" style="margin-top:8px;">
         <input id="ld-cf-frente" list="dl-confrontantes" placeholder="Frente (ex: Rua, Avenida, vizinho)" value="${escape(l.confrontante_frente||'')}">
         <input id="ld-cf-fundo" list="dl-confrontantes" placeholder="Fundo" value="${escape(l.confrontante_fundo||'')}">
         <input id="ld-cf-dir" list="dl-confrontantes" placeholder="Lateral direita" value="${escape(l.confrontante_lat_dir||'')}">

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -16611,7 +16611,7 @@ function renderLoteamentoUpload(v) {
       relEl.innerHTML = `
         <div class="card" style="border-left:3px solid ${preview ? '#0ea5e9' : 'var(--gold)'};">
           <h4 style="margin:0 0 6px;">${preview ? '👁 Preview' : '✅ Import realizado'} · ${escape(r.loteamento_nome || '—')}</h4>
-          <div style="display:grid; grid-template-columns:repeat(3,1fr); gap:6px; font-size:13px;">
+          <div class="lp-grid-3" style="gap:6px; font-size:13px;">
             <div>📋 Total linhas: <strong>${r.total_linhas}</strong></div>
             <div>🆕 Lotes criados: <strong style="color:var(--gold);">${r.lotes_criados}</strong></div>
             <div>🔄 Atualizados: <strong>${r.lotes_atualizados}</strong></div>
@@ -16749,7 +16749,7 @@ async function mountLoteamentoSelectorsLaudo() {
         medidas teóricas e área.
         ${loteamentos.length === 0 ? '<br><em>⚠️ Nenhum loteamento cadastrado. Vá na aba <strong>🏘️ Loteamentos</strong> pra importar.</em>' : ''}
       </p>
-      <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px;">
+      <div class="lp-grid-3">
         <select id="ld-lt-loteamento" ${loteamentos.length === 0 ? 'disabled' : ''}>
           <option value="">— loteamento —</option>
           ${loteamentos.map(lt => `<option value="${lt.id}" ${preSel.loteamentoId === lt.id ? 'selected' : ''}>${escape(lt.nome)}</option>`).join('')}

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -103,6 +103,28 @@
     display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 8px;
   }
   @media (max-width: 600px) { .form-grid { grid-template-columns: 1fr; } }
+
+  /* === LP-GRID: utility classes responsivas (v3.3.0) === */
+  .lp-grid-auto {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 8px;
+  }
+  .lp-grid-2 { display: grid; grid-template-columns: 1fr 1fr;        gap: 8px; }
+  .lp-grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr;    gap: 8px; }
+  .lp-grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+  .lp-grid-5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
+
+  @media (max-width: 768px) {
+    .lp-grid-auto, .lp-grid-2, .lp-grid-3, .lp-grid-4, .lp-grid-5 {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 900px) and (min-width: 769px) {
+    .lp-grid-4, .lp-grid-5 { grid-template-columns: 1fr 1fr; }
+  }
+
   input, select, textarea, button {
     font-family: inherit; font-size: 14px; padding: 8px 12px;
     border: 1px solid var(--border); border-radius: var(--radius);

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.2.0';
+const CACHE = 'zayra-v3.3.0';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
## Summary

v3.3.0 Mobile Foundation — torna o `obras.html` totalmente operacional em viewports mobile (≤768px) sem mexer em backend. **15 commits, 57 conversões de inline grids para utility classes**, tudo em um arquivo (`src/public/obras.html`) + bump de versão.

Motivado por screenshot do CEO em campo no rugged GNSS: coluna "Confrontante" cortada em "Confro..." na aba Dados do laudo, impossível de ler durante demarcação real. Investigação mostrou que `obras.html` tinha 108 inline grids ignorando viewports mobile (o `@media (max-width: 768px)` global não atinge inline styles).

## O que tem dentro

### Bloco 1 — Foundation (5 commits)
- `docs(v3.3.0)`: spec + plan de implementação
- `feat(mobile)`: utility classes `.lp-grid-auto` / `.lp-grid-2/3/4/5` no `<style>` global
- `feat(mobile)`: safety net `[style*="grid-template-columns"]:not([data-keep-grid])` força 1-col em qualquer inline grid não migrado
- `chore`: bump 3.2.0 → 3.3.0 em `package.json` + `identity.ts`
- `chore`: **bump `CACHE = 'zayra-v3.3.0'` em `sw.js` (ÚLTIMO commit do bloco)** — ordem crítica para não criar versão inconsistente em clients abertos entre commits

### Bloco 2 — View-by-view refactor (9 commits, 56 conversões)
Cada commit cobre uma área navegacional inteira:

| Commit | View | Conversões |
|---|---|---|
| `refactor laudo tab Dados` | Aba do screenshot original do CEO | 4 |
| `refactor laudo tab Pontos` | Vértices + medidas (rugged GNSS) | 4 |
| `refactor laudo tab Cadastros` | Contratante / Rep PJ / Executor RT | 3 |
| `refactor laudo tab Art` | ART/TRT + Financeiro | 2 |
| `refactor Loteamentos` | Stats import + dropdowns encadeados | 2 |
| `refactor renderNotas` | NFe.io config + endereço + valor/código/iss | 3 |
| `refactor renderRecibos` | Form recibo + cadastro cliente PF/PJ + modal NFe | 12 |
| `refactor renderCalculos region` | Calculadoras + ZAYRA visual + Laudo Novo wizard | 11 |
| `refactor renderPropostasLista + Editor` | Cards de proposta + forms | 15 |

### Bloco 3 — Modais + audit (1 commit + audit, 1 conversão)
- `refactor modal Editar Obra`: 1fr 2fr → lp-grid-auto
- **Audit dos demais (todos no-op):**
  - Calendar (`.cal-grid` 7 cols): classe CSS — safety net não atinge, já preserva 7 cols em mobile naturalmente
  - Modal Cartão/ZAYRA/Cartórios/Clonagem: zero inline grids fixos pendentes
  - Inputs com width fixo: todos widths pequenos (60-120px) intencionais em cells de tabela; nenhum ≥170px problemático
  - Botões com padding pequeno: regra global `@media { button { min-height: 44px } }` já garante touch target
  - Tabelas: main-page (Folha 4192/4259) já com `<div style="overflow-x:auto;">`; outras em print templates isolados

## Ordem dos commits do bloco Foundation (crítica)

CACHE bump em `sw.js` foi o ÚLTIMO commit do bloco foundation. Garante que utility classes + safety net já estão no HTML quando o cache rotaciona nos clients — clients abertos entre commits não pegam HTML novo apontando para classes que ainda não existem.

## Como a safety net protege casos não-migrados

`[style*="grid-template-columns"]:not([data-keep-grid])` no `@media (max-width: 768px)` força 1-coluna para qualquer inline grid em viewport mobile. Cobre:
- Tabelas `1fr 70px 100px 30px` em Despesas (intencional ficar não-migrado)
- Split Vale `minmax(320px, 420px) 1fr` em Propostas Editor (preserva proporção em desktop, colapsa em mobile)
- Qualquer grid inline futuro

`data-keep-grid` é o opt-out (não usado neste release — calendar usa classe CSS, safety net já não atinge).

## Spec + Plan
- Spec: [docs/superpowers/specs/2026-05-10-mobile-foundation-design.md](docs/superpowers/specs/2026-05-10-mobile-foundation-design.md)
- Plan: [docs/superpowers/plans/2026-05-10-mobile-foundation.md](docs/superpowers/plans/2026-05-10-mobile-foundation.md)

## Test plan

### Automatizado
- [x] `npm run typecheck` passa (verificado após cada commit)
- [x] Sem testes Vitest novos (ROI baixo pra layout responsivo)

### Manual (DOD — validado pelo CEO em produção)
- [x] V3.3.0 ativo no rugged GNSS (badge verde visível)
- [x] Layout operacional: campos sem corte, tabs do laudo navegáveis, sub-tabs do laudo renderizando
- [x] Autocomplete de cartórios (v3.2.0) ainda funcionando

## Versão

```
package.json    : 3.2.0 → 3.3.0
identity.ts     : 3.2.0 → 3.3.0
sw.js (CACHE)   : zayra-v3.2.0 → zayra-v3.3.0
```

## Decisões importantes

1. **Inline execution sobre subagent-driven**: depois do audit completo (108 grids categorizados — 8 tasks no-op, 11 substantivas), ficou claro que dispatch de 33+ subagents (impl + 2 reviews × 11 tasks) pra fazer 84 Edit operations mecânicos em 1 arquivo desperdiçaria 5x o tempo sem ganho de qualidade.

2. **PR único v3.3.0 em vez de PR1+PR2+PR3 separados**: governança ajustada após perceber que PR1 já entrega valor (safety net resolve a dor visível em campo), e dividir traria overhead de review × 3 sem benefício real.

3. **Calendar (`.cal-grid`) intocado**: classe CSS (não inline), safety net não atinge — já preserva 7 colunas em mobile naturalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

