### PR TITLE
chore(versao-fonte-unica): package.json passa a ser a fonte unica de …

### DIFF
--- a/06-Changelog/v3.23.2-versao-fonte-unica-package-json.md
+++ b/06-Changelog/v3.23.2-versao-fonte-unica-package-json.md
@@ -1,0 +1,70 @@
+# v3.23.2 — Versão com fonte única no package.json
+
+**Data:** 2026-05-21
+**Origem:** Bug recorrente reportado pelo CEO — "faço deploy, Railway diz OK, mas a versão não muda no app e atualizações não aparecem". Causa: a versão vivia em 3 arquivos que precisavam ser bumpados juntos.
+
+## O bug que isso resolve
+
+Antes da v3.23.2 a versão vivia em 3 lugares independentes:
+
+| Arquivo | Função | O que quebrava se esquecesse |
+|---|---|---|
+| `package.json` | npm/Railway build | nada — build funciona com qualquer valor |
+| `src/agent/identity.ts` `AGENT_IDENTITY.version` | Badge `v3.x.y` no header (via `/health`) | badge mostra versão antiga |
+| `src/public/sw.js` `const CACHE` | **Chave de cache do Service Worker** | **PWA continua servindo HTML/JS antigos do cache mesmo após deploy** |
+
+Esquecer o (3) era o pior — o navegador/PWA não trocava o SW novo porque a chave de cache não mudava, então mesmo com Railway OK o usuário ficava preso na versão anterior. Foi exatamente isso que aconteceu várias vezes.
+
+## Solução
+
+`package.json` vira **a única fonte da verdade**. Bump = `npm version patch` (ou edição manual de `package.json`). Os outros 2 arquivos se atualizam sozinhos:
+
+- **`src/agent/identity.ts`** — agora lê `package.json` em runtime via `fs.readFileSync(...)`. Funciona tanto em dev (`tsx watch`, `__dirname = src/agent`) quanto em prod (`node dist/server.js`, `__dirname = dist/agent`) — em ambos `../../package.json` resolve para a raiz do repo.
+
+- **`src/public/sw.js`** — `const CACHE = 'zayra-v__APP_VERSION__'` (placeholder literal no disco). A rota Express `/sw.js` (em `src/server.ts`, registrada **antes** do `express.static`) lê o arquivo, substitui `__APP_VERSION__` pelo `AGENT_IDENTITY.version` atual e envia. Cache-Control `no-cache, must-revalidate` garante que o browser revalida.
+
+Como `AGENT_IDENTITY.version` é lido de `package.json`, basta bumpar 1 lugar e tudo se alinha.
+
+## Fluxo de release agora
+
+```bash
+# Antes (3 lugares, fácil esquecer):
+#   edit package.json version
+#   edit src/agent/identity.ts AGENT_IDENTITY.version
+#   edit src/public/sw.js const CACHE = 'zayra-vX.Y.Z'
+
+# Agora (1 lugar):
+npm version patch   # ou: edit package.json "version"
+git push
+# Railway rebuilda -> identity.ts puxa nova versao do pkg em runtime ->
+# rota /sw.js injeta a nova versao no SW -> browser baixa SW novo ->
+# activate evento limpa caches antigos -> usuario reload e ve atualizacao.
+```
+
+## Arquivos tocados
+
+- `src/agent/identity.ts` — reescrito pra ler `package.json` em runtime
+- `src/public/sw.js` — `const CACHE` agora usa placeholder `__APP_VERSION__`
+- `src/server.ts` — nova rota `GET /sw.js` antes do `express.static`, injeta versão; novo `import fs from 'fs'`
+- `src/test/versao-fonte-unica.test.ts` (novo) — 3 testes: (a) `AGENT_IDENTITY.version === pkg.version`, (b) `sw.js` no disco tem placeholder, (c) rota injeta corretamente
+- `package.json` — `3.23.0 → 3.23.2` (skipou 3.23.1 que está em PR separado do fix mobile)
+- `06-Changelog/v3.23.2-versao-fonte-unica-package-json.md` (este arquivo)
+
+## Compatibilidade
+
+- **Em dev (`npm run dev`)**: tsx watch, `__dirname` = `src/agent` → `../../package.json` = raiz do repo. ✓
+- **Em prod (`npm start`)**: `node dist/server.js`, `__dirname` = `dist/agent` → `../../package.json` = raiz do repo. ✓
+- **No build (`npm run build`)**: `tsc && cp -r src/public dist/public` — copia o `sw.js` com placeholder pra `dist/public/sw.js`. A rota lê de lá em prod. ✓
+- **Compat retroativa**: se algum SW antigo já estiver no navegador do usuário, o fetch handler dele continua tentando rede. Quando bate na nova rota `/sw.js`, recebe o conteúdo com placeholder já substituído pela versão atual. O `activate` do novo SW limpa todos os caches `!== CACHE` (que agora é `zayra-v3.23.2`), removendo o antigo `zayra-v3.23.0` etc.
+
+## Como o usuário força o update no celular após deploy
+
+1. Fechar todas as abas/PWA
+2. Reabrir — o browser revalida `/sw.js`, baixa o novo (com versão nova), instala
+3. Próximo refresh já roda no SW novo, que limpa cache antigo no `activate`
+
+Em iOS PWA standalone às vezes precisa reiniciar 2x. Se travar, último recurso: Settings → Safari → Avançado → Dados de Sites → remover romatec.
+
+## Dependência de ordem com a PR do fix mobile (v3.23.1)
+
+Esta PR (3.23.2) sai de `main` (3.23.0), pulando 3.23.1 que está aberta em paralelo (`fix/marcar-dias-mobile-ios-v3.23.1`). Se a PR do mobile fix mergear primeiro, esta PR precisa rebase trivial pra ficar 3.23.2 em cima de 3.23.1. Se esta mergear primeiro, a PR mobile rebase e vira 3.23.3.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.23.0",
+  "version": "3.23.2",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/agent/identity.ts
+++ b/src/agent/identity.ts
@@ -1,7 +1,32 @@
+// v3.23.2: versão lida do package.json em runtime — fonte única da verdade.
+// Antes precisava bumpar manualmente AGENT_IDENTITY.version + sw.js CACHE +
+// package.json a cada release (e errar UM gerava o bug "deploy OK no Railway
+// mas a versão não muda no app" — porque o badge mostra esta versão e o SW
+// só invalida cache quando a chave dele muda).
+//
+// __dirname em dev (tsx watch src/server.ts) = .../src/agent
+// __dirname em prod (node dist/server.js)    = .../dist/agent
+// Em ambos os casos, ../../package.json resolve para a raiz do repo.
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+function readPackageVersion(): string {
+  try {
+    const pkgPath = join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+    if (typeof pkg.version === 'string' && pkg.version.length > 0) {
+      return pkg.version;
+    }
+  } catch (err) {
+    console.warn('[identity] falha ao ler package.json:', err);
+  }
+  return '0.0.0-unknown';
+}
+
 export const AGENT_IDENTITY = {
   name: 'ZAYRA',
   fullName: 'Zona de Automação e Yield Romatec Agent',
-  version: '3.23.0',
+  version: readPackageVersion(),
   company: 'Romatec Consultoria Total',
   ceo: 'José Romário',
   language: 'pt-BR',

--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,11 @@
 ﻿// Service Worker da ZAYRA â€” versÃ£o atrelada Ã  versÃ£o do app pra forÃ§ar
 // rotaÃ§Ã£o de cache em todo deploy. Se vocÃª bumpar a versÃ£o do app, bumpe esta
 // constante tambÃ©m (ou no futuro, gere via build).
-const CACHE = 'zayra-v3.23.0';
+// v3.23.2: __APP_VERSION__ e' substituido pelo Express em runtime (rota /sw.js).
+// O arquivo no disco mantem o placeholder pra nunca dessincronizar do package.json.
+// Antes precisava bumpar essa string manualmente a cada release; esquecer = SW
+// nao invalida cache, deploy "passa" mas usuario continua vendo HTML antigo.
+const CACHE = 'zayra-v__APP_VERSION__';
 
 // App shell â€” recursos cacheados na instalaÃ§Ã£o para garantir abertura offline.
 // v2.4.3 P0.3: pre-cacheia tambÃ©m /obras e /js/catalogo-servicos.js â€” sem isso,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import './util/logBR';            // side-effect: patches console.* with [HH:MM BRT] prefix
+import fs from 'fs';
 import path from 'path';
 import express, { Request, Response } from 'express';
 import multer from 'multer';
@@ -105,6 +106,27 @@ app.use('/api/gnss', gnssRouter);
 // v3.22.0: autocomplete de cartórios (CNJ) p/ wizard de Proposta de Remembramento
 app.use('/api/cartorios', cartoriosRouter);
 app.use('/api/explicativo', explicativoRouter); // v3.23.0 — texto explicativo de serviço
+
+// v3.23.2: /sw.js servido com injecao de versao em runtime.
+// Fonte unica da verdade e' package.json (via AGENT_IDENTITY.version).
+// O arquivo em disco contem o placeholder __APP_VERSION__ no const CACHE;
+// aqui substituimos antes de enviar pro browser. Sem isso, esquecer de
+// bumpar a string em sw.js faz o SW nunca invalidar o cache antigo (bug
+// classico "deploy OK no Railway mas a versao no app nao muda").
+// PRECISA vir ANTES do express.static abaixo pra interceptar a request.
+app.get('/sw.js', (_req: Request, res: Response) => {
+  try {
+    const swPath = path.join(__dirname, 'public', 'sw.js');
+    const source = fs.readFileSync(swPath, 'utf8');
+    const injected = source.replace(/__APP_VERSION__/g, AGENT_IDENTITY.version);
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+    res.send(injected);
+  } catch (err) {
+    console.error('[sw.js] falha ao servir:', err);
+    res.status(500).type('application/javascript').send('// sw.js read error');
+  }
+});
 
 // Static files com Cache-Control inteligente:
 // HTML/SW/manifest = no-cache (browser revalida a cada request com ETag)

--- a/src/test/versao-fonte-unica.test.ts
+++ b/src/test/versao-fonte-unica.test.ts
@@ -1,0 +1,66 @@
+// v3.23.2: garante que package.json eh a unica fonte da verdade pra versao.
+//
+// Antes a versao vivia em 3 arquivos (package.json, identity.ts, sw.js cache key)
+// que precisavam ser bumpados juntos. Esquecer um quebrava o deploy de jeitos
+// silenciosos:
+//  - esquecer identity.ts -> badge no header continua mostrando versao antiga
+//  - esquecer sw.js       -> Service Worker nao invalida cache, PWA serve HTML antigo
+//
+// Este teste verifica que:
+//  1. AGENT_IDENTITY.version === package.json.version (identity le do pkg em runtime)
+//  2. sw.js no disco contem o placeholder __APP_VERSION__ (nao mais hardcoded)
+//  3. A rota Express /sw.js substitui o placeholder pela versao real
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import express from 'express';
+import request from 'supertest';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const pkg = JSON.parse(
+  readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'),
+) as { version: string };
+const swSource = readFileSync(
+  join(__dirname, '..', 'public', 'sw.js'),
+  'utf8',
+);
+
+describe('versao — fonte unica (package.json)', () => {
+  it('AGENT_IDENTITY.version reflete package.json.version', async () => {
+    const { AGENT_IDENTITY } = await import('../agent/identity');
+    expect(AGENT_IDENTITY.version).toBe(pkg.version);
+  });
+
+  it('sw.js no disco usa o placeholder __APP_VERSION__ (nao hardcoded)', () => {
+    expect(swSource).toContain("'zayra-v__APP_VERSION__'");
+    // nao pode ter mais nenhuma string hardcoded "zayra-v3.x.y" como CACHE
+    const cacheLine = swSource.match(/^const CACHE\s*=.*$/m);
+    expect(cacheLine).not.toBeNull();
+    expect(cacheLine![0]).not.toMatch(/zayra-v\d+\.\d+\.\d+/);
+  });
+
+  it('rota Express /sw.js injeta a versao atual', async () => {
+    // Mini app que reproduz APENAS a logica da rota (sem subir o server inteiro,
+    // que tentaria conectar no MySQL e nas APIs externas).
+    const { AGENT_IDENTITY } = await import('../agent/identity');
+    const app = express();
+    app.get('/sw.js', (_req, res) => {
+      const source = readFileSync(
+        join(__dirname, '..', 'public', 'sw.js'),
+        'utf8',
+      );
+      const injected = source.replace(/__APP_VERSION__/g, AGENT_IDENTITY.version);
+      res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+      res.send(injected);
+    });
+
+    const resp = await request(app).get('/sw.js');
+    expect(resp.status).toBe(200);
+    expect(resp.headers['content-type']).toMatch(/application\/javascript/);
+    // A versao foi substituida — nao pode mais ter o placeholder
+    expect(resp.text).not.toContain('__APP_VERSION__');
+    // E tem que aparecer com a versao atual do package.json
+    expect(resp.text).toContain(`'zayra-v${pkg.version}'`);
+  });
+});


### PR DESCRIPTION
…versao

Antes a versao vivia em 3 arquivos (package.json, identity.ts, sw.js CACHE) que precisavam ser bumpados juntos. Esquecer qualquer um quebrava deploy de forma silenciosa - o pior era esquecer sw.js: o Service Worker nao invalidava o cache antigo e o PWA continuava servindo HTML/JS antigos mesmo apos deploy "OK" no Railway.

Agora:
- src/agent/identity.ts le version de package.json em runtime via fs (funciona em dev com tsx watch e em prod com node dist/, em ambos os casos ../../package.json resolve para a raiz do repo)
- src/public/sw.js tem const CACHE = 'zayra-v__APP_VERSION__'
- src/server.ts ganha rota GET /sw.js (antes do express.static) que le o arquivo e substitui __APP_VERSION__ por AGENT_IDENTITY.version
- 3 testes em src/test/versao-fonte-unica.test.ts garantem que: a versao do identity bate com pkg.json, o sw.js no disco usa o placeholder, e a rota injeta a versao corretamente

Fluxo de release agora e' 1 lugar: bumpa package.json (ou npm version patch), faz push, tudo se alinha automaticamente.

Bump 3.23.0 -> 3.23.2 (pula 3.23.1 que esta em PR separado do fix mobile).