### PR TITLE
feat(georref-opcionais): valores default atualizados + UI editavel

### DIFF
--- a/06-Changelog/v3.23.6-anexos-dropzone-overlap.md
+++ b/06-Changelog/v3.23.6-anexos-dropzone-overlap.md
@@ -67,4 +67,82 @@ O markup ganhou `data-keep-grid` no container do grid (atributo explicativo) —
 ## PR
 - Branch: `fix/anexos-dropzone-overlap`
 - Base: `main` (`a1e638a`)
-- 1 commit semântico
+- 2 commits semânticos (layout fix + opcionais editáveis)
+
+---
+
+## Adendo — Opcionais editáveis + novos defaults
+
+### Mudança nos valores default
+
+Atualizado `config/pricing-params.json` (bloco `opcionais_georref`):
+
+| Opcional | Antes | Depois | Razão |
+|---|---|---|---|
+| CCIR | R$ 350 | **R$ 1.621** (1 SM 2026) | Esforço real INCRA: acesso, conferência cadastral, eventual delimitação de APP/RL |
+| CAR | R$ 800 | **R$ 1.621** (1 SM 2026) | Mesma lógica do CCIR (SICAR exige análise ambiental + georref simplificado) |
+| ITR | R$ 250/exerc. | **R$ 300/exerc.** | Receita Federal: geração de DARFs, parcelamento, acompanhamento |
+| Anuência | R$ 150/confr. | **R$ 150/confr.** (inalterado) | Já alinhado ao mercado (visita por confrontante + reconhecimento de firma) |
+| Retificação | sob orçamento | sob orçamento (inalterado) | Caso a caso |
+
+Cada opcional ganhou flag `editavel: true` (informativo — o backend já respeitava o `valor_unitario` enviado pelo payload desde v3.23.5).
+
+### UI — todos os campos editáveis
+
+O bloco "Serviços adicionais opcionais" no form Georref foi refatorado de checkbox+texto estático para **checkbox + input numérico do valor + input qty (quando aplica) + subtotal calculado on-change**.
+
+Estrutura por linha:
+
+| Opcional | Checkbox | Valor unit. | Qty | Subtotal |
+|---|---|---|---|---|
+| CCIR | `[ ]` | `R$ [1621.00]` | — (fixo 1) | R$ 0,00 |
+| CAR | `[ ]` | `R$ [1621.00]` | — (fixo 1) | R$ 0,00 |
+| ITR | `[ ]` | `R$/exerc. [300.00]` | `Exerc. [0]` | R$ 0,00 |
+| Anuência | `[ ]` | `R$/confr. [150.00]` | `Confr. [0]` | R$ 0,00 |
+| Retificação | `[ ]` | — (sob orçamento) | — | — |
+
+Comportamento on-change:
+- Valor e qty começam `disabled` (opacidade 45%) quando o checkbox está desmarcado
+- Marcar o checkbox habilita os inputs e calcula subtotal imediato
+- Subtotal individual atualiza em cada `input`/`change`
+- Total geral em box dourado embaixo: "Total dos opcionais (informativo — NÃO soma ao Romatec)"
+
+Restore do cache (volta do preview) preserva também `valor_unitario` editado pelo usuário.
+
+### Backend — engine já respeitava override
+
+O `calcularGeorreferenciamento` já lia `opc?.ccir.valor_unitario ?? params.opcionais_georref.ccir.valor_unitario` desde v3.23.5. Mudou só o default no params.json. **Zero alteração na engine** — comportamento de override já estava implementado.
+
+### Testes (6 novos em georreferenciamento.test.ts)
+
+- **CCIR R$ 1.200 (override):** valor enviado pelo usuário prevalece sobre default 1621
+- **CCIR + CAR novos defaults (3242):** 1621 × 2 confere com 1 SM × 2
+- **ITR 5 exerc. × R$ 300 = R$ 1.500:** novo default multiplica corretamente
+- **Cenário completo (R$ 5.192):** CCIR 1621 + CAR 1621 + ITR 5×300 + Anuência 3×150
+- **Fallback params.json:** quando payload tem `contratado:true` sem `valor_unitario`, usa o default 1621
+- **Desconto (Anuência R$ 100/confr.):** override pra valor menor que o default
+
+Total Romatec permanece intacto em todos os cenários (opcionais não somam).
+
+### Arquivos tocados (adendo)
+
+- `config/pricing-params.json` — bumps de CCIR/CAR/ITR + `editavel: true` em todos
+- `src/services/pricing/params.ts` — type ganha `editavel?: boolean` opcional
+- `src/services/pricing/georreferenciamento.test.ts` — +6 testes (24 → 30)
+- `src/public/obras.html`:
+  - Bloco opcionais reescrito: cada linha é `.opcional-row` com inputs editáveis
+  - Novas classes CSS: `.opcional-row`, `.opcional-check`, `.opcional-controls`, `.opcional-subtotal`, `.opcionais-total` + media query <640px
+  - Handler `_recalcularOpcionaisTotal()` wire-up em `change`/`input`
+  - `geoPreview.onclick` lê `Number(...Valor.value)` em vez de hardcode
+  - Restore do cache restaura também `valor_unitario` (`setVal('geoOpcCcirValor', op.ccir?.valor_unitario)` etc.)
+
+### Validação
+
+- `npm run typecheck`: ✅
+- `npx vitest run src/services/pricing/georreferenciamento.test.ts`: ✅ 30/30
+- `npm test`: ✅ 466 passing / 1 skipped / 0 failures (460 → 466)
+
+### Compatibilidade
+
+- **Propostas antigas:** continuam com `valor_unitario` congelado em `dados_imovel.opcionais.<chave>.valor_unitario`. Ler/exibir/recalcular usa o valor original — bump de default em params.json NÃO afeta retroativamente.
+- **Outros 4 forms:** não tocados — quem implementar opcionais lá no futuro pode replicar o padrão.

--- a/config/pricing-params.json
+++ b/config/pricing-params.json
@@ -94,23 +94,28 @@
   },
   "opcionais_georref": {
     "_AVISO": "Servicos adicionais opcionais de Georreferenciamento Rural — NAO somam ao total Romatec (saem em seccao informativa propria do PDF). Valor_unitario congelado em dados_imovel.opcionais.<chave>.valor_unitario no momento da criacao da proposta — reajustes futuros aqui nao afetam propostas antigas.",
+    "_AVISO_DEFAULTS_V3_23_6": "Valores atualizados em v3.23.6: CCIR 350->1621 (1 SM 2026, condiz com esforco real de acesso INCRA + delimitacao APP/RL); CAR 800->1621 (mesma logica); ITR 250->300 por exercicio (Receita Federal: geracao DARFs + parcelamento + acompanhamento). Anuencia mantida 150/confrontante. Retificacao mantida sob orcamento.",
     "ccir": {
       "rotulo": "Atualizacao do CCIR (INCRA)",
-      "valor_unitario": 350.00
+      "valor_unitario": 1621.00,
+      "editavel": true
     },
     "car": {
       "rotulo": "Atualizacao / emissao do CAR (SICAR)",
-      "valor_unitario": 800.00
+      "valor_unitario": 1621.00,
+      "editavel": true
     },
     "itr": {
       "rotulo": "Regularizacao de ITR em atraso",
-      "valor_unitario": 250.00,
-      "unidade": "por exercicio"
+      "valor_unitario": 300.00,
+      "unidade": "por exercicio",
+      "editavel": true
     },
     "anuencia": {
       "rotulo": "Coleta de anuencia dos confrontantes",
       "valor_unitario": 150.00,
-      "unidade": "por confrontante"
+      "unidade": "por confrontante",
+      "editavel": true
     },
     "retificacao": {
       "rotulo": "Retificacao de area (Lei 10.931/2004)",

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -313,6 +313,108 @@
     }
   }
 
+  /* === v3.23.6: opcionais editaveis (valor unitario + qty) com subtotal e total === */
+  .opcional-row {
+    display: grid;
+    grid-template-columns: minmax(180px, 1.4fr) minmax(0, 2fr);
+    gap: 10px;
+    align-items: center;
+    padding: 8px 4px;
+    border-bottom: 1px solid var(--border);
+  }
+  .opcional-row:last-of-type { border-bottom: none; }
+  .opcional-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 12.5px;
+    color: var(--text);
+    margin: 0;
+  }
+  .opcional-check input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--neon);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .opcional-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .opcional-controls .campo-qty,
+  .opcional-controls .campo-valor {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+  }
+  .opcional-controls .campo-label {
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+  .opcional-controls .campo-qty input,
+  .opcional-controls .campo-valor input {
+    width: 78px;
+    padding: 4px 6px;
+    font-size: 12px;
+    text-align: right;
+    color: var(--gold);
+    font-weight: 600;
+  }
+  .opcional-controls input:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .opcional-subtotal {
+    font-size: 11px;
+    color: var(--text-muted);
+    min-width: 110px;
+    text-align: right;
+  }
+  .opcional-subtotal strong {
+    color: var(--gold);
+    font-weight: 700;
+  }
+  .opcional-controls .campo-info {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .opcionais-total {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    margin-top: 8px;
+    background: rgba(201, 168, 76, 0.08);
+    border: 1px solid var(--gold-dim);
+    border-radius: var(--radius);
+    font-size: 12.5px;
+    color: var(--text-muted);
+  }
+  .opcionais-total strong {
+    color: var(--gold);
+    font-size: 14px;
+    font-weight: 700;
+  }
+  @media (max-width: 640px) {
+    .opcional-row {
+      grid-template-columns: 1fr;
+      gap: 6px;
+    }
+    .opcional-controls {
+      justify-content: flex-start;
+      padding-left: 24px;
+    }
+  }
+
   input, select, textarea, button {
     font-family: inherit; font-size: 14px; padding: 8px 12px;
     border: 1px solid var(--border); border-radius: var(--radius);
@@ -6763,43 +6865,90 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
           <input id="geoValidadeDias" type="number" min="1" step="1" value="15" style="width:100%;">
         </label>
 
-        <!-- v3.23.5: Servicos adicionais opcionais — NAO somam ao total Romatec.
-             Aparecem em seccao informativa propria no PDF (5 linhas sempre, marcadas
-             se contratadas). Valor unitario congelado no envio. -->
+        <!-- v3.23.6: Servicos adicionais opcionais TODOS editaveis — checkbox + valor
+             unitario + qty (quando aplica) + subtotal calculado on-change. Valor congela
+             no envio em dados_imovel.opcionais.<chave>.valor_unitario, entao reajustar
+             defaults aqui no futuro nao afeta propostas antigas.
+             Novos defaults v3.23.6 (acordados com CEO):
+               CCIR/CAR R$ 1.621 = 1 SM 2026 (esforco real INCRA/SICAR + APP/RL)
+               ITR R$ 300/exercicio (Receita: DARFs + parcelamento + acompanhamento)
+               Anuencia R$ 150/confrontante (visita + reconhecimento de firma) — inalterado
+               Retificacao: sob orcamento (caso a caso) -->
         <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">➕ Serviços adicionais opcionais</p>
-        <span style="font-size:10px; color:var(--text-muted); margin-bottom:4px;">Marque os que o cliente quer contratar — vão em seção informativa no PDF, NÃO somam ao total Romatec.</span>
+        <span style="font-size:10px; color:var(--text-muted); margin-bottom:4px;">Marque os contratados. Valores editáveis caso queira aplicar desconto ou ajuste pontual. NÃO somam ao total Romatec — vão em seção informativa do PDF.</span>
 
-        <label style="display:flex; gap:6px; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:6px;">
-          <input id="geoOpcCcir" type="checkbox">
-          <span style="flex:1;">Atualização do CCIR (INCRA)</span>
-          <span style="color:var(--gold); font-weight:600;">R$ 350,00</span>
-        </label>
-
-        <label style="display:flex; gap:6px; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:6px;">
-          <input id="geoOpcCar" type="checkbox">
-          <span style="flex:1;">Atualização / emissão do CAR (SICAR)</span>
-          <span style="color:var(--gold); font-weight:600;">R$ 800,00</span>
-        </label>
-
-        <div style="display:flex; gap:6px; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:6px;">
-          <input id="geoOpcItr" type="checkbox">
-          <span style="flex:1;">Regularização de ITR em atraso</span>
-          <input id="geoOpcItrQty" type="number" min="0" step="1" placeholder="exerc." style="width:70px; font-size:12px;">
-          <span style="color:var(--gold); font-weight:600;">×R$ 250</span>
+        <div class="opcional-row" data-opcional="ccir">
+          <label class="opcional-check">
+            <input id="geoOpcCcir" type="checkbox">
+            <span>Atualização do CCIR (INCRA)</span>
+          </label>
+          <div class="opcional-controls">
+            <label class="campo-valor"><span class="campo-label">R$</span>
+              <input id="geoOpcCcirValor" type="number" step="0.01" min="0" value="1621.00">
+            </label>
+            <span class="opcional-subtotal">Subtotal: <strong id="geoOpcCcirSubtotal">R$ 0,00</strong></span>
+          </div>
         </div>
 
-        <div style="display:flex; gap:6px; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:6px;">
-          <input id="geoOpcAnuencia" type="checkbox">
-          <span style="flex:1;">Coleta de anuência dos confrontantes</span>
-          <input id="geoOpcAnuenciaQty" type="number" min="0" step="1" placeholder="qtd" style="width:70px; font-size:12px;">
-          <span style="color:var(--gold); font-weight:600;">×R$ 150</span>
+        <div class="opcional-row" data-opcional="car">
+          <label class="opcional-check">
+            <input id="geoOpcCar" type="checkbox">
+            <span>Atualização / emissão do CAR (SICAR)</span>
+          </label>
+          <div class="opcional-controls">
+            <label class="campo-valor"><span class="campo-label">R$</span>
+              <input id="geoOpcCarValor" type="number" step="0.01" min="0" value="1621.00">
+            </label>
+            <span class="opcional-subtotal">Subtotal: <strong id="geoOpcCarSubtotal">R$ 0,00</strong></span>
+          </div>
         </div>
 
-        <label style="display:flex; gap:6px; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:6px;">
-          <input id="geoOpcRetificacao" type="checkbox">
-          <span style="flex:1;">Retificação de área (Lei 10.931/2004)</span>
-          <span style="color:var(--text-muted); font-style:italic;">Sob orçamento</span>
-        </label>
+        <div class="opcional-row" data-opcional="itr">
+          <label class="opcional-check">
+            <input id="geoOpcItr" type="checkbox">
+            <span>Regularização de ITR em atraso</span>
+          </label>
+          <div class="opcional-controls">
+            <label class="campo-qty"><span class="campo-label">Exerc.</span>
+              <input id="geoOpcItrQty" type="number" min="0" step="1" value="0" placeholder="0">
+            </label>
+            <label class="campo-valor"><span class="campo-label">R$/exerc.</span>
+              <input id="geoOpcItrValor" type="number" step="0.01" min="0" value="300.00">
+            </label>
+            <span class="opcional-subtotal">Subtotal: <strong id="geoOpcItrSubtotal">R$ 0,00</strong></span>
+          </div>
+        </div>
+
+        <div class="opcional-row" data-opcional="anuencia">
+          <label class="opcional-check">
+            <input id="geoOpcAnuencia" type="checkbox">
+            <span>Coleta de anuência dos confrontantes</span>
+          </label>
+          <div class="opcional-controls">
+            <label class="campo-qty"><span class="campo-label">Confr.</span>
+              <input id="geoOpcAnuenciaQty" type="number" min="0" step="1" value="0" placeholder="0">
+            </label>
+            <label class="campo-valor"><span class="campo-label">R$/confr.</span>
+              <input id="geoOpcAnuenciaValor" type="number" step="0.01" min="0" value="150.00">
+            </label>
+            <span class="opcional-subtotal">Subtotal: <strong id="geoOpcAnuenciaSubtotal">R$ 0,00</strong></span>
+          </div>
+        </div>
+
+        <div class="opcional-row" data-opcional="retificacao">
+          <label class="opcional-check">
+            <input id="geoOpcRetificacao" type="checkbox">
+            <span>Retificação de área (Lei 10.931/2004)</span>
+          </label>
+          <div class="opcional-controls">
+            <span class="campo-info">Sob orçamento — valor a definir após análise</span>
+          </div>
+        </div>
+
+        <div class="opcionais-total">
+          <span>Total dos opcionais (informativo — NÃO soma ao Romatec):</span>
+          <strong id="geoOpcionaisTotal">R$ 0,00</strong>
+        </div>
 
         <div style="display:flex; gap:6px; margin-top:12px;">
           <button id="geoPreview" style="flex:1; background:var(--success); color:#fff; border-color:var(--success);">🧮 Calcular preview</button>
@@ -6846,6 +6995,54 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
   // v3.23.4: wire-up dos anexos (sem isso clique no dropzone nao abria file picker)
   wireUpAnexosDropzone(subtipo);
 
+  // v3.23.6: opcionais editaveis — calcula subtotal por linha + total geral
+  // on-change. Disabled visualmente quando checkbox desmarcado.
+  const _opcConfigs = [
+    { key: 'Ccir',      hasQty: false },
+    { key: 'Car',       hasQty: false },
+    { key: 'Itr',       hasQty: true  },
+    { key: 'Anuencia',  hasQty: true  },
+  ];
+  function _fmtBRL(n) {
+    return 'R$ ' + Number(n || 0).toFixed(2).replace('.', ',').replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+  }
+  function _calcOpcionalRow(cfg) {
+    const check = document.getElementById('geoOpc' + cfg.key);
+    const valor = document.getElementById('geoOpc' + cfg.key + 'Valor');
+    const qty   = cfg.hasQty ? document.getElementById('geoOpc' + cfg.key + 'Qty') : null;
+    const sub   = document.getElementById('geoOpc' + cfg.key + 'Subtotal');
+    if (!check || !valor || !sub) return 0;
+    const ativo = check.checked;
+    const v = parseFloat(valor.value) || 0;
+    const q = qty ? (parseInt(qty.value, 10) || 0) : 1;
+    valor.disabled = !ativo;
+    if (qty) qty.disabled = !ativo;
+    const s = ativo ? (v * q) : 0;
+    sub.textContent = _fmtBRL(s);
+    return s;
+  }
+  function _recalcularOpcionaisTotal() {
+    let t = 0;
+    for (const cfg of _opcConfigs) t += _calcOpcionalRow(cfg);
+    const totalEl = document.getElementById('geoOpcionaisTotal');
+    if (totalEl) totalEl.textContent = _fmtBRL(t);
+  }
+  // Wire-up listeners
+  for (const cfg of _opcConfigs) {
+    const ids = ['geoOpc' + cfg.key, 'geoOpc' + cfg.key + 'Valor'];
+    if (cfg.hasQty) ids.push('geoOpc' + cfg.key + 'Qty');
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (!el) continue;
+      el.addEventListener('change', _recalcularOpcionaisTotal);
+      el.addEventListener('input',  _recalcularOpcionaisTotal);
+    }
+  }
+  // Retificacao — checkbox so pra payload, nao soma
+  const _retCheck = document.getElementById('geoOpcRetificacao');
+  if (_retCheck) _retCheck.addEventListener('change', _recalcularOpcionaisTotal);
+  _recalcularOpcionaisTotal(); // estado inicial: tudo desmarcado, subtotais zero, inputs disabled
+
   // restaura cache se voltou do preview
   const cache = state.consultoriaFormCache;
   if (cache && cache.subtipo === subtipo) {
@@ -6874,13 +7071,20 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
     setVal('geoPerimetro',     d.perimetro_m);
     setVal('geoValidadeDias',  d.validade_dias);
     const op = d.opcionais || {};
-    setChk('geoOpcCcir',       op.ccir?.contratado);
-    setChk('geoOpcCar',        op.car?.contratado);
-    setChk('geoOpcItr',        op.itr?.contratado);
-    setVal('geoOpcItrQty',     op.itr?.quantidade);
-    setChk('geoOpcAnuencia',   op.anuencia?.contratado);
-    setVal('geoOpcAnuenciaQty', op.anuencia?.quantidade);
-    setChk('geoOpcRetificacao', op.retificacao?.contratado);
+    setChk('geoOpcCcir',         op.ccir?.contratado);
+    // v3.23.6: restaura valor_unitario editado pelo usuario
+    setVal('geoOpcCcirValor',    op.ccir?.valor_unitario);
+    setChk('geoOpcCar',          op.car?.contratado);
+    setVal('geoOpcCarValor',     op.car?.valor_unitario);
+    setChk('geoOpcItr',          op.itr?.contratado);
+    setVal('geoOpcItrQty',       op.itr?.quantidade);
+    setVal('geoOpcItrValor',     op.itr?.valor_unitario);
+    setChk('geoOpcAnuencia',     op.anuencia?.contratado);
+    setVal('geoOpcAnuenciaQty',  op.anuencia?.quantidade);
+    setVal('geoOpcAnuenciaValor', op.anuencia?.valor_unitario);
+    setChk('geoOpcRetificacao',  op.retificacao?.contratado);
+    // dispara recalculo apos restore (estado dos checkboxes pode ter mudado)
+    if (typeof _recalcularOpcionaisTotal === 'function') _recalcularOpcionaisTotal();
   }
 
   document.getElementById('geoPreview').onclick = async () => {
@@ -6918,24 +7122,27 @@ async function renderConsultoriaFormGeoRural(v, toggleHTML) {
       cri: _criInput || `CRI de ${_municipio}/${_estado}`,
       perimetro_m: Number(document.getElementById('geoPerimetro').value) || undefined,
       validade_dias: Number(document.getElementById('geoValidadeDias').value) || 15,
+      // v3.23.6: valor_unitario agora vem dos inputs editaveis (nao mais hardcoded).
+      // Defaults dos inputs: CCIR/CAR 1621, ITR 300/exerc, Anuencia 150/confrontante.
+      // Usuario pode aplicar desconto/ajuste; valor congela aqui no envio.
       opcionais: {
         ccir: {
           contratado: document.getElementById('geoOpcCcir').checked,
-          valor_unitario: 350.00,
+          valor_unitario: Number(document.getElementById('geoOpcCcirValor').value) || 1621.00,
         },
         car: {
           contratado: document.getElementById('geoOpcCar').checked,
-          valor_unitario: 800.00,
+          valor_unitario: Number(document.getElementById('geoOpcCarValor').value) || 1621.00,
         },
         itr: {
           contratado: document.getElementById('geoOpcItr').checked,
           quantidade: Number(document.getElementById('geoOpcItrQty').value) || 0,
-          valor_unitario: 250.00,
+          valor_unitario: Number(document.getElementById('geoOpcItrValor').value) || 300.00,
         },
         anuencia: {
           contratado: document.getElementById('geoOpcAnuencia').checked,
           quantidade: Number(document.getElementById('geoOpcAnuenciaQty').value) || 0,
-          valor_unitario: 150.00,
+          valor_unitario: Number(document.getElementById('geoOpcAnuenciaValor').value) || 150.00,
         },
         retificacao: {
           contratado: document.getElementById('geoOpcRetificacao').checked,

--- a/src/services/pricing/georreferenciamento.test.ts
+++ b/src/services/pricing/georreferenciamento.test.ts
@@ -248,6 +248,110 @@ describe('Opcionais (secao_opcionais_georref)', () => {
   });
 });
 
+// v3.23.6: valores default subiram (CCIR/CAR 350/800 -> 1621; ITR 250 -> 300) e
+// a UI agora permite editar valor_unitario por linha. Engine deve respeitar o
+// valor passado no payload (override) E cair no default do pricing-params.json
+// quando o payload omitir.
+describe('v3.23.6 — valor_unitario editavel (override do default)', () => {
+  it('respeita CCIR R$ 1.200 enviado pelo usuario (override do default 1621)', async () => {
+    const r = await calcularGeorreferenciamento({
+      ...inputBase,
+      opcionais: {
+        ccir: { contratado: true, valor_unitario: 1200 },
+        car:  { contratado: false, valor_unitario: 1621 },
+        itr:  { contratado: false, quantidade: 0, valor_unitario: 300 },
+        anuencia: { contratado: false, quantidade: 0, valor_unitario: 150 },
+        retificacao: { contratado: false, valor: 'sob_orcamento' },
+      },
+    });
+    const ccir = r.custos.secao_opcionais_georref!.itens.find((i) => i.chave === 'ccir')!;
+    expect(ccir.valor_unitario).toBe(1200);
+    expect(ccir.subtotal).toBe(1200);
+    expect(r.custos.secao_opcionais_georref!.subtotal).toBe(1200);
+  });
+
+  it('CCIR + CAR nos novos defaults (1621 + 1621 = 3242) — bate com 1 SM × 2', async () => {
+    const r = await calcularGeorreferenciamento({
+      ...inputBase,
+      opcionais: {
+        ccir: { contratado: true,  valor_unitario: 1621 },
+        car:  { contratado: true,  valor_unitario: 1621 },
+        itr:  { contratado: false, quantidade: 0, valor_unitario: 300 },
+        anuencia: { contratado: false, quantidade: 0, valor_unitario: 150 },
+        retificacao: { contratado: false, valor: 'sob_orcamento' },
+      },
+    });
+    expect(r.custos.secao_opcionais_georref!.subtotal).toBe(3242);
+  });
+
+  it('ITR multiplica corretamente: 5 exercicios x R$ 300 = R$ 1.500 (novo default)', async () => {
+    const r = await calcularGeorreferenciamento({
+      ...inputBase,
+      opcionais: {
+        ccir: { contratado: false, valor_unitario: 1621 },
+        car:  { contratado: false, valor_unitario: 1621 },
+        itr:  { contratado: true,  quantidade: 5, valor_unitario: 300 },
+        anuencia: { contratado: false, quantidade: 0, valor_unitario: 150 },
+        retificacao: { contratado: false, valor: 'sob_orcamento' },
+      },
+    });
+    const itr = r.custos.secao_opcionais_georref!.itens.find((i) => i.chave === 'itr')!;
+    expect(itr.quantidade).toBe(5);
+    expect(itr.valor_unitario).toBe(300);
+    expect(itr.subtotal).toBe(1500);
+  });
+
+  it('Cenario completo: CCIR 1621 + CAR 1621 + ITR 5x300 + Anuencia 3x150 = R$ 5.192', async () => {
+    const r = await calcularGeorreferenciamento({
+      ...inputBase,
+      opcionais: {
+        ccir: { contratado: true, valor_unitario: 1621 },
+        car:  { contratado: true, valor_unitario: 1621 },
+        itr:  { contratado: true, quantidade: 5, valor_unitario: 300 },
+        anuencia: { contratado: true, quantidade: 3, valor_unitario: 150 },
+        retificacao: { contratado: false, valor: 'sob_orcamento' },
+      },
+    });
+    // 1621 + 1621 + 1500 + 450 = 5192
+    expect(r.custos.secao_opcionais_georref!.subtotal).toBe(5192);
+    // total Romatec permanece inalterado (opcionais nao somam)
+    expect(r.custos.secao_5_total).toBe(11030.2);
+  });
+
+  it('cai no default do params (1621) quando payload tem contratado=true mas omite valor_unitario', async () => {
+    // Quando o frontend nao envia valor_unitario (campo undefined), o engine
+    // usa params.opcionais_georref.ccir.valor_unitario (atualizado pra 1621 em v3.23.6)
+    const r = await calcularGeorreferenciamento({
+      ...inputBase,
+      opcionais: {
+        ccir: { contratado: true } as any, // valor_unitario omitido
+        car:  { contratado: false, valor_unitario: 1621 },
+        itr:  { contratado: false, quantidade: 0, valor_unitario: 300 },
+        anuencia: { contratado: false, quantidade: 0, valor_unitario: 150 },
+        retificacao: { contratado: false, valor: 'sob_orcamento' },
+      },
+    });
+    const ccir = r.custos.secao_opcionais_georref!.itens.find((i) => i.chave === 'ccir')!;
+    expect(ccir.subtotal).toBe(1621); // novo default
+  });
+
+  it('desconto: usuario ajusta Anuencia pra R$ 100/confrontante (override)', async () => {
+    const r = await calcularGeorreferenciamento({
+      ...inputBase,
+      opcionais: {
+        ccir: { contratado: false, valor_unitario: 1621 },
+        car:  { contratado: false, valor_unitario: 1621 },
+        itr:  { contratado: false, quantidade: 0, valor_unitario: 300 },
+        anuencia: { contratado: true, quantidade: 4, valor_unitario: 100 },
+        retificacao: { contratado: false, valor: 'sob_orcamento' },
+      },
+    });
+    const anu = r.custos.secao_opcionais_georref!.itens.find((i) => i.chave === 'anuencia')!;
+    expect(anu.valor_unitario).toBe(100);
+    expect(anu.subtotal).toBe(400);
+  });
+});
+
 describe('Defaults quando opcionais omitidos', () => {
   it('roda sem finalidade nem opcionais (retrocompat com inputs antigos)', async () => {
     const r = await calcularGeorreferenciamento(inputBase);

--- a/src/services/pricing/params.ts
+++ b/src/services/pricing/params.ts
@@ -59,11 +59,13 @@ interface PricingParams {
   };
   tjma_emolumentos_2026: { fonte: string; limite_maximo_total: number };
   // v3.23.5: servicos adicionais opcionais de Georreferenciamento Rural.
+  // v3.23.6: `editavel` indica que o valor_unitario pode ser editado pelo
+  // usuario na UI no momento da proposta (sem afetar o default global).
   opcionais_georref?: {
-    ccir:        { rotulo: string; valor_unitario: number };
-    car:         { rotulo: string; valor_unitario: number };
-    itr:         { rotulo: string; valor_unitario: number; unidade?: string };
-    anuencia:    { rotulo: string; valor_unitario: number; unidade?: string };
+    ccir:        { rotulo: string; valor_unitario: number; editavel?: boolean };
+    car:         { rotulo: string; valor_unitario: number; editavel?: boolean };
+    itr:         { rotulo: string; valor_unitario: number; unidade?: string; editavel?: boolean };
+    anuencia:    { rotulo: string; valor_unitario: number; unidade?: string; editavel?: boolean };
     retificacao: { rotulo: string; valor: 'sob_orcamento' };
   };
   _meta?: { ultima_atualizacao: string; atualizado_por: string; versao: string };


### PR DESCRIPTION
Mudanca de valores default em config/pricing-params.json (opcionais_georref):
- CCIR: R$ 350 -> R$ 1.621 (1 SM 2026, condiz com esforco real INCRA/SICAR)
- CAR:  R$ 800 -> R$ 1.621 (mesma logica do CCIR, SICAR + APP/RL)
- ITR:  R$ 250/exerc -> R$ 300/exerc (Receita: DARFs + parcelamento + acompanhamento)
- Anuencia: R$ 150/confrontante (inalterado — alinhado ao mercado)
- Retificacao: sob orcamento (inalterado — caso a caso)

UI no form Georref Rural — todos os valores editaveis: Bloco "Servicos adicionais opcionais" refatorado de checkbox+texto estatico para checkbox + input numerico do valor + input qty (quando aplica) + subtotal calculado on-change. Estrutura por linha:
- CCIR/CAR: checkbox | R$ [1621.00] | Subtotal: R$ X
- ITR:      checkbox | Exerc. [N] | R$/exerc. [300.00] | Subtotal
- Anuencia: checkbox | Confr. [N] | R$/confr. [150.00] | Subtotal
- Retific:  checkbox | "Sob orcamento — valor a definir"

Total geral em box dourado: "Total dos opcionais (informativo — NAO soma ao Romatec)" — atualiza em tempo real. Inputs ficam disabled (opacity 45%) quando o checkbox correspondente esta desmarcado.

Backend (engine) NAO mudou — desde v3.23.5 ja respeita valor_unitario do payload (com fallback pro params.json e depois hardcoded). Mudou so o default em params.json e a colecao de dados em geoPreview.onclick (le os inputs editaveis em vez de hardcoded 350/800/250/150).

Restore do cache (volta do preview): tambem restaura valor_unitario editado pelo usuario via setVal('geoOpcCcirValor', op.ccir?.valor_unitario)
+ dispara _recalcularOpcionaisTotal() pra atualizar subtotais.

Propostas antigas: zero impacto retroativo — valor_unitario fica congelado em dados_imovel.opcionais.<chave>.valor_unitario no momento da criacao, bump de default aqui nao mexe nelas.

6 testes novos em georreferenciamento.test.ts (24 -> 30):
- CCIR R$ 1.200 (override do default 1621)
- CCIR + CAR nos novos defaults (3242 = 1 SM x 2)
- ITR 5 exerc x R$ 300 = R$ 1.500
- Cenario completo (CCIR 1621 + CAR 1621 + ITR 5x300 + Anuencia 3x150 = R$ 5.192)
- Fallback params.json (contratado:true sem valor_unitario usa 1621)
- Desconto (Anuencia R$ 100/confr override)

Em todos os cenarios, secao_5_total (Romatec) permanece 11030.20 — opcionais nao somam.

Total: 467 testes (466 passing, 1 skipped, 0 failures).