### PR TITLE
fix(georref-form): grid explicito 60/40 + anexos sticky (resolve perc…

### DIFF
--- a/06-Changelog/v3.23.6-anexos-dropzone-overlap.md
+++ b/06-Changelog/v3.23.6-anexos-dropzone-overlap.md
@@ -1,0 +1,70 @@
+# v3.23.6 — Form Georref Rural: grid explícito 60/40 + anexos sticky
+
+**Data:** 2026-05-21
+**Origem:** CEO reportou via screenshot (na v3.23.5 recém-mergeada) que o painel de Anexos parecia "sobrepor" os campos de Cliente/Endereço/Município/UF do formulário de Georreferenciamento Rural. Visualmente o problema era a coluna direita curta "flutuando" ao lado da coluna esquerda muito longa (depois das novas seções de v3.23.5: Finalidade, Matrícula/CRI, Perímetro, Validade, Opcionais).
+
+## Diagnóstico
+
+Não havia overlap real de DOM — nenhum `position: absolute` ou `z-index` errado. O que acontecia:
+
+1. Form usava grid `repeat(auto-fit, minmax(360px, 1fr))` inline. Em viewport ≥720px → 2 colunas iguais.
+2. Após v3.23.5, a coluna esquerda ganhou ~6 novas seções (Finalidade, Matrícula/CRI, Perímetro, Validade dias, 5 opcionais com qty inputs) — ficou cerca de 2× mais alta que a direita.
+3. Com `align-items: start` (default), a coluna direita (anexos) ficava colada no topo, ocupando ~30% da altura disponível. Os outros 70% da coluna direita eram vazios.
+4. Visualmente parecia que os anexos "flutuavam" sobre os campos do meio do form, mesmo sem overlap real.
+
+Bônus: ao rolar o form para preencher os campos do meio/fim, o painel de anexos saía da viewport — o usuário tinha que rolar de volta pro topo pra anexar arquivos.
+
+## Fix
+
+Substituído o grid inline `auto-fit minmax(360px,1fr)` por:
+
+- **CSS class `.form-georref-grid`** com `grid-template-columns: minmax(0, 1.5fr) minmax(280px, 1fr)` — proporção fixa 60/40 explícita (em vez de duas colunas iguais)
+- **Coluna esquerda `.form-georref-fields`** com `flex-direction: column; min-width: 0` (o `min-width:0` é crítico em grid pra permitir shrink — sem ele, options longas de select estouram a coluna)
+- **Coluna direita `<aside class="form-georref-anexos">`** com `position: sticky; top: 16px` — o painel de anexos agora acompanha o scroll do form, sempre visível enquanto o usuário preenche os campos
+- **Media query `(max-width: 768px)`** própria que colapsa pra 1 coluna e desliga o sticky (`position: static`) — em mobile o painel volta a empilhar abaixo dos campos, comportamento natural
+
+O markup ganhou `data-keep-grid` no container do grid (atributo explicativo) — o safety-net global em `<style>` linhas 130-133 que força `grid-template-columns: 1fr !important` em inline `style*="grid-template-columns"` em <768px NÃO atinge classes CSS, mas o atributo deixa a intenção clara pro próximo dev que ler isso.
+
+## Arquivos tocados
+
+- `src/public/obras.html`:
+  - +bloco CSS `.form-georref-grid` / `.form-georref-fields` / `.form-georref-anexos` no `<style>` (após o bloco de tabs v3.23.3, ~linha 256)
+  - `renderConsultoriaFormGeoRural` (~linha 6594): inline grid → `class="form-georref-grid" data-keep-grid`; left col → `class="form-georref-fields"`; right col → `<aside class="form-georref-anexos">` com `<h3>` e `.anexos-hint` em vez dos `<p>` informativos antigos
+  - IDs preservados: `cnsDropZone`, `cnsAnexoInput`, `cnsAnexosLista` — `wireUpAnexosDropzone(subtipo)` continua funcionando sem mexer
+- `src/test/anexos-dropzone-overlap.test.ts` (novo) — 7 testes:
+  - CSS `.form-georref-grid` usa 1.5fr/1fr
+  - `.form-georref-fields` tem `min-width: 0`
+  - `.form-georref-anexos` é sticky top:16px
+  - media query <=768px colapsa o grid e desliga sticky
+  - markup do form usa as classes novas + `data-keep-grid` + `<aside>`
+  - inline `grid-template-columns:repeat(auto-fit, minmax(360px, 1fr))` NÃO existe mais em renderConsultoriaFormGeoRural
+  - `wireUpAnexosDropzone(subtipo)` continua sendo chamado (regressão guard)
+- `package.json` — `3.23.5 → 3.23.6`
+- `06-Changelog/v3.23.6-anexos-dropzone-overlap.md` (este)
+
+## Como testar manualmente
+
+1. `npm run dev`
+2. Chrome DevTools → Toggle device toolbar
+3. Testar em 3 viewports:
+   - **Desktop 1280×800**: form em 2 colunas, anexos à direita; rolar o form e verificar que o painel de anexos acompanha (sticky) com `top: 16px` da viewport
+   - **Tablet 800×600**: ainda 2 colunas (≥768px); sticky funciona
+   - **iPhone 13 mini (375×812)**: empilha — anexos vai abaixo dos campos, full width, sem sticky
+4. Verificar que clicar no dropzone abre file picker (fix v3.23.4 não regrediu)
+
+## Compatibilidade
+
+- **Outros 4 forms** (`renderConsultoriaFormInline`, `renderConsultoriaFormDesmRem`, `renderConsultoriaFormRetificacao`, `renderConsultoriaFormPTAM`) NÃO foram tocados — continuam usando o grid `auto-fit, minmax(360px, 1fr)` antigo. Se o CEO quiser aplicar o mesmo padrão neles, é trivial replicar (mesmas 3 classes CSS).
+- **Safety-net global** (linhas 130-133) continua valendo pros inline grids antigos; a `.form-georref-grid` tem media query própria — comportamentos não colidem.
+- **`wireUpAnexosDropzone`** (helper unificado v3.23.4) inalterado — depende só dos IDs do dropzone, que foram preservados.
+
+## Validação
+
+- `npm run typecheck`: ✅
+- `npx vitest run src/test/anexos-dropzone-overlap.test.ts`: ✅ 7/7
+- `npm test`: ✅ 460 passing / 1 skipped / 0 failures (453 antes + 7 novos)
+
+## PR
+- Branch: `fix/anexos-dropzone-overlap`
+- Base: `main` (`a1e638a`)
+- 1 commit semântico

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.23.5",
+  "version": "3.23.6",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -254,6 +254,65 @@
     }
   }
 
+  /* === v3.23.6: form Georref Rural — grid 60/40 explicito + anexos sticky === */
+  /* O grid antigo (auto-fit, minmax(360px,1fr)) deixava a coluna direita curta
+     "flutuando" visualmente quando a esquerda (apos os campos novos de v3.23.5:
+     Finalidade/Matricula/CRI/Perimetro/Opcionais) ficou muito mais alta. Agora
+     sao colunas explicitas 1.5fr/1fr e a coluna direita acompanha o scroll via
+     position:sticky. Em <768px empilha (anexos vai abaixo, full width). */
+  .form-georref-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(280px, 1fr);
+    gap: 24px;
+    align-items: start;
+    margin-top: 4px;
+  }
+  .form-georref-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 13px;
+    /* CRITICO em grid: permite o conteudo encolher (selects/inputs com option
+       longa nao estouram a coluna). Sem isso, a coluna esquerda empurra o anexos */
+    min-width: 0;
+  }
+  .form-georref-anexos {
+    position: sticky;
+    top: 16px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+  }
+  .form-georref-anexos h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--neon);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .form-georref-anexos .anexos-hint {
+    margin: 0;
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+  @media (max-width: 768px) {
+    .form-georref-grid {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+    .form-georref-anexos {
+      position: static; /* sticky perde sentido com 1 coluna */
+    }
+  }
+
   input, select, textarea, button {
     font-family: inherit; font-size: 14px; padding: 8px 12px;
     border: 1px solid var(--border); border-radius: var(--radius);
@@ -6591,8 +6650,12 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
       </div>
     </div>
     <div class="card">
-      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(360px, 1fr)); gap:16px;">
-       <div style="display:grid; gap:10px; font-size:13px;">
+      <!-- v3.23.6: grid explicito 1.5fr/1fr com anexos sticky (substitui auto-fit que
+           deixava colunas desbalanceadas apos as novas secoes de v3.23.5).
+           data-keep-grid impede o safety-net global (linha 130) de forcar 1 coluna em
+           viewport <=768px — o controle mobile fica na media query da .form-georref-grid. -->
+      <div class="form-georref-grid" data-keep-grid>
+       <div class="form-georref-fields">
         <label>Cliente
           <div style="display:flex; gap:6px;">
             <select id="geoCliente" style="flex:1;"><option value="">— escolher —</option>${cliOpts}</select>
@@ -6744,20 +6807,18 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
         </div>
        </div>
 
-       <div style="display:flex; flex-direction:column; gap:10px;">
-         <div>
-           <p style="margin:0; font-weight:600; font-size:13px;">📎 Anexos da Proposta</p>
-           <p style="margin:2px 0 0; font-size:11px; color:var(--text-muted);">
-             Plantas anteriores, levantamentos prévios, croquis. Formatos: PDF, PNG, JPEG.
-           </p>
-         </div>
+       <aside class="form-georref-anexos">
+         <h3>📎 Anexos da Proposta</h3>
+         <p class="anexos-hint">
+           Plantas anteriores, levantamentos prévios, croquis. Formatos: PDF, PNG, JPEG.
+         </p>
          <label id="cnsDropZone" style="border:2px dashed var(--border-strong); border-radius:8px; padding:24px; text-align:center; cursor:pointer; background:rgba(0,255,136,0.03);">
            <input type="file" id="cnsAnexoInput" multiple accept=".pdf,.png,.jpg,.jpeg" style="display:none;">
            <div style="font-size:28px; margin-bottom:6px;">📤</div>
            <div style="font-size:13px; color:var(--neon); font-weight:600;">Clique ou arraste arquivos</div>
          </label>
          <div id="cnsAnexosLista" style="display:flex; flex-direction:column; gap:6px;"></div>
-       </div>
+       </aside>
       </div>
     </div>`;
 

--- a/src/test/anexos-dropzone-overlap.test.ts
+++ b/src/test/anexos-dropzone-overlap.test.ts
@@ -1,0 +1,85 @@
+// v3.23.6: smoke test do refactor de layout do form Georref Rural.
+//
+// Bug original: depois das novas secoes adicionadas em v3.23.5
+// (Finalidade/Matricula/CRI/Perimetro/Validade/Opcionais), a coluna esquerda
+// ficou muito mais alta que a direita. Com grid auto-fit minmax(360px,1fr)
+// nao havia overlap real de DOM, mas visualmente a coluna de anexos curta
+// "flutuava" ao lado de uma coluna de fields gigante, dando impressao de
+// sobreposicao.
+//
+// Fix: trocar pra grid explicito 1.5fr/1fr, anexos sticky (acompanha scroll)
+// e media query propria pra colapsar em mobile (em vez de depender do
+// safety-net global).
+//
+// Esse teste garante que as classes CSS e o markup novo nao regridem.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const obrasHtml = readFileSync(
+  join(__dirname, '..', 'public', 'obras.html'),
+  'utf8',
+);
+
+describe('obras.html — form Georref Rural layout v3.23.6', () => {
+  it('CSS .form-georref-grid usa grid explicito 1.5fr/1fr', () => {
+    const m = obrasHtml.match(/\.form-georref-grid\s*\{[^}]*\}/);
+    expect(m, 'classe .form-georref-grid nao encontrada').not.toBeNull();
+    expect(m![0]).toMatch(/display:\s*grid/);
+    expect(m![0]).toMatch(/grid-template-columns:\s*minmax\(0,\s*1\.5fr\)\s+minmax\(280px,\s*1fr\)/);
+  });
+
+  it('CSS .form-georref-fields tem min-width:0 (CRITICO em grid)', () => {
+    // Sem min-width:0 o conteudo intrinseco da option mais longa estoura a coluna
+    const m = obrasHtml.match(/\.form-georref-fields\s*\{[^}]*\}/);
+    expect(m).not.toBeNull();
+    expect(m![0]).toMatch(/min-width:\s*0/);
+  });
+
+  it('CSS .form-georref-anexos usa position:sticky top:16px', () => {
+    const m = obrasHtml.match(/\.form-georref-anexos\s*\{[^}]*\}/);
+    expect(m).not.toBeNull();
+    expect(m![0]).toMatch(/position:\s*sticky/);
+    expect(m![0]).toMatch(/top:\s*16px/);
+  });
+
+  it('em <=768px o grid colapsa e anexos volta a position:static', () => {
+    // Procura a media query que tem ambas as regras
+    expect(obrasHtml).toMatch(
+      /@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.form-georref-grid\s*\{[^}]*grid-template-columns:\s*1fr/,
+    );
+    expect(obrasHtml).toMatch(
+      /@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.form-georref-anexos\s*\{[^}]*position:\s*static/,
+    );
+  });
+
+  it('renderConsultoriaFormGeoRural emite o markup com as classes novas', () => {
+    const fn = obrasHtml.match(/function renderConsultoriaFormGeoRural\([^)]*\)\s*\{[\s\S]*?\n\}/);
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+    expect(body).toContain('class="form-georref-grid"');
+    expect(body).toContain('data-keep-grid'); // explicita intencao vs safety-net
+    expect(body).toContain('class="form-georref-fields"');
+    expect(body).toContain('<aside class="form-georref-anexos">');
+    expect(body).toContain('</aside>');
+    // dropzone IDs preservados (wireUpAnexosDropzone depende deles)
+    expect(body).toContain('id="cnsDropZone"');
+    expect(body).toContain('id="cnsAnexoInput"');
+  });
+
+  it('NAO ha mais o grid inline auto-fit antigo no form Georref', () => {
+    // O auto-fit minmax(360px,1fr) era usado em VARIOS forms; aqui valida que
+    // o renderConsultoriaFormGeoRural NAO o usa mais (so os outros 4 forms)
+    const fn = obrasHtml.match(/function renderConsultoriaFormGeoRural\([^)]*\)\s*\{[\s\S]*?\n\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).not.toMatch(/grid-template-columns:repeat\(auto-fit, minmax\(360px, 1fr\)\)/);
+  });
+
+  it('wireUpAnexosDropzone segue sendo chamado em renderConsultoriaFormGeoRural', () => {
+    // Garante que o refactor de layout nao removeu a chamada do helper de wireup
+    // (regressao do fix v3.23.4 de dropzone inerte)
+    const fn = obrasHtml.match(/function renderConsultoriaFormGeoRural\([^)]*\)\s*\{[\s\S]*?\n\}/);
+    expect(fn!.toString()).toContain('wireUpAnexosDropzone(subtipo);');
+  });
+});


### PR DESCRIPTION
…eived overlap)

Bug reportado: depois das novas secoes adicionadas em v3.23.5 (Finalidade/Matricula/CRI/Perimetro/Validade/Opcionais), a coluna direita de Anexos parecia "flutuar" sobrepondo os campos do meio do form.

Diagnostico: nao havia overlap real de DOM. O grid auto-fit minmax(360px,1fr) fazia 2 colunas iguais, mas a esquerda ficou ~2x mais alta depois dos novos campos. align-items:start (default) deixava a coluna direita curta colada no topo, com muito espaco vazio embaixo, dando impressao visual de sobreposicao. Bonus: ao rolar pra preencher o meio do form, o painel de anexos saia da viewport.

Fix: substituir grid inline auto-fit por classes CSS explicitas:
- .form-georref-grid: grid-template-columns minmax(0,1.5fr) minmax(280px,1fr)
- .form-georref-fields: flex column, min-width:0 (critico em grid pra permitir shrink — sem isso, options longas de select estouram a coluna)
- aside.form-georref-anexos: position:sticky top:16px (acompanha scroll — painel de anexos sempre visivel enquanto preenche o form)
- @media (max-width:768px): colapsa pra 1 coluna + position:static (mobile)

Markup ganhou data-keep-grid no container (explicita vs safety-net global linha 130-133 que afeta inline styles, nao classes).

IDs preservados (cnsDropZone, cnsAnexoInput, cnsAnexosLista) — helper wireUpAnexosDropzone do v3.23.4 continua funcionando.

Outros 4 forms (Averbacao/DesmRem/Retif/PTAM) NAO tocados — mantem grid auto-fit antigo. Se quiser aplicar mesmo padrao neles, e' trivial.

7 testes novos em src/test/anexos-dropzone-overlap.test.ts garantem:
- classes CSS presentes com regras corretas
- media query <=768px colapsa + desliga sticky
- markup usa as classes + data-keep-grid + <aside>
- grid inline antigo NAO existe mais em renderConsultoriaFormGeoRural
- wireUpAnexosDropzone(subtipo) continua sendo chamado (regressao guard)

Total: 461 testes (460 passing, 1 skipped, 0 failures).