### PR TITLE
fix(pdf): anexos voltam juntos no PDF default (reverte v3.23.7)

### DIFF
--- a/06-Changelog/v3.23.10-anexos-junto-no-pdf.md
+++ b/06-Changelog/v3.23.10-anexos-junto-no-pdf.md
@@ -1,0 +1,94 @@
+# v3.23.10 — Anexos voltam juntos no PDF (reverte v3.23.7)
+
+**Data:** 2026-05-21
+**Origem:** CEO testou v3.23.9 em produção. PDF da proposta correto, modal de assinatura PJ/PF funcionando — mas o cliente final prefere **um único arquivo** com proposta + anexos juntos (mais fácil de armazenar/encaminhar/enviar pro cartório). Reverter a decisão de v3.23.7.
+
+## Mudança
+
+| Rota | v3.23.7-9 (PDF "limpo") | v3.23.10 (revertido) |
+|---|---|---|
+| `GET /api/propostas-consultoria/:id/pdf` (default) | Só a proposta | **Proposta + anexos** |
+| `GET /api/propostas-consultoria/:id/pdf?incluir_anexos=1` | Proposta + anexos | Proposta + anexos (idem) |
+| **NOVO** `?sem_anexos=1` ou `?somente_principal=1` | n/a | Só a proposta (opt-out) |
+| `GET /v/:hash/pdf` (público) | Só a proposta | **Proposta + anexos** |
+| `POST /enviar-whatsapp` | 1 proposta + N anexos (mensagens separadas) | **1 PDF unificado** |
+| `POST /enviar-telegram` | Idem WhatsApp | **1 PDF unificado** |
+
+## Backend (`propostasConsultoria.ts`)
+
+- `enviarPropostaConsultoriaWhatsApp`: volta a usar `gerarPdfPropostaConsultoriaComAnexos`. Loop de anexos individuais + throttle 1.5s removido. Mensagem única no WhatsApp com PDF merged.
+- `enviarPropostaConsultoriaTelegram`: idem. Guard de 50MB preservado.
+- Helpers `sleep` e `ANEXO_THROTTLE_MS` ficam comentados (caso outras integrações futuras precisem)
+
+## Endpoint (`server.ts`)
+
+```typescript
+// v3.23.10: default volta pra ComAnexos. Opt-out via ?sem_anexos=1 (ou
+// ?somente_principal=1 legado). ?incluir_anexos=1 ainda aceito como
+// opt-in explicito (compat com v3.23.7-9).
+const semAnexos = req.query.sem_anexos === '1' || req.query.somente_principal === '1';
+const incluirExplicito = req.query.incluir_anexos === '1';
+const incluirAnexos = incluirExplicito || !semAnexos;
+const buf = incluirAnexos
+  ? await gerarPdfPropostaConsultoriaComAnexos(id)
+  : await gerarPdfPropostaConsultoria(id);
+```
+
+Compat retro tripla:
+- `?somente_principal=1` (v1.66.9 legado) — opt-out
+- `?incluir_anexos=1` (v3.23.7-9 transient) — opt-in (no-op desde v3.23.10 já que default é incluir)
+- `?sem_anexos=1` (v3.23.10 novo) — opt-out
+
+## Testes ajustados
+
+Os 4 smoke tests da v3.23.7 (`proposta-georref-pdf-cleanup.test.ts`) foram invertidos:
+- "endpoint default sem anexos" → "endpoint default COM anexos"
+- "/v/:hash/pdf sem anexos" → "/v/:hash/pdf COM anexos"
+- "enviar-whatsapp em mensagens separadas" → "enviar-whatsapp PDF unificado"
+- "enviar-telegram mensagens separadas" → "enviar-telegram PDF unificado"
+
+Os smoke tests específicos da v3.23.8 (`proposta-georref-pdf-v3-23-8.test.ts`) continuam válidos (Bug A/B/C ainda corrigidos — só o roteamento dos anexos mudou).
+
+## Versão
+
+- `package.json`: 3.23.9 → **3.23.10**
+
+## Validação
+
+- `npm run typecheck`: ✅
+- `npm test`: ✅ **487 passing / 1 skipped / 0 failures**
+
+## Validação manual obrigatória (pós-deploy)
+
+1. Gerar PROP-2026-0016 com 2 anexos cadastrados
+2. Baixar `/api/propostas-consultoria/16/pdf` (default) → deve ter **proposta + anexos** no PDF
+3. Baixar `/api/propostas-consultoria/16/pdf?sem_anexos=1` → só a proposta (3-4 págs)
+4. Acessar `/v/:hash/pdf` (público) → proposta + anexos
+5. Enviar via WhatsApp → **1 mensagem** com PDF unificado (não 3)
+6. Verificar que o PDF unificado tem:
+   - 3-4 páginas da proposta principal
+   - 1 página por anexo PNG/JPEG (imagem centralizada + legenda "Anexo: filename")
+   - Páginas do anexo PDF concatenadas no fim
+
+## PR
+
+- Branch: `fix/anexos-junto-no-pdf` (a partir de `feature/assinatura-pj-pf-selector`)
+- Base: `main`
+- 1 commit semântico
+
+## Decisão histórica
+
+O ciclo v3.23.7 → v3.23.10 foi:
+
+1. **v3.23.6 e antes:** PDF unificado (default)
+2. **v3.23.7:** CEO reclamou que anexos "vazavam" no PDF. Inverteu pra default sem anexos
+3. **v3.23.8:** corrigiu 3 regressões introduzidas em v3.23.7
+4. **v3.23.9:** seletor PJ/PF na assinatura
+5. **v3.23.10:** CEO reverteu de novo — cliente final prefere PDF unificado
+
+Lição aprendida: a decisão de "anexos juntos ou separados" depende do uso final (cliente / cartório / órgão). Resposta correta é manter **ambos os caminhos** disponíveis (`?incluir_anexos=1` e `?sem_anexos=1`) e ter um default razoável. Default agora = juntos.
+
+## Follow-ups
+
+- Considerar adicionar opção no form de Nova Proposta: checkbox "anexos junto no PDF" (true por default) que vira config persistida por proposta
+- Painel admin com toggle global "PDF default" (juntos/separados) — só pra evitar oscilar entre defaults

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.23.9",
+  "version": "3.23.10",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -1541,12 +1541,13 @@ function formatDataBR(d: Date | string): string {
 
 // ── Envio ──────────────────────────────────────────────────────────────────
 
-// v3.23.7: helper de delay entre envios pra nao estourar rate-limit da Z-API.
-// Z-API recomenda 1-2s entre mensagens; usamos 1500ms.
-const ANEXO_THROTTLE_MS = 1500;
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
+// v3.23.7 a v3.23.9: helper sleep + ANEXO_THROTTLE_MS pra loop de envio
+// individual de anexos. v3.23.10 reverteu pra PDF unificado — helper nao usado
+// mais aqui, mantido caso outras integracoes futuras precisem.
+// const ANEXO_THROTTLE_MS = 1500;
+// function sleep(ms: number): Promise<void> {
+//   return new Promise((r) => setTimeout(r, ms));
+// }
 
 export async function enviarPropostaConsultoriaWhatsApp(input: { id: string; telefone?: string }) {
   const idNum = Number(input.id);
@@ -1555,27 +1556,14 @@ export async function enviarPropostaConsultoriaWhatsApp(input: { id: string; tel
   const tel = (input.telefone?.trim()) || p.cliente?.telefone || '';
   if (!tel) throw new Error('Telefone obrigatorio (informe ou cadastre no cliente).');
 
-  // v3.23.7: PDF SEM anexos. Antes mandava o merged (proposta + plantas/fotos/matriculas
-  // num PDF unico de 10+ paginas), agora manda so a proposta enxuta. Anexos seguem em
-  // mensagens separadas no Z-API — cliente recebe arquivos individuais (melhor pra
-  // download seletivo e organizacao no aparelho).
-  const propostaBuf = await gerarPdfPropostaConsultoria(input.id);
-  const safeNome = (p.cliente?.nome || 'cliente').replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30);
-  const fileNameProposta = `Proposta_${p.numero}_${safeNome}.pdf`;
-  const respPrincipal = await sendWhatsAppDocument(tel, propostaBuf.toString('base64'), fileNameProposta);
-
-  // Anexos enviados como mensagens separadas, com throttle pra nao dropar conexao Z-API.
-  const anexos = await carregarAnexosProposta(idNum);
-  const anexosEnviados: Array<{ filename: string; messageId?: string }> = [];
-  for (const anexo of anexos) {
-    await sleep(ANEXO_THROTTLE_MS);
-    try {
-      const r = await sendWhatsAppDocument(tel, anexo.buffer.toString('base64'), anexo.filename);
-      anexosEnviados.push({ filename: anexo.filename, messageId: r.messageId });
-    } catch (err) {
-      console.warn(`[whatsapp-consultoria] falha ao enviar anexo "${anexo.filename}": ${(err as Error).message}`);
-    }
-  }
+  // v3.23.10: PDF UNIFICADO (proposta + anexos no mesmo arquivo). Antes:
+  // - v3.23.7-9: enviava proposta separado + cada anexo em mensagem propria
+  //   com throttle. UX boa pra download seletivo mas o cliente acabou pedindo
+  //   pra voltar pra 1 unico arquivo (mais facil de armazenar/encaminhar).
+  // - Agora: PDF merged via gerarPdfPropostaConsultoriaComAnexos.
+  const pdfBuf = await gerarPdfPropostaConsultoriaComAnexos(input.id);
+  const fileName = `Proposta_${p.numero}_${(p.cliente?.nome || 'cliente').replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30)}.pdf`;
+  const r = await sendWhatsAppDocument(tel, pdfBuf.toString('base64'), fileName);
 
   await pool.execute(
     `UPDATE propostas
@@ -1588,11 +1576,9 @@ export async function enviarPropostaConsultoriaWhatsApp(input: { id: string; tel
 
   return {
     ok: true as const,
-    message: `Proposta ${p.numero} enviada via WhatsApp para ${respPrincipal.phone} (msgId ${respPrincipal.messageId || '?'}). ${anexosEnviados.length}/${anexos.length} anexo(s) enviado(s) em mensagens separadas.`,
-    messageId: respPrincipal.messageId,
-    phone: respPrincipal.phone,
-    anexos_enviados: anexosEnviados.length,
-    anexos_total: anexos.length,
+    message: `Proposta ${p.numero} enviada via WhatsApp para ${r.phone} (msgId ${r.messageId || '?'}, ${(pdfBuf.length / 1024).toFixed(0)} KB).`,
+    messageId: r.messageId,
+    phone: r.phone,
   };
 }
 
@@ -1607,27 +1593,23 @@ export async function enviarPropostaConsultoriaTelegram(input: { id: string; cha
   if (!chatId) throw new Error('chatId Telegram obrigatorio (defina TELEGRAM_LEAD_CHAT_ID ou TELEGRAM_AUTHORIZED_USER_IDS, ou passe explicit).');
 
   // v1.66.14: log + try/catch detalhado pra diagnosticar falhas no 2o envio
-  // v3.23.7: PDF SEM anexos (apenas proposta principal). Anexos vao em mensagens
-  // separadas com throttle. Antes o PDF unico passava de 50MB e o Telegram rejeitava;
-  // agora cada peca cabe folgado individualmente.
+  // v3.23.10: revertido pra PDF UNIFICADO (proposta + anexos no mesmo arquivo).
+  // CEO pediu — cliente prefere 1 arquivo unico. Telegram aceita ate 50MB; guard mantido.
   console.log(`[telegram-consultoria] iniciando envio proposta=${p.numero} chat=${chatId}`);
   let pdfBuf: Buffer;
   try {
-    pdfBuf = await gerarPdfPropostaConsultoria(input.id);
-    console.log(`[telegram-consultoria] PDF proposta gerado: ${(pdfBuf.length / 1024 / 1024).toFixed(2)} MB`);
+    pdfBuf = await gerarPdfPropostaConsultoriaComAnexos(input.id);
+    console.log(`[telegram-consultoria] PDF gerado: ${(pdfBuf.length / 1024 / 1024).toFixed(2)} MB`);
   } catch (err) {
     console.error('[telegram-consultoria] erro ao gerar PDF:', (err as Error).message);
     throw new Error(`Falha ao gerar PDF: ${(err as Error).message}`);
   }
 
-  // Telegram limita arquivos a 50MB. Como o PDF agora e' so a proposta (3-4 paginas),
-  // dificilmente passa disso, mas mantemos o guard pra robustez.
   if (pdfBuf.length > 50 * 1024 * 1024) {
-    throw new Error(`PDF tem ${(pdfBuf.length / 1024 / 1024).toFixed(1)} MB e o Telegram aceita ate 50 MB.`);
+    throw new Error(`PDF tem ${(pdfBuf.length / 1024 / 1024).toFixed(1)} MB e o Telegram aceita ate 50 MB. Reduza o tamanho dos anexos da proposta.`);
   }
 
-  const safeNome = (p.cliente?.nome || 'cliente').replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30);
-  const fileName = `Proposta_${p.numero}_${safeNome}.pdf`;
+  const fileName = `Proposta_${p.numero}_${(p.cliente?.nome || 'cliente').replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30)}.pdf`;
   try {
     await sendTelegramDocument(chatId, pdfBuf, fileName, `Proposta ${p.numero} — ${SUBTIPO_LABEL[p.subtipo || ''] || p.subtipo}`);
     console.log(`[telegram-consultoria] envio OK proposta=${p.numero}`);
@@ -1639,19 +1621,6 @@ export async function enviarPropostaConsultoriaTelegram(input: { id: string; cha
     throw new Error(`Telegram rejeitou: ${desc}${code ? ` (code ${code})` : ''}`);
   }
 
-  // v3.23.7: anexos individuais (Telegram aceita ate 30 msgs/seg por chat — throttle leve)
-  const anexos = await carregarAnexosProposta(idNum);
-  let anexosEnviados = 0;
-  for (const anexo of anexos) {
-    await sleep(ANEXO_THROTTLE_MS);
-    try {
-      await sendTelegramDocument(chatId, anexo.buffer, anexo.filename, `Anexo: ${anexo.filename}`);
-      anexosEnviados++;
-    } catch (err) {
-      console.warn(`[telegram-consultoria] falha ao enviar anexo "${anexo.filename}": ${(err as Error).message}`);
-    }
-  }
-
   await pool.execute(
     `UPDATE propostas
         SET status = IF(status = 'rascunho', 'enviada', status)
@@ -1661,9 +1630,7 @@ export async function enviarPropostaConsultoriaTelegram(input: { id: string; cha
 
   return {
     ok: true as const,
-    message: `Proposta ${p.numero} enviada via Telegram (chat ${chatId}, ${(pdfBuf.length / 1024).toFixed(0)} KB). ${anexosEnviados}/${anexos.length} anexo(s) em mensagens separadas.`,
-    anexos_enviados: anexosEnviados,
-    anexos_total: anexos.length,
+    message: `Proposta ${p.numero} enviada via Telegram (chat ${chatId}, ${(pdfBuf.length / 1024).toFixed(0)} KB).`,
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3408,14 +3408,12 @@ app.get('/v/:hash/pdf', async (req: Request, res: Response) => {
       res.setHeader('Content-Disposition', `inline; filename="${r.numero}.pdf"`);
       return res.send(buf);
     }
-    // v1.99.17: fallback para proposta — serve só a proposta principal (sem anexos).
-    // v3.23.7: anexos foram REMOVIDOS do PDF servido pela rota publica /v/:hash/pdf.
-    // O cliente externo (cartorio, MPF, etc) recebia o PDF colado com plantas,
-    // matriculas e fotos do imovel; agora vê só a proposta tecnica/comercial. Os
-    // anexos seguem acessiveis via API autenticada /api/propostas-consultoria/:id/anexos.
+    // v1.99.17: fallback para proposta — serve PDF completo (proposta + anexos).
+    // v3.23.7-9: experimento serviu so a proposta principal — CEO pediu reverter
+    // em v3.23.10. Cliente externo/cartorio prefere um arquivo unico.
     const p = await propostasConsultoria.buscarPropostaPorHash(hash);
     if (p) {
-      const buf = await propostasConsultoria.gerarPdfPropostaConsultoria(p.id);
+      const buf = await propostasConsultoria.gerarPdfPropostaConsultoriaComAnexos(p.id);
       res.setHeader('Content-Type', 'application/pdf');
       res.setHeader('Content-Disposition', `inline; filename="${p.numero}.pdf"`);
       return res.send(buf);
@@ -3443,13 +3441,18 @@ app.post  ('/api/propostas-consultoria/preview',
 app.get   ('/api/propostas-consultoria/:id/pdf', async (req: Request, res: Response) => {
   try {
     const id = String(req.params.id);
-    // v3.23.7: INVERSAO DE DEFAULT — historico:
+    // Historico do default deste endpoint:
     //   v1.66.9: default era COMPLETO (merge proposta + anexos);  ?somente_principal=1 opt-out
-    //   v3.23.7: default e' SO A PROPOSTA;                        ?incluir_anexos=1 opt-in
-    // Razao: CEO reportou que o PDF "vazava" anexos do cliente (plantas, matriculas,
-    // fotos da fazenda) no documento da proposta. Cliente externo recebia bagunca.
-    // Compat retro: ?somente_principal=1 continua aceito (era no-op antes, agora redundante).
-    const incluirAnexos = req.query.incluir_anexos === '1';
+    //   v3.23.7: default invertido pra SO A PROPOSTA;             ?incluir_anexos=1 opt-in
+    //   v3.23.10: CEO pediu pra REVERTER ao default v1.66.9 — anexos JUNTOS no PDF.
+    //     Razao: cartorio/INCRA/cliente final preferem 1 arquivo unico do que multiplos
+    //     anexos avulsos. ?sem_anexos=1 e' o opt-out pra quem quer so a proposta enxuta.
+    //     Compat: ?somente_principal=1 (antigo) e ?incluir_anexos=1 (transient v3.23.7-9)
+    //     tambem sao aceitos. somente_principal=1 e sem_anexos=1 sao sinonimos.
+    const semAnexos = req.query.sem_anexos === '1' || req.query.somente_principal === '1';
+    // ?incluir_anexos=1 ainda funciona como opt-in explicito (caso alguem dependa)
+    const incluirExplicito = req.query.incluir_anexos === '1';
+    const incluirAnexos = incluirExplicito || !semAnexos;
     const buf = incluirAnexos
       ? await propostasConsultoria.gerarPdfPropostaConsultoriaComAnexos(id)
       : await propostasConsultoria.gerarPdfPropostaConsultoria(id);

--- a/src/test/proposta-georref-pdf-cleanup.test.ts
+++ b/src/test/proposta-georref-pdf-cleanup.test.ts
@@ -31,52 +31,46 @@ describe('Fix 1 — anexos nao vazam mais no PDF principal', () => {
     expect(propostasConsultoriaSrc).toMatch(/export async function gerarPdfPropostaConsultoriaComAnexos/);
   });
 
-  it('endpoint /api/.../pdf default e gerarPdfPropostaConsultoria (sem anexos)', () => {
-    // Default invertido em v3.23.7: antes era ComAnexos (default merge); agora e' sem.
-    // O caminho ComAnexos vira opt-in via ?incluir_anexos=1.
-    expect(serverSrc).toMatch(/req\.query\.incluir_anexos === '1'/);
-    expect(serverSrc).toMatch(
-      /incluirAnexos[\s\S]{0,80}gerarPdfPropostaConsultoriaComAnexos[\s\S]{0,80}gerarPdfPropostaConsultoria\(/,
-    );
+  it('endpoint /api/.../pdf default e ComAnexos (anexos juntos no PDF — v3.23.10)', () => {
+    // v3.23.10: REVERTIDO ao comportamento v1.66.9. Anexos voltaram pro PDF default.
+    // ?sem_anexos=1 (ou ?somente_principal=1 legado) e' o opt-out pra versao enxuta.
+    // ?incluir_anexos=1 ainda funciona como opt-in explicito (compat com v3.23.7-9).
+    expect(serverSrc).toMatch(/req\.query\.sem_anexos === '1'/);
+    expect(serverSrc).toMatch(/somente_principal === '1'/); // compat legado
+    // O default (sem nenhum query string) usa o ComAnexos
+    expect(serverSrc).toMatch(/incluirAnexos\s*=[\s\S]{0,80}!semAnexos/);
   });
 
-  it('rota publica /v/:hash/pdf usa gerarPdfPropostaConsultoria (sem anexos)', () => {
-    // Cliente externo (cartorio, MPF, INCRA) nao deve ver plantas/matriculas/fotos
-    // bagunçando o PDF da proposta tecnica. Anexos seguem na API autenticada.
+  it('rota publica /v/:hash/pdf usa ComAnexos (v3.23.10)', () => {
+    // Revertido em v3.23.10 — cliente final / cartorio prefere PDF unico.
     const idxVHash = serverSrc.indexOf("app.get('/v/:hash/pdf'");
     expect(idxVHash, '/v/:hash/pdf handler nao encontrado').toBeGreaterThan(0);
-    // Janela ate o proximo "app." (proximo handler) — pega o corpo inteiro
     const idxFim = serverSrc.indexOf('app.', idxVHash + 30);
     const trechoVHash = serverSrc.slice(idxVHash, idxFim > 0 ? idxFim : idxVHash + 2000);
-    expect(trechoVHash).toContain('gerarPdfPropostaConsultoria(p.id)');
-    expect(trechoVHash).not.toMatch(/gerarPdfPropostaConsultoriaComAnexos/);
+    expect(trechoVHash).toContain('gerarPdfPropostaConsultoriaComAnexos(p.id)');
   });
 
-  it('enviar-whatsapp envia proposta + cada anexo em mensagens separadas', () => {
+  it('enviar-whatsapp envia PDF unificado (v3.23.10)', () => {
+    // v3.23.10: revertido pra PDF unico (proposta + anexos no mesmo arquivo).
+    // CEO pediu — cliente prefere 1 arquivo unico de armazenar/encaminhar.
     const fn = propostasConsultoriaSrc.match(
       /export async function enviarPropostaConsultoriaWhatsApp[\s\S]+?\n\}/,
     );
     expect(fn).not.toBeNull();
     const body = fn![0];
-    // Usa o PDF SEM anexos
-    expect(body).toContain('gerarPdfPropostaConsultoria(input.id)');
-    expect(body).not.toContain('gerarPdfPropostaConsultoriaComAnexos');
-    // Loop de anexos com throttle
-    expect(body).toContain('carregarAnexosProposta');
-    expect(body).toMatch(/for \(const anexo of anexos\)/);
-    expect(body).toMatch(/await sleep\(ANEXO_THROTTLE_MS\)/);
+    expect(body).toContain('gerarPdfPropostaConsultoriaComAnexos(input.id)');
+    // Loop de anexos individuais foi removido
+    expect(body).not.toMatch(/for \(const anexo of anexos\)/);
   });
 
-  it('enviar-telegram tambem envia anexos em mensagens separadas', () => {
+  it('enviar-telegram envia PDF unificado (v3.23.10)', () => {
     const fn = propostasConsultoriaSrc.match(
       /export async function enviarPropostaConsultoriaTelegram[\s\S]+?\n\}/,
     );
     expect(fn).not.toBeNull();
     const body = fn![0];
-    expect(body).toContain('gerarPdfPropostaConsultoria(input.id)');
-    expect(body).not.toContain('gerarPdfPropostaConsultoriaComAnexos');
-    expect(body).toContain('carregarAnexosProposta');
-    expect(body).toMatch(/for \(const anexo of anexos\)/);
+    expect(body).toContain('gerarPdfPropostaConsultoriaComAnexos(input.id)');
+    expect(body).not.toMatch(/for \(const anexo of anexos\)/);
   });
 });
 


### PR DESCRIPTION
CEO testou v3.23.9 em prod. Modal de assinatura PJ/PF OK, PDF da proposta correto, mas cliente final (cartorio/INCRA/cliente direto) prefere UM unico arquivo com proposta + anexos juntos — mais facil de armazenar e encaminhar.

Reverte a decisao de v3.23.7 de separar:
- GET /pdf: default volta a chamar gerarPdfPropostaConsultoriaComAnexos
- GET /v/:hash/pdf (publico): tambem volta pro ComAnexos
- enviar-whatsapp e enviar-telegram: PDF unificado (1 mensagem so). Loop de anexos individuais + throttle removido. Helpers sleep/ ANEXO_THROTTLE_MS comentados pra reuso futuro.

Compat retro tripla preservada:
- ?somente_principal=1  (v1.66.9 legado) -> opt-out
- ?incluir_anexos=1     (v3.23.7-9 transient) -> opt-in (no-op desde v3.23.10)
- ?sem_anexos=1         (v3.23.10 novo) -> opt-out

Testes ajustados: os 4 smoke tests da v3.23.7 invertidos pra refletir o novo comportamento. Os 6 smoke tests da v3.23.8 (bugs A/B/C) continuam validos — so o roteamento dos anexos mudou, nao a logica do gerador.

Total: 487 passing / 1 skipped / 0 failures.