### PR TITLE
fix(anexos-dropzone): wire-up unificado em todas as 5 modalidades de …

### DIFF
--- a/06-Changelog/v3.23.4-anexos-dropzone-todas-modalidades.md
+++ b/06-Changelog/v3.23.4-anexos-dropzone-todas-modalidades.md
@@ -1,0 +1,67 @@
+# v3.23.4 — Dropzone de Anexos quebrado em 4 das 5 modalidades de Nova Proposta
+
+**Data:** 2026-05-21
+**Origem:** CEO reportou via screenshot — tentando anexar planta em Nova Proposta → Desmembramento, clicar no dropzone "Clique ou arraste arquivos" não fazia nada. File picker nunca abria. Hipótese inicial era sobreposição de elementos pelo botão "+ Novo cliente", mas o bug real era mais sério: 4 das 5 telas de Nova Proposta renderizavam o dropzone sem nenhum handler conectado.
+
+## Diagnóstico
+
+A tela de Nova Proposta tem 5 forms diferentes, um por modalidade:
+
+| Form (função) | Modalidade |
+|---|---|
+| `renderConsultoriaFormInline` | Averbação (e dispatcher pros outros) |
+| `renderConsultoriaFormGeoRural` | Georreferenciamento Rural (INCRA) |
+| `renderConsultoriaFormDesmRem` | **Desmembramento / Remembramento** |
+| `renderConsultoriaFormRetificacao` | Retificação de Área |
+| `renderConsultoriaFormPTAM` | Avaliação PTAM |
+
+Os 5 forms renderizam **o mesmo HTML** do dropzone (`<label id="cnsDropZone">` + `<input type="file" id="cnsAnexoInput">`), mas o código de wireup (`dropZone.onclick = () => fileInput.click()` + drag/drop handlers + leitura do arquivo) só existia inline em `renderConsultoriaFormInline`. **Os outros 4 forms não chamavam o wireup**, então o dropzone ficava no DOM mas inerte — clicar não fazia nada, drop não fazia nada.
+
+A intuição visual do CEO sobre "+ Novo cliente" estar sobreposto era um falso positivo (red herring) — o botão estava onde devia, mas como o dropzone não tinha handler, a impressão era de "alguma coisa interceptando o clique".
+
+## Fix
+
+Extrair o wireup pra função reutilizável `wireUpAnexosDropzone(subtipo)` no nível do módulo e chamar de **todas as 5** funções de render. State compartilhado continua em `state.consultoriaAnexosTemp` / `state.consultoriaAnexosExistentes` (já era global). O `subtipo` (já existente em todas as 5 funções como variável local) serve pra detectar troca de proposta e limpar `consultoriaAnexosTemp`.
+
+## Arquivos tocados
+
+- `src/public/obras.html`:
+  - +helper `wireUpAnexosDropzone(subtipo)` antes da linha ~6220
+  - `renderConsultoriaFormInline`: 71 linhas inline removidas, substituídas pela chamada ao helper
+  - `renderConsultoriaFormGeoRural` (~linha 6715): nova chamada
+  - `renderConsultoriaFormDesmRem` (~linha 7059): nova chamada
+  - `renderConsultoriaFormRetificacao` (~linha 7719): nova chamada
+  - `renderConsultoriaFormPTAM` (~linha 7913): nova chamada
+- `src/test/anexos-dropzone-wireup.test.ts` (novo) — 4 testes: garantem 1 definição do helper, 5 invocações (1 por render fn), handler `onclick` correto, e contagem `<label id="cnsDropZone">` == 5
+- `package.json` — `3.23.3 → 3.23.4`
+- `06-Changelog/v3.23.4-anexos-dropzone-todas-modalidades.md` (este)
+
+## Como testar manualmente
+
+1. Abrir `/obras.html` → aba **Proposta** → **Nova Proposta**
+2. Para CADA modalidade abaixo, abrir o form e clicar no dropzone "Clique ou arraste arquivos" no card direito:
+   - ✅ Averbação
+   - ✅ Georreferenciamento Rural
+   - ✅ Desmembramento (urbano)
+   - ✅ Desmembramento Rural (INCRA)
+   - ✅ Remembramento
+   - ✅ Retificação de Área
+   - ✅ Avaliação PTAM
+3. **Esperado em cada uma:**
+   - File picker do sistema abre
+   - Selecionar PDF/JPG/PNG ≤15MB → arquivo aparece na lista abaixo do dropzone com badge "novo"
+   - Arrastar arquivo direto pro dropzone → background muda + arquivo é aceito
+   - Arquivo > 15MB → alert "excede 15 MB"
+   - Tipo não suportado (ex: .docx, .exe) → alert "não suportado"
+4. Trocar entre modalidades (botão "← Voltar" + escolher outra) — `consultoriaAnexosTemp` é limpo automaticamente
+5. Submeter proposta → anexos vão no payload via `/api/propostas-consultoria/:id/anexos` (rota existente, não mexida)
+
+## Notas de implementação
+
+- **Mantida a unicidade de IDs no DOM** (`cnsDropZone`, `cnsAnexoInput`): só 1 form fica no DOM por vez (cada `v.innerHTML = ...` substitui), então `getElementById` continua válido. Não foi necessário converter pra `querySelector`/classes.
+- **Comportamento de troca de subtipo preservado**: o helper detecta mudança via `state.consultoriaUltimoSubtipo !== subtipo` e zera `consultoriaAnexosTemp` (mesmo comportamento do código antigo inline).
+- **Limites e MIMEs preservados**: PDF/PNG/JPEG, máximo 15MB por arquivo, sem limite de quantidade. Iguais ao que existia em Averbação.
+
+## Compatibilidade
+
+Backend não mudou — endpoint `POST /api/propostas-consultoria/:id/anexos` e `DELETE /api/propostas-consultoria/anexos/:id` continuam recebendo o mesmo payload base64. Propostas já criadas com anexos seguem funcionando (lista de existentes renderiza igual).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -6217,6 +6217,89 @@ function renderConsultoriaEscolhaInline(v, toggleHTML) {
   });
 }
 
+// v3.23.4: wireup unificado do dropzone de anexos (#cnsDropZone + #cnsAnexoInput).
+// Bug recorrente — cada um dos 5 forms de Nova Proposta renderiza esse mesmo HTML mas
+// originalmente so renderConsultoriaFormInline (Averbacao) anexava handlers. Nos outros
+// 4 (GeoRural, DesmRem, Retif, PTAM) o clique no dropzone nao abria o file picker
+// porque nenhum onclick estava attached. CEO reportou ao tentar anexar planta em
+// Desmembramento. Solucao: chamar essa funcao no final do render de cada form.
+// State compartilhado em state.consultoriaAnexosTemp / state.consultoriaAnexosExistentes.
+function wireUpAnexosDropzone(subtipo) {
+  const MIMES_OK = ['application/pdf', 'image/png', 'image/jpeg', 'image/jpg'];
+  const MAX_BYTES = 15 * 1024 * 1024;
+
+  if (!state.consultoriaAnexosTemp) state.consultoriaAnexosTemp = [];
+  // Trocou de subtipo? Limpa temp pra nao misturar anexos de proposta anterior.
+  if (state.consultoriaUltimoSubtipo !== subtipo) {
+    state.consultoriaAnexosTemp = [];
+    state.consultoriaUltimoSubtipo = subtipo;
+  }
+
+  const renderAnexos = () => {
+    const lista = document.getElementById('cnsAnexosLista');
+    if (!lista) return;
+    const existentes = (state.consultoriaAnexosExistentes || []).map(a => `
+      <div style="display:flex; gap:8px; align-items:center; padding:6px 8px; background:rgba(0,255,136,0.04); border:1px solid var(--border); border-radius:6px;">
+        <span style="font-size:18px;">${a.mimetype.includes('pdf') ? '📄' : '🖼️'}</span>
+        <div style="flex:1; min-width:0; overflow:hidden;">
+          <div style="font-size:12px; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${escape(a.filename)}</div>
+          <div style="font-size:10px; color:var(--text-muted);">${(a.tamanho_bytes / 1024).toFixed(1)} KB · ${a.mimetype} · <span style="color:var(--neon);">salvo</span></div>
+        </div>
+        <button type="button" data-rm-anexo-existente="${a.id}" class="btn-danger" style="padding:4px 8px; font-size:11px;" title="Remover do banco">×</button>
+      </div>`).join('');
+    const novos = state.consultoriaAnexosTemp.map((a, i) => `
+      <div style="display:flex; gap:8px; align-items:center; padding:6px 8px; background:var(--bg-elev); border:1px solid var(--border); border-radius:6px;">
+        <span style="font-size:18px;">${a.mimetype.includes('pdf') ? '📄' : '🖼️'}</span>
+        <div style="flex:1; min-width:0; overflow:hidden;">
+          <div style="font-size:12px; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${escape(a.filename)}</div>
+          <div style="font-size:10px; color:var(--text-muted);">${(a.tamanho / 1024).toFixed(1)} KB · ${a.mimetype} · <span style="color:var(--gold);">novo</span></div>
+        </div>
+        <button type="button" data-rm-anexo="${i}" class="btn-danger" style="padding:4px 8px; font-size:11px;">×</button>
+      </div>`).join('');
+    lista.innerHTML = existentes + novos;
+    lista.querySelectorAll('[data-rm-anexo]').forEach(b => b.onclick = () => {
+      state.consultoriaAnexosTemp.splice(Number(b.dataset.rmAnexo), 1);
+      renderAnexos();
+    });
+    lista.querySelectorAll('[data-rm-anexo-existente]').forEach(b => b.onclick = async () => {
+      const aId = b.dataset.rmAnexoExistente;
+      if (!confirm('Remover anexo permanentemente do banco?')) return;
+      b.disabled = true;
+      try {
+        await api('/api/propostas-consultoria/anexos/' + aId, { method: 'DELETE' });
+        state.consultoriaAnexosExistentes = state.consultoriaAnexosExistentes.filter(x => String(x.id) !== String(aId));
+        renderAnexos();
+      } catch (e) { alert('Erro: ' + e.message); b.disabled = false; }
+    });
+  };
+  renderAnexos();
+
+  const dropZone = document.getElementById('cnsDropZone');
+  const fileInput = document.getElementById('cnsAnexoInput');
+  if (!dropZone || !fileInput) return;
+
+  const processarArquivos = async (files) => {
+    for (const file of Array.from(files)) {
+      if (!MIMES_OK.includes(file.type)) { alert(`"${file.name}" não suportado. Use PDF, PNG ou JPEG.`); continue; }
+      if (file.size > MAX_BYTES) { alert(`"${file.name}" excede 15 MB.`); continue; }
+      const conteudo_b64 = await new Promise((resolve, reject) => {
+        const r = new FileReader();
+        r.onload = () => resolve(String(r.result).split(',')[1]);
+        r.onerror = reject;
+        r.readAsDataURL(file);
+      });
+      state.consultoriaAnexosTemp.push({ filename: file.name, mimetype: file.type, tamanho: file.size, conteudo_b64 });
+    }
+    renderAnexos();
+  };
+
+  dropZone.onclick = () => fileInput.click();
+  fileInput.onchange = (e) => processarArquivos(e.target.files);
+  dropZone.ondragover = (e) => { e.preventDefault(); dropZone.style.background = 'rgba(0,255,136,0.08)'; };
+  dropZone.ondragleave = () => { dropZone.style.background = 'rgba(0,255,136,0.03)'; };
+  dropZone.ondrop = (e) => { e.preventDefault(); dropZone.style.background = 'rgba(0,255,136,0.03)'; processarArquivos(e.dataTransfer.files); };
+}
+
 async function renderConsultoriaFormInline(v, toggleHTML, subtipo) {
   // v1.99.4+: cada subtipo nao-Averbacao tem form proprio. Aqui despacha.
   if (subtipo === 'georreferenciamento_rural') {
@@ -6411,78 +6494,10 @@ async function renderConsultoriaFormInline(v, toggleHTML, subtipo) {
   inpArea.oninput = recalcularValorVenal;
   selPadrao.onchange = recalcularValorVenal;
 
-  // v1.66.9: gestao de anexos (Planta/Mapa) durante o form
-  if (!state.consultoriaAnexosTemp) state.consultoriaAnexosTemp = [];
-  if (state.consultoriaUltimoSubtipo !== subtipo) {
-    state.consultoriaAnexosTemp = [];
-    state.consultoriaUltimoSubtipo = subtipo;
-  }
-  const renderAnexos = () => {
-    const lista = document.getElementById('cnsAnexosLista');
-    if (!lista) return;
-    // v1.66.15: anexos existentes (modo edicao) com badge "salvo" + delete via API
-    const existentes = (state.consultoriaAnexosExistentes || []).map(a => `
-      <div style="display:flex; gap:8px; align-items:center; padding:6px 8px; background:rgba(0,255,136,0.04); border:1px solid var(--border); border-radius:6px;">
-        <span style="font-size:18px;">${a.mimetype.includes('pdf') ? '📄' : '🖼️'}</span>
-        <div style="flex:1; min-width:0; overflow:hidden;">
-          <div style="font-size:12px; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${escape(a.filename)}</div>
-          <div style="font-size:10px; color:var(--text-muted);">${(a.tamanho_bytes / 1024).toFixed(1)} KB · ${a.mimetype} · <span style="color:var(--neon);">salvo</span></div>
-        </div>
-        <button type="button" data-rm-anexo-existente="${a.id}" class="btn-danger" style="padding:4px 8px; font-size:11px;" title="Remover do banco">×</button>
-      </div>`).join('');
-    const novos = state.consultoriaAnexosTemp.map((a, i) => `
-      <div style="display:flex; gap:8px; align-items:center; padding:6px 8px; background:var(--bg-elev); border:1px solid var(--border); border-radius:6px;">
-        <span style="font-size:18px;">${a.mimetype.includes('pdf') ? '📄' : '🖼️'}</span>
-        <div style="flex:1; min-width:0; overflow:hidden;">
-          <div style="font-size:12px; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${escape(a.filename)}</div>
-          <div style="font-size:10px; color:var(--text-muted);">${(a.tamanho / 1024).toFixed(1)} KB · ${a.mimetype} · <span style="color:var(--gold);">novo</span></div>
-        </div>
-        <button type="button" data-rm-anexo="${i}" class="btn-danger" style="padding:4px 8px; font-size:11px;">×</button>
-      </div>`).join('');
-    lista.innerHTML = existentes + novos;
-    lista.querySelectorAll('[data-rm-anexo]').forEach(b => b.onclick = () => {
-      state.consultoriaAnexosTemp.splice(Number(b.dataset.rmAnexo), 1);
-      renderAnexos();
-    });
-    // v1.66.15: remove anexo existente (DELETE imediato no banco)
-    lista.querySelectorAll('[data-rm-anexo-existente]').forEach(b => b.onclick = async () => {
-      const aId = b.dataset.rmAnexoExistente;
-      if (!confirm('Remover anexo permanentemente do banco?')) return;
-      b.disabled = true;
-      try {
-        await api('/api/propostas-consultoria/anexos/' + aId, { method: 'DELETE' });
-        state.consultoriaAnexosExistentes = state.consultoriaAnexosExistentes.filter(x => String(x.id) !== String(aId));
-        renderAnexos();
-      } catch (e) { alert('Erro: ' + e.message); b.disabled = false; }
-    });
-  };
-  renderAnexos();
-
-  const dropZone = document.getElementById('cnsDropZone');
-  const fileInput = document.getElementById('cnsAnexoInput');
-  const MIMES_OK = ['application/pdf', 'image/png', 'image/jpeg', 'image/jpg'];
-  const MAX_BYTES = 15 * 1024 * 1024;
-  const processarArquivos = async (files) => {
-    for (const file of Array.from(files)) {
-      if (!MIMES_OK.includes(file.type)) { alert(`"${file.name}" não suportado. Use PDF, PNG ou JPEG.`); continue; }
-      if (file.size > MAX_BYTES) { alert(`"${file.name}" excede 15 MB.`); continue; }
-      const conteudo_b64 = await new Promise((resolve, reject) => {
-        const r = new FileReader();
-        r.onload = () => resolve(String(r.result).split(',')[1]);
-        r.onerror = reject;
-        r.readAsDataURL(file);
-      });
-      state.consultoriaAnexosTemp.push({ filename: file.name, mimetype: file.type, tamanho: file.size, conteudo_b64 });
-    }
-    renderAnexos();
-  };
-  if (dropZone && fileInput) {
-    dropZone.onclick = () => fileInput.click();
-    fileInput.onchange = (e) => processarArquivos(e.target.files);
-    dropZone.ondragover = (e) => { e.preventDefault(); dropZone.style.background = 'rgba(0,255,136,0.08)'; };
-    dropZone.ondragleave = () => { dropZone.style.background = 'rgba(0,255,136,0.03)'; };
-    dropZone.ondrop = (e) => { e.preventDefault(); dropZone.style.background = 'rgba(0,255,136,0.03)'; processarArquivos(e.dataTransfer.files); };
-  }
+  // v3.23.4: gestao de anexos extraida pra helper reutilizavel wireUpAnexosDropzone()
+  // — antes era inline aqui e nos outros 4 forms (DesmRem/Retif/PTAM/GeoRural) o
+  // wireup nao existia, deixando o dropzone inerte. Ver definicao acima do helper.
+  wireUpAnexosDropzone(subtipo);
 
   // v1.66.12: restaura form a partir do cache (volta do preview preserva dados)
   const cache = state.consultoriaFormCache;
@@ -6696,6 +6711,8 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
   document.querySelector('[data-cons-voltar]').onclick = voltarParaEscolha;
   document.getElementById('geoCancelar').onclick = voltarParaEscolha;
   document.getElementById('geoNovoCliente').onclick = () => abrirCadastroClienteModal(subtipo);
+  // v3.23.4: wire-up dos anexos (sem isso clique no dropzone nao abria file picker)
+  wireUpAnexosDropzone(subtipo);
 
   // restaura cache se voltou do preview
   const cache = state.consultoriaFormCache;
@@ -7038,6 +7055,8 @@ async function renderConsultoriaFormDesmRem(v, toggleHTML, subtipo) {
   document.querySelector('[data-cons-voltar]').onclick = voltarParaEscolha;
   document.getElementById('dxCancelar').onclick = voltarParaEscolha;
   document.getElementById('dxNovoCliente').onclick = () => abrirCadastroClienteModal(subtipo);
+  // v3.23.4: wire-up dos anexos (sem isso clique no dropzone nao abria file picker)
+  wireUpAnexosDropzone(subtipo);
 
   // restaura cache
   const cache = state.consultoriaFormCache;
@@ -7696,6 +7715,8 @@ async function renderConsultoriaFormRetificacao(v, toggleHTML) {
   document.querySelector('[data-cons-voltar]').onclick = voltarParaEscolha;
   document.getElementById('rxCancelar').onclick = voltarParaEscolha;
   document.getElementById('rxNovoCliente').onclick = () => abrirCadastroClienteModal(subtipo);
+  // v3.23.4: wire-up dos anexos (sem isso clique no dropzone nao abria file picker)
+  wireUpAnexosDropzone(subtipo);
 
   const cache = state.consultoriaFormCache;
   if (cache && cache.subtipo === subtipo) {
@@ -7888,6 +7909,8 @@ async function renderConsultoriaFormPTAM(v, toggleHTML) {
   document.querySelector('[data-cons-voltar]').onclick = voltarParaEscolha;
   document.getElementById('ptCancelar').onclick = voltarParaEscolha;
   document.getElementById('ptNovoCliente').onclick = () => abrirCadastroClienteModal(subtipo);
+  // v3.23.4: wire-up dos anexos (sem isso clique no dropzone nao abria file picker)
+  wireUpAnexosDropzone(subtipo);
 
   // Mostra/esconde campo de valor customizado
   const selFaixa = document.getElementById('ptFaixa');

--- a/src/test/anexos-dropzone-wireup.test.ts
+++ b/src/test/anexos-dropzone-wireup.test.ts
@@ -1,0 +1,75 @@
+// v3.23.4: smoke test do fix do dropzone de anexos quebrado em Nova Proposta.
+//
+// Bug: clicar no dropzone "Clique ou arraste arquivos" em Desmembramento/Desdobro/
+// Remembramento/Retificacao/PTAM nao abria o file picker. Causa: o HTML do dropzone
+// (#cnsDropZone + #cnsAnexoInput) era renderizado por 5 funcoes diferentes de form,
+// mas o wireup (dropZone.onclick = () => fileInput.click()) so existia em
+// renderConsultoriaFormInline (Averbacao). Os outros 4 forms emitem o markup mas
+// nao anexavam handlers — dropzone ficava inerte.
+//
+// Fix: extrair pra funcao reutilizavel wireUpAnexosDropzone() e chamar de todos
+// os 5 render functions. Esse teste garante que ninguem regrida no futuro
+// removendo uma das chamadas.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const obrasHtml = readFileSync(
+  join(__dirname, '..', 'public', 'obras.html'),
+  'utf8',
+);
+
+describe('obras.html — dropzone de anexos wired em todos os forms de Nova Proposta (v3.23.4)', () => {
+  it('define a funcao wireUpAnexosDropzone exatamente uma vez', () => {
+    const matches = obrasHtml.match(/function wireUpAnexosDropzone\s*\(/g) || [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('o helper attacha onclick no dropzone que dispara fileInput.click()', () => {
+    // Pega o corpo da funcao
+    const fnMatch = obrasHtml.match(
+      /function wireUpAnexosDropzone\s*\([^)]*\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(fnMatch).not.toBeNull();
+    const body = fnMatch![0];
+    // O handler critico: clique no dropZone aciona fileInput.click
+    expect(body).toMatch(/dropZone\.onclick\s*=\s*\(\)\s*=>\s*fileInput\.click\(\)/);
+    // Drag/drop tambem
+    expect(body).toMatch(/dropZone\.ondrop\s*=/);
+    expect(body).toMatch(/fileInput\.onchange\s*=/);
+  });
+
+  it('chama wireUpAnexosDropzone em TODAS as 5 funcoes de render de form de proposta', () => {
+    // Funcoes esperadas (cada uma renderiza seu proprio <label id="cnsDropZone">)
+    const renderFns = [
+      'renderConsultoriaFormInline',        // Averbacao + dispatcher
+      'renderConsultoriaFormGeoRural',      // Georref Rural
+      'renderConsultoriaFormDesmRem',       // Desmembramento + Remembramento
+      'renderConsultoriaFormRetificacao',   // Retificacao de area
+      'renderConsultoriaFormPTAM',          // Avaliacao PTAM
+    ];
+
+    for (const fnName of renderFns) {
+      // Captura o corpo da funcao (do nome ate proxima declaracao top-level)
+      const re = new RegExp(
+        String.raw`(async\s+)?function\s+${fnName}\s*\([^)]*\)\s*\{[\s\S]*?\n(?=(async\s+)?function\s+\w)`,
+      );
+      const m = obrasHtml.match(re);
+      expect(m, `nao encontrei a funcao ${fnName}`).not.toBeNull();
+      expect(
+        m![0],
+        `funcao ${fnName} nao chama wireUpAnexosDropzone — dropzone vai ficar inerte`,
+      ).toContain('wireUpAnexosDropzone(');
+    }
+  });
+
+  it('numero de dropzones (#cnsDropZone) bate com numero de chamadas wireUp', () => {
+    // 5 forms renderizam o dropzone -> precisa de 5 chamadas (1 por form)
+    const dropzones = (obrasHtml.match(/<label id="cnsDropZone"/g) || []).length;
+    // Conta so invocacoes reais (terminam com ;) — exclui a definicao e mencoes em comentarios
+    const invocations = (obrasHtml.match(/wireUpAnexosDropzone\(subtipo\)\s*;/g) || []).length;
+    expect(dropzones).toBe(5);
+    expect(invocations).toBe(5);
+  });
+});


### PR DESCRIPTION
…Nova Proposta

Bug: clicar no dropzone "Clique ou arraste arquivos" em Desmembramento (e Desdobro, Remembramento, Retificacao, PTAM, Georref Rural) nao abria o file picker. Causa: o HTML do dropzone (#cnsDropZone + #cnsAnexoInput) era renderizado por 5 funcoes diferentes de form (renderConsultoriaForm{Inline,GeoRural,DesmRem,Retificacao,PTAM}) mas o wireup do onclick/drag/drop so existia inline em renderConsultoriaFormInline. Os outros 4 forms emitiam o markup mas nao anexavam handlers - dropzone ficava inerte. A impressao visual de "+ Novo cliente cobrindo o dropzone" reportada pelo CEO era falso positivo: nao tinha sobreposicao, o dropzone que estava sem listener.

Fix: extrair o wireup pra funcao reutilizavel wireUpAnexosDropzone(subtipo) no nivel do modulo e chamar das 5 funcoes de render. State compartilhado continua em state.consultoriaAnexosTemp / state.consultoriaAnexosExistentes (ja global). Comportamento de troca de subtipo (limpa temp) preservado via deteccao state.consultoriaUltimoSubtipo !== subtipo dentro do helper.

Test: src/test/anexos-dropzone-wireup.test.ts (4 testes) - garante 1 definicao
+ 5 invocacoes do helper, presenca dos handlers criticos, e contagem "<label id=cnsDropZone>" == 5. Smoke test pra evitar regressao se alguem remover uma chamada no futuro.

Bump 3.23.3 -> 3.23.4 (so package.json, ja que apos PR #70 e' fonte unica).