### PR TITLE
Fix/hero obra ativa mobile v3.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Roma — Assistente executivo de voz da Romatec Consultoria Imobiliária",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,7 @@
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.4.2',
+  version: '3.4.3',
   company: 'Romatec Consultoria Imobiliária',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -147,6 +147,20 @@
     .card select, .card input, .card textarea {
       max-width: 100%; min-width: 0;
     }
+    /* v3.4.3: ~30 elementos no app usam padrao "flex:1; min-width:NNNpx" pra
+       garantir tamanho minimo no desktop (Hero Card "Obra Ativa", Folha Mensal,
+       laudos, recibos, etc). Em mobile com flex-wrap, esses elementos quebram
+       pra proxima linha mas o min-width forca largura > viewport, causando
+       scroll horizontal. Reseta min-width pra 0 em mobile (com flex-wrap o
+       elemento ocupa 100% naturalmente). */
+    [style*="min-width:140px"], [style*="min-width: 140px"],
+    [style*="min-width:160px"], [style*="min-width: 160px"],
+    [style*="min-width:180px"], [style*="min-width: 180px"],
+    [style*="min-width:200px"], [style*="min-width: 200px"],
+    [style*="min-width:220px"], [style*="min-width: 220px"],
+    [style*="min-width:240px"], [style*="min-width: 240px"] {
+      min-width: 0 !important;
+    }
   }
 
   input, select, textarea, button {
@@ -1601,14 +1615,14 @@ function renderDashboard() {
     const statusCor = obra.status === 'concluida' ? 'var(--neon)' : obra.status === 'paralisada' ? 'var(--warning)' : 'var(--gold)';
     hero = `<div class="card" style="background:linear-gradient(135deg, rgba(0,255,153,0.06), rgba(255,184,0,0.04)); border:1px solid var(--gold-dim); margin-bottom:14px;">
       <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:12px; flex-wrap:wrap;">
-        <div style="flex:1; min-width:240px;">
+        <div style="flex:1 1 240px; min-width:0;">
           <p style="margin:0 0 4px; font-size:11px; text-transform:uppercase; letter-spacing:0.6px; color:var(--text-muted);">Obra Ativa</p>
           <h2 style="margin:0; font-size:20px; color:var(--gold);">${escape(obra.nome)}</h2>
           <p style="margin:4px 0; font-size:13px;">${escape(obra.cliente||'-')}</p>
           <p style="margin:2px 0; font-size:12px; color:var(--text-muted);">${escape(obra.endereco||'-')}${obra.cidade?', '+escape(obra.cidade):''}</p>
           <p style="margin:8px 0 0;"><span class="badge" style="background:${statusCor}; color:#000; font-weight:600;">${escape(obra.status)}</span></p>
         </div>
-        <div style="min-width:200px; text-align:right;">
+        <div style="flex:1 1 200px; min-width:0; text-align:right;">
           <p style="margin:0; font-size:11px; text-transform:uppercase; letter-spacing:0.6px; color:var(--text-muted);">Orçamento</p>
           <p style="margin:4px 0; font-size:24px; color:var(--gold); font-weight:600;">${fmt(orc)}</p>
           <p style="margin:8px 0 4px; font-size:11px; color:var(--text-muted);">Consumo: ${consumo}% (${fmt(sai)})</p>
@@ -4295,7 +4309,7 @@ function renderFolha() {
       <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-bottom: 12px;">
         <button id="folhaPrev">◀ Mês anterior</button>
         <button id="folhaNext">Próximo ▶</button>
-        <select id="folhaObra" style="flex:1; min-width:200px;">${obraOpts}</select>
+        <select id="folhaObra" style="flex:1 1 200px; min-width:0;">${obraOpts}</select>
         <button id="folhaPdf" class="btn-gold">📄 Exportar PDF</button>
         <button id="folhaCsv" class="btn-gold">📊 CSV</button>
       </div>

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker da ZAYRA — versão atrelada à versão do app pra forçar
 // rotação de cache em todo deploy. Se você bumpar a versão do app, bumpe esta
 // constante também (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.4.2';
+const CACHE = 'zayra-v3.4.3';
 
 // App shell — recursos cacheados na instalação para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia também /obras e /js/catalogo-servicos.js — sem isso,


### PR DESCRIPTION
## Sumário
Bug: Hero Card "OBRA ATIVA" no Painel e aba "Folha Mensal" estouravam o viewport mobile. Causa raiz é o padrão `flex:1; min-width:NNNpx` espalhado em ~30 lugares pelo app (Hero, Folha, laudos, recibos, propostas, etc) — em mobile com `flex-wrap:wrap`, mesmo quebrando pra próxima linha, o `min-width:240px` força largura > viewport 360px.

## Fix em 2 camadas
1. **Inline nos 3 alvos confirmados** (Hero Card x2, Folha Mensal select): troca `flex:1; min-width:Xpx` por `flex:1 1 Xpx; min-width:0` — melhora desktop também (basis explícito).
2. **CSS global em mobile**: attribute selectors cobrem `[style*="min-width:140/160/180/200/220/240px"]` setando `min-width:0 !important`. Cobre os ~28 outros lugares sem precisar editar cada um.

## Validação pós-deploy
- [ ] Painel mobile (360x800): card "OBRA ATIVA" sem scroll horizontal
- [ ] Aba Folha Mensal mobile: select obra + tabela sem scroll horizontal no container (tabela mantém scroll INTERNO de 680px que é proposital)
- [ ] Outras telas (laudos, recibos, vto): verificar que nada quebrou no desktop

4 commits, CACHE bump (`zayra-v3.4.3`) como último.
