### PR TITLE
Fix/vto pdf mobile laudo v3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.4.1',
+  version: '3.4.2',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/integrations/vistorias.ts
+++ b/src/integrations/vistorias.ts
@@ -540,17 +540,23 @@ export async function gerarPdfVistoria(
     );
   }
 
-  // v3.4.1: itera buffered pages e desenha footer em CADA pagina (em vez de
-  // uma chamada solta no fim do doc que criava pagina vazia). lineBreak:false
-  // garante que o texto nao tente quebrar e disparar pagina nova.
+  // v3.4.2: itera buffered pages e desenha footer em CADA pagina.
+  // CRITICO: footer fica em Y=812 (page.height - 30), que esta ABAIXO da margem
+  // inferior padrao (842-48=794). Sem mexer na margem, PDFKit dispara auto-page-
+  // break em cada chamada de text() e cria N paginas vazias (uma por pagina
+  // original). Setando margins.bottom=0 ao redor do text(), a area usavel se
+  // estende ate o fim da pagina e o footer fica abaixo sem disparar break.
   const range = doc.bufferedPageRange();
   for (let i = range.start; i < range.start + range.count; i++) {
     doc.switchToPage(i);
+    const savedBottomMargin = doc.page.margins.bottom;
+    doc.page.margins.bottom = 0;
     doc.fontSize(8).fillColor('#888').text(
       `${brand} — Relatório gerado eletronicamente.`,
       48, doc.page.height - 30,
       { width: 499, align: 'center', lineBreak: false },
     );
+    doc.page.margins.bottom = savedBottomMargin;
   }
   doc.end();
   await new Promise<void>(resolve => doc.on('end', () => resolve()));

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -131,6 +131,22 @@
     [style*="grid-template-columns"]:not([data-keep-grid]) {
       grid-template-columns: 1fr !important;
     }
+    /* v3.4.2: filhos do grid com grid-column inline (ex: "1/3") expandiam pra
+       2 colunas mesmo com o container forcado pra 1fr — o browser criava uma
+       coluna implicita e o card estourava o viewport. Reseta pra auto. */
+    .lp-grid-auto > [style*="grid-column"],
+    .lp-grid-2 > [style*="grid-column"],
+    .lp-grid-3 > [style*="grid-column"],
+    .lp-grid-4 > [style*="grid-column"],
+    .lp-grid-5 > [style*="grid-column"] {
+      grid-column: auto !important;
+    }
+    /* v3.4.2: select/input dentro de card nunca estoura coluna mesmo com
+       option longa (ex: "FAZENDA GLORIA - INCORPORADORA EXEMPLO LTDA") ou
+       datalist. min-width:0 e' o truque que permite o flex/grid encolher. */
+    .card select, .card input, .card textarea {
+      max-width: 100%; min-width: 0;
+    }
   }
 
   input, select, textarea, button {

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.4.1';
+const CACHE = 'zayra-v3.4.2';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
## Sumário
Dois hotfixes:

### 1. PDF VTO — paginas em branco apos assinatura
A v3.4.1 piorou o bug original: antes era 1 pagina em branco (7 paginas total), virou 6 paginas em branco (12 paginas total). Causa: o footer no loop `bufferedPageRange` usa Y=812 (page.height - 30) que esta abaixo da margem inferior padrao (Y=794). Cada chamada `text()` em Y fora da area usavel dispara auto-page-break — multiplicado por N paginas no loop.

**Fix:** ao redor de cada `text()` do footer, seta `margins.bottom = 0` temporariamente, desenha, restaura. Sem auto-page-break. PDF fica com exatamente as paginas de conteudo (6).

### 2. Mobile — Laudo de Demarcacao estourando viewport
Cards "Identificacao do imovel" e "Confrontantes" estouravam horizontalmente em 360x800 / 412x915. Causa: inputs com `style="grid-column:1/3;"` inline. Em mobile a media query reseta `grid-template-columns` do container, mas nao reseta `grid-column` dos filhos — browser cria coluna implicita pra acomodar "1/3" e o card expande alem do viewport.

**Fix:** reset `grid-column: auto !important` em mobile pra filhos dos containers `.lp-grid-*` com `grid-column` inline. Bonus: `max-width:100% + min-width:0` em todos os inputs/selects de `.card` pra prevenir estouro por option longa em select.

## Validação pós-merge
- [ ] Re-assinar VTO #7 → confirmar PDF com EXATAMENTE 6 paginas (sem paginas em branco)
- [ ] Adobe Reader: confirmar assinatura ICP-Brasil ainda valida
- [ ] Mobile (360x800): abrir Laudo de Demarcacao → cards de Identificacao e Confrontantes sem scroll horizontal
- [ ] Mobile (412x915): mesma validacao

4 commits, CACHE bump (`zayra-v3.4.2`) como ultimo.
