### PR TITLE
feat(quinzena-ux): botao Voltar substitui X + status pago/cancelado n…

### DIFF
--- a/06-Changelog/v3.23.11-quinzena-ux-pago-status.md
+++ b/06-Changelog/v3.23.11-quinzena-ux-pago-status.md
@@ -1,0 +1,128 @@
+# v3.23.11 — Modal do calendário de quinzena: Voltar + status pago/cancelado
+
+**Data:** 2026-05-21
+**Origem:** CEO pediu 2 ajustes UX no modal de marcação de dias (Gestão de Obras → Marcar Dias → 📅 calendário do funcionário):
+1. X do canto direito não tinha área de toque suficiente em mobile (~16px, abaixo dos 44px iOS HIG) — substituir por botão "◀ Voltar" mais visível
+2. Diferenciar visualmente dias **pagos** (azul) de **pendentes** (verde/amarelo atual) e **cancelados** (cinza riscado), pra dar feedback de quitação direto no calendário
+
+## Mudança 1 — Botão Voltar substitui X (com investigação da causa)
+
+### Causa do "X não funciona" reportado
+Investigado o handler atual:
+```html
+<button id="calClose" style="border:none;background:transparent;color:var(--text-muted);font-size:22px;cursor:pointer;">×</button>
+```
+
+Handler funcional em `obras.html:11108`. **Causa real:** sem `padding` ou `min-width`, a área de toque é só o bbox do glifo × (~16-18px). Abaixo dos **44×44px** mínimos da iOS HIG. Em mobile, dedo médio errava o alvo. Causa **(c)** das 4 hipóteses do brief.
+
+### Fix
+- Removido `#calClose` completamente
+- Adicionado **2 botões "◀ Voltar"**:
+  - **`#calVoltarTop`** no header (à esquerda do nome do funcionário)
+  - **`#calVoltarBottom`** no rodapé (após "Resetar mês"/"Resetar tudo") — mobile-friendly, usuário não precisa rolar pro topo depois de marcar dias
+- Nova classe CSS `.cal-voltar-btn` com `min-height: 44px` e `min-width: 88px` (iOS HIG)
+- Handler unificado `_calFechar()` chamado por: 2 botões + tecla `Escape` + clique fora do modal
+
+```css
+.cal-voltar-btn {
+  min-height: 44px;
+  min-width: 88px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  /* ... transitions + hover/active states ... */
+}
+```
+
+## Mudança 2 — 4 estados visuais para dias
+
+### Modelo de dados (não precisou ALTER TABLE)
+O brief sugeria criar coluna `pago` em `romatec_obra_funcionario_dias`. Investigação mostrou modelo melhor que já existia:
+- `romatec_obra_funcionario_dias.fechamento_id` (FK pra fechamento)
+- `folha_fechamento_itens.status_pagamento ENUM('aberta','paga','cancelada')` + `data_pagamento`
+
+Pagamento é **por item de fechamento (= quinzena inteira do funcionário)**, não dia-a-dia. Bate com a regra de negócio real.
+
+### Backend (`obras.ts` `listarDiasFuncionario`)
+SQL ganhou LEFT JOIN com `folha_fechamento_itens`. Payload agora inclui `fechamento_id`, `status_fechamento`, `data_pagamento` em cada dia:
+
+```sql
+SELECT
+  d.id, d.data, d.periodo, d.valor, d.obra_id, d.observacoes,
+  d.fechamento_id,
+  fi.status_pagamento AS status_fechamento,
+  fi.data_pagamento
+FROM romatec_obra_funcionario_dias d
+LEFT JOIN folha_fechamento_itens fi
+  ON d.fechamento_id IS NOT NULL
+ AND fi.fechamento_id = d.fechamento_id
+ AND fi.funcionario_id = d.funcionario_id
+WHERE d.funcionario_id = ?
+```
+
+### Frontend (`obras.html` `desenharCalendario`)
+Constrói `statusPorData[dataIso]` a partir do `status_fechamento` de cada dia (com rank `paga > cancelada > aberta` no caso de múltiplos períodos no mesmo dia com status diferentes — raro mas possível).
+
+Classes CSS condicionais por estado:
+
+| Estado | CSS | Visual |
+|---|---|---|
+| **Pendente integral** | `.cal-cell.integral` | Verde |
+| **Pendente meia (manhã)** | `.cal-cell.manha` | Amarelo (top) |
+| **Pendente meia (tarde)** | `.cal-cell.tarde` | Amarelo (bottom) |
+| **Pago integral** | `.cal-cell.pago-integral` | **Azul escuro** + ✓ |
+| **Pago meia (manhã)** | `.cal-cell.pago-manha` | **Azul claro (top)** + ✓ |
+| **Pago meia (tarde)** | `.cal-cell.pago-tarde` | **Azul claro (bottom)** + ✓ |
+| **Cancelado** | `.cal-cell.cancelado` | **Cinza** com `line-through` |
+
+Checkmark ✓ aparece no canto inferior direito de células pagas via `::after`.
+
+### Legenda atualizada
+
+```
+🟢 Integral pendente · 🟡 Meia (manhã) · 🟡 Meia (tarde) · 🔵 Pago · ⚫ Cancelado
+```
+
+## Arquivos tocados
+
+- `src/integrations/obras.ts` (~linha 1063): `listarDiasFuncionario` ganha LEFT JOIN
+- `src/public/obras.html`:
+  - Header e rodapé do modal `#calOverlay` (linhas ~1055-1115)
+  - CSS `.cal-voltar-btn`, `.cal-cell.pago-*`, `.cal-cell.cancelado` (após linha ~590)
+  - JS handler `_calFechar` substituindo `calClose.onclick` (linha ~11108)
+  - JS `desenharCalendario` com `statusPorData` e lógica de 4 estados (linha ~11030)
+- `src/test/quinzena-ux-pago-status.test.ts` (novo) — **12 smoke tests** cobrindo: X removido, Voltar com tap target 44x44, handler ESC/overlay, backend JOIN, payload com 3 campos novos, CSS dos 4 estados, checkmark, legenda, render condicional
+- `package.json` — `3.23.10 → 3.23.11`
+- `06-Changelog/v3.23.11-quinzena-ux-pago-status.md` (este)
+
+## Validação
+
+- `npm run typecheck`: ✅
+- `npm test`: ✅ **499 passing / 1 skipped / 0 failures** (era 487 → +12 novos)
+
+## Validação manual obrigatória (pós-deploy)
+
+1. Abrir modal de marcação de dias num funcionário com **fechamento já pago**
+2. Verificar: dias daquele fechamento aparecem em **azul** com ✓
+3. Abrir noutro com **fechamento cancelado** (se houver) — dias em **cinza riscado**
+4. Funcionário com quinzena ATIVA (sem fechamento) — dias verde/amarelo normal
+5. **Mobile (iPhone DevTools):** clicar Voltar no topo OU no rodapé — ambos fecham o modal
+6. **ESC** também fecha
+7. **Clique fora do modal** (overlay escuro) também fecha
+8. Confirmar que o X NÃO aparece mais em lugar nenhum
+
+## Sobre login do colaborador (Leonardo)
+
+Brief do user mencionou um próximo prompt sobre login do colaborador — fica como **branch separada `feature/login-colaborador`** APÓS esta `feature/quinzena-ux-pago-status` mergear, com o mesmo padrão de análise de divergências antes de codar.
+
+## PR
+
+- Branch: `feature/quinzena-ux-pago-status` (cortada de `fix/anexos-junto-no-pdf` pra carregar os 4 PRs pendentes)
+- Base: `main`
+- 1 commit semântico
+
+## Follow-ups (não bloqueiam merge)
+
+1. Tooltip ao passar mouse sobre dia pago — mostrar data_pagamento + forma_pagamento (já vem do JOIN, basta render)
+2. Filtro "mostrar só pendentes" no modal — útil quando há muitos meses de histórico
+3. Replicar padrão `cal-voltar-btn` em outros modais legacy (recibos, vistorias) que usam X pequeno

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.23.10",
+  "version": "3.23.11",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/obras.ts
+++ b/src/integrations/obras.ts
@@ -1066,13 +1066,35 @@ export async function listarDiasFuncionario(input: {
 }) {
   if (!input.funcionario_id) throw new Error('funcionario_id obrigatório');
   const params: (string | number)[] = [input.funcionario_id];
-  let sql = 'SELECT * FROM romatec_obra_funcionario_dias WHERE funcionario_id = ?';
+  // v3.23.11: LEFT JOIN com folha_fechamento_itens — retorna status do
+  // fechamento pra UI poder colorir dias pagos (azul) vs pendentes (verde/amarelo)
+  // vs cancelados (cinza). O `pago` e' por ITEM de fechamento (a quinzena inteira
+  // do funcionario), nao dia-a-dia. Dia sem fechamento (`fechamento_id IS NULL`)
+  // continua aparecendo como pendente — caso comum da quinzena ativa.
+  let sql = `
+    SELECT
+      d.id, d.data, d.periodo, d.valor, d.obra_id, d.observacoes,
+      d.fechamento_id,
+      fi.status_pagamento AS status_fechamento,
+      fi.data_pagamento
+    FROM romatec_obra_funcionario_dias d
+    LEFT JOIN folha_fechamento_itens fi
+      ON d.fechamento_id IS NOT NULL
+     AND fi.fechamento_id = d.fechamento_id
+     AND fi.funcionario_id = d.funcionario_id
+    WHERE d.funcionario_id = ?
+  `;
   if (input.ano && input.mes) {
-    sql += ' AND YEAR(data) = ? AND MONTH(data) = ?';
+    sql += ' AND YEAR(d.data) = ? AND MONTH(d.data) = ?';
     params.push(input.ano, input.mes);
   }
-  sql += ' ORDER BY data ASC';
-  const [rows] = await pool.execute<DiaRow[]>(sql, params);
+  sql += ' ORDER BY d.data ASC';
+  type DiaRowExt = DiaRow & {
+    fechamento_id: number | null;
+    status_fechamento: 'aberta' | 'paga' | 'cancelada' | null;
+    data_pagamento: Date | string | null;
+  };
+  const [rows] = await pool.execute<DiaRowExt[]>(sql, params);
   return rows.map(r => ({
     id: String(r.id),
     data: r.data instanceof Date ? r.data.toISOString().slice(0, 10) : String(r.data),
@@ -1080,6 +1102,12 @@ export async function listarDiasFuncionario(input: {
     valor: num(r.valor),
     obra_id: r.obra_id ? String(r.obra_id) : null,
     observacoes: r.observacoes,
+    // v3.23.11: novos campos pra UI colorir
+    fechamento_id: r.fechamento_id ? Number(r.fechamento_id) : null,
+    status_fechamento: r.status_fechamento ?? null,
+    data_pagamento: r.data_pagamento
+      ? (r.data_pagamento instanceof Date ? r.data_pagamento.toISOString() : String(r.data_pagamento))
+      : null,
   }));
 }
 

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -593,6 +593,62 @@
     background: rgba(0,255,136,0.18); border-color: var(--neon);
     color: var(--neon); font-weight: 600;
   }
+  /* v3.23.11: estados pago/cancelado (folha_fechamento_itens.status_pagamento).
+     Cada dia carrega o status do item de fechamento do funcionario via JOIN
+     no endpoint listarDiasFuncionario. */
+  .cal-cell.pago-integral {
+    background: rgba(30, 58, 138, 0.35); border-color: #3b82f6;
+    color: #93c5fd; font-weight: 600;
+  }
+  .cal-cell.pago-manha {
+    background: linear-gradient(180deg, rgba(96, 165, 250, 0.45) 50%, var(--bg-elev) 50%);
+    border-color: #60a5fa; color: #93c5fd; font-weight: 600;
+  }
+  .cal-cell.pago-tarde {
+    background: linear-gradient(180deg, var(--bg-elev) 50%, rgba(96, 165, 250, 0.45) 50%);
+    border-color: #60a5fa; color: #93c5fd; font-weight: 600;
+  }
+  /* Checkmark discreto no canto inferior direito quando pago */
+  .cal-cell.pago-integral::after,
+  .cal-cell.pago-manha::after,
+  .cal-cell.pago-tarde::after {
+    content: '✓'; position: absolute; bottom: 2px; right: 3px;
+    font-size: 9px; opacity: 0.85; color: #93c5fd; z-index: 2;
+    line-height: 1;
+  }
+  /* Cancelado — fechamento existia mas foi anulado depois. Cinza translucido com strike */
+  .cal-cell.cancelado {
+    background: rgba(107, 114, 128, 0.18); border-color: #6b7280;
+    color: #9ca3af; font-weight: 500; text-decoration: line-through;
+  }
+  /* v3.23.11: botao Voltar — padrao iOS HIG min 44x44 area de toque.
+     Antes era um × no canto direito com font-size:22px e zero padding
+     (~16px de tap area). Mobile sofria pra acertar. */
+  .cal-voltar-btn {
+    min-height: 44px;
+    min-width: 88px;
+    padding: 10px 14px;
+    border: 1px solid var(--border);
+    background: var(--bg-elev);
+    color: var(--text);
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: var(--radius);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    transition: all 0.15s;
+  }
+  .cal-voltar-btn:hover {
+    background: var(--surface);
+    border-color: var(--neon);
+    color: var(--neon);
+  }
+  .cal-voltar-btn:active {
+    transform: scale(0.97);
+  }
   .cal-cell-label {
     position: absolute; bottom: 2px; right: 4px;
     font-size: 8px; opacity: 0.8;
@@ -1054,12 +1110,17 @@ window.forcarUpdateApp = forcarUpdate;
 
 <div class="cal-overlay" id="calOverlay">
   <div class="cal-modal" id="calModal">
+    <!-- v3.23.11: header reformulado. Antes tinha um × no canto direito com
+         font-size:22px e zero padding — area de toque ~16px, abaixo dos 44px
+         iOS HIG, dificil de acertar em mobile. Substituido por botao "◀ Voltar"
+         a esquerda com tap target 44x44, padrao iOS-like. Tem outro "◀ Voltar"
+         espelhado no rodape pra usuario nao precisar rolar pra fechar. -->
     <div class="cal-head">
-      <div>
+      <button id="calVoltarTop" class="cal-voltar-btn" type="button" aria-label="Voltar para lista">◀ Voltar</button>
+      <div style="flex:1; min-width:0;">
         <h2 id="calNome">—</h2>
         <p id="calMeta">—</p>
       </div>
-      <button id="calClose" style="border:none;background:transparent;color:var(--text-muted);font-size:22px;cursor:pointer;">×</button>
     </div>
     <div class="cal-nav">
       <button id="calPrev">◀ Anterior</button>
@@ -1069,10 +1130,15 @@ window.forcarUpdateApp = forcarUpdate;
     <div class="cal-help">
       <strong>1)</strong> Clique nos dias pra <strong>selecionar</strong> (pode marcar vários). <strong>2)</strong> Aperte o botão do período pra aplicar.
     </div>
+    <!-- v3.23.11: legenda ganha 4o item — azul (pago) + cinza (cancelado). Pago
+         e' por ITEM de fechamento (a quinzena inteira do funcionario), nao
+         dia-a-dia. Cancelado = fechamento foi anulado depois de criado. -->
     <div class="cal-legend">
-      <span><span class="cal-legend-dot" style="background:rgba(0,255,136,0.4);"></span>Integral</span>
+      <span><span class="cal-legend-dot" style="background:rgba(0,255,136,0.4);"></span>Integral pendente</span>
       <span><span class="cal-legend-dot" style="background:linear-gradient(180deg,rgba(201,168,76,0.5) 50%,transparent 50%);"></span>Meia (manhã)</span>
       <span><span class="cal-legend-dot" style="background:linear-gradient(180deg,transparent 50%,rgba(201,168,76,0.5) 50%);"></span>Meia (tarde)</span>
+      <span><span class="cal-legend-dot" style="background:rgba(59,130,246,0.35); border:1px solid #3b82f6;"></span>🔵 Pago</span>
+      <span><span class="cal-legend-dot" style="background:rgba(107,114,128,0.2); border:1px solid #6b7280;"></span>⚫ Cancelado</span>
     </div>
     <div class="cal-grid" id="calGrid"></div>
     <div id="calActions" style="padding: 12px 20px; border-top: 1px solid var(--border); display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
@@ -1091,6 +1157,11 @@ window.forcarUpdateApp = forcarUpdate;
     <div style="padding: 12px 20px 16px; display:flex; gap:8px; flex-wrap:wrap; border-top: 1px solid var(--border);">
       <button id="calResetMes" class="btn-danger" style="border:1px solid var(--danger); padding:6px 12px;">🗑️ Resetar mês</button>
       <button id="calResetTudo" class="btn-danger" style="border:1px solid var(--danger); padding:6px 12px;">🗑️ Resetar tudo</button>
+    </div>
+    <!-- v3.23.11: Voltar tambem no rodape — depois de marcar dias, usuario nao
+         precisa rolar pra cima pra fechar. Mobile-friendly. -->
+    <div style="padding: 12px 20px 16px; display:flex; gap:8px; border-top: 1px solid var(--border);">
+      <button id="calVoltarBottom" class="cal-voltar-btn" type="button" style="flex:1;" aria-label="Voltar para lista">◀ Voltar</button>
     </div>
   </div>
 </div>
@@ -10963,9 +11034,21 @@ function desenharCalendario() {
 
   // Mapa data → array de períodos marcados
   const marcado = {};
+  // v3.23.11: tambem mapa data → status do fechamento (paga|cancelada|aberta|null)
+  // Se o dia esta vinculado a um fechamento_item, mostra a cor do status.
+  // Se mais de um periodo no mesmo dia tem status diferente (raro), prevalece o
+  // mais "forte" na escala paga > cancelada > aberta.
+  const statusPorData = {};
+  const rankStatus = { 'paga': 3, 'cancelada': 2, 'aberta': 1 };
   cal.dias.forEach(d => {
     if (!marcado[d.data]) marcado[d.data] = new Set();
     marcado[d.data].add(d.periodo);
+    if (d.status_fechamento) {
+      const atual = statusPorData[d.data];
+      if (!atual || (rankStatus[d.status_fechamento] || 0) > (rankStatus[atual] || 0)) {
+        statusPorData[d.data] = d.status_fechamento;
+      }
+    }
   });
 
   const primeiroDia = new Date(cal.ano, cal.mes-1, 1);
@@ -10982,12 +11065,27 @@ function desenharCalendario() {
   for (let d = 1; d <= ultimoDia; d++) {
     const dataIso = `${cal.ano}-${String(cal.mes).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
     const periodos = marcado[dataIso] || new Set();
+    const status = statusPorData[dataIso] || null;
     let cls = '';
     let label = '';
-    if (periodos.has('integral')) { cls = 'integral'; label = '1d'; }
-    else if (periodos.has('manha') && periodos.has('tarde')) { cls = 'full-day'; label = '½+½'; }
-    else if (periodos.has('manha')) { cls = 'manha'; label = 'M'; }
-    else if (periodos.has('tarde')) { cls = 'tarde'; label = 'T'; }
+    // v3.23.11: 4 estados — cancelado, pago-{integral|manha|tarde}, pendente (verde/amarelo).
+    // Cancelado e' state final: independente do periodo, mostra cinza com strike.
+    if (status === 'cancelada' && periodos.size > 0) {
+      cls = 'cancelado';
+      label = periodos.has('integral') ? '1d' : (periodos.has('manha') && periodos.has('tarde') ? '½+½' : (periodos.has('manha') ? 'M' : 'T'));
+    } else if (status === 'paga') {
+      // Pago: azul. Mesma logica de periodo do pendente, prefixado com "pago-".
+      if (periodos.has('integral')) { cls = 'pago-integral'; label = '1d'; }
+      else if (periodos.has('manha') && periodos.has('tarde')) { cls = 'pago-integral'; label = '½+½'; }
+      else if (periodos.has('manha')) { cls = 'pago-manha'; label = 'M'; }
+      else if (periodos.has('tarde')) { cls = 'pago-tarde'; label = 'T'; }
+    } else {
+      // Pendente (status='aberta' ou null): verde/amarelo original.
+      if (periodos.has('integral')) { cls = 'integral'; label = '1d'; }
+      else if (periodos.has('manha') && periodos.has('tarde')) { cls = 'full-day'; label = '½+½'; }
+      else if (periodos.has('manha')) { cls = 'manha'; label = 'M'; }
+      else if (periodos.has('tarde')) { cls = 'tarde'; label = 'T'; }
+    }
     if (dataIso === todayIso) cls += ' today';
     if (cal.selecionados.has(dataIso)) cls += ' selected';
     html += `<div class="cal-cell ${cls}" data-d="${dataIso}"><span class="cal-day-num">${d}</span><span class="cal-cell-label">${label}</span></div>`;
@@ -11105,8 +11203,16 @@ async function resetarTudoCalendario() {
   }
 }
 
-document.getElementById('calClose').onclick = () => document.getElementById('calOverlay').classList.remove('open');
-document.getElementById('calOverlay').onclick = e => { if (e.target.id === 'calOverlay') document.getElementById('calOverlay').classList.remove('open'); };
+// v3.23.11: handler de fechar unificado — 2 botoes Voltar (topo + rodape) + ESC + click no overlay
+function _calFechar() {
+  document.getElementById('calOverlay').classList.remove('open');
+}
+document.getElementById('calVoltarTop').onclick = _calFechar;
+document.getElementById('calVoltarBottom').onclick = _calFechar;
+document.getElementById('calOverlay').onclick = e => { if (e.target.id === 'calOverlay') _calFechar(); };
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && document.getElementById('calOverlay').classList.contains('open')) _calFechar();
+});
 document.getElementById('calPrev').onclick = () => {
   if (cal.mes === 1) { cal.mes = 12; cal.ano--; } else cal.mes--;
   carregarMesCalendario();

--- a/src/test/quinzena-ux-pago-status.test.ts
+++ b/src/test/quinzena-ux-pago-status.test.ts
@@ -1,0 +1,112 @@
+// v3.23.11: smoke tests da UI nova do modal de marcacao de dias (quinzena).
+//
+// 3 mudancas testadas via leitura do HTML/CSS (sem render real — jsdom puro):
+// 1. Botao X removido, substituido por 2 botoes "◀ Voltar" (header + rodape)
+// 2. Render de celulas com 4 estados (pendente verde/amarelo, pago azul, cancelado cinza)
+// 3. Legenda atualizada com 4 itens (incluindo Pago e Cancelado)
+//
+// Backend: SQL do listarDiasFuncionario faz LEFT JOIN com folha_fechamento_itens.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const obrasHtml = readFileSync(join(REPO_ROOT, 'src', 'public', 'obras.html'), 'utf8');
+const obrasTs = readFileSync(join(REPO_ROOT, 'src', 'integrations', 'obras.ts'), 'utf8');
+
+describe('Mudanca 1 — botao X removido, Voltar adicionado', () => {
+  it('o X antigo (#calClose) NAO existe mais no DOM do modal', () => {
+    // Era um <button id="calClose">×</button> com area de toque ~16px
+    expect(obrasHtml).not.toMatch(/<button[^>]*id=["']calClose["']/);
+  });
+
+  it('existe Voltar no header (#calVoltarTop)', () => {
+    expect(obrasHtml).toMatch(/<button[^>]*id=["']calVoltarTop["'][^>]*class=["']cal-voltar-btn["']/);
+    expect(obrasHtml).toMatch(/aria-label=["']Voltar para lista["']/);
+  });
+
+  it('existe Voltar no rodape (#calVoltarBottom) — mobile-friendly', () => {
+    expect(obrasHtml).toMatch(/<button[^>]*id=["']calVoltarBottom["']/);
+  });
+
+  it('CSS .cal-voltar-btn tem min 44x44 (iOS HIG tap target)', () => {
+    const css = obrasHtml.match(/\.cal-voltar-btn\s*\{[^}]+\}/);
+    expect(css, 'CSS .cal-voltar-btn nao encontrado').not.toBeNull();
+    expect(css![0]).toMatch(/min-height:\s*44px/);
+    expect(css![0]).toMatch(/min-width:\s*88px/);
+  });
+
+  it('handler unificado _calFechar atende: 2 botoes + ESC + click overlay', () => {
+    expect(obrasHtml).toMatch(/function _calFechar\(\)/);
+    expect(obrasHtml).toMatch(/getElementById\(['"]calVoltarTop['"]\)\.onclick = _calFechar/);
+    expect(obrasHtml).toMatch(/getElementById\(['"]calVoltarBottom['"]\)\.onclick = _calFechar/);
+    // ESC handler
+    expect(obrasHtml).toMatch(/addEventListener\(['"]keydown['"][\s\S]+?Escape[\s\S]+?_calFechar/);
+    // Overlay click handler
+    expect(obrasHtml).toMatch(/getElementById\(['"]calOverlay['"]\)\.onclick[\s\S]+?_calFechar/);
+  });
+});
+
+describe('Mudanca 2 — backend retorna status do fechamento', () => {
+  it('listarDiasFuncionario faz LEFT JOIN com folha_fechamento_itens', () => {
+    expect(obrasTs).toMatch(/LEFT JOIN folha_fechamento_itens/);
+    expect(obrasTs).toMatch(/fi\.fechamento_id = d\.fechamento_id/);
+    expect(obrasTs).toMatch(/fi\.funcionario_id = d\.funcionario_id/);
+  });
+
+  it('payload de cada dia inclui fechamento_id, status_fechamento, data_pagamento', () => {
+    // Extracao por anchor — pega do header da funcao ate proximo export
+    const idxStart = obrasTs.indexOf('export async function listarDiasFuncionario');
+    const idxEnd = obrasTs.indexOf('\nexport ', idxStart + 50);
+    expect(idxStart).toBeGreaterThan(0);
+    expect(idxEnd).toBeGreaterThan(idxStart);
+    const body = obrasTs.slice(idxStart, idxEnd);
+    expect(body).toMatch(/fechamento_id:[\s\S]+?\?\s*Number\(r\.fechamento_id\)\s*:\s*null/);
+    expect(body).toMatch(/status_fechamento:\s*r\.status_fechamento\s*\?\?\s*null/);
+    expect(body).toMatch(/data_pagamento:/);
+  });
+});
+
+describe('Mudanca 3 — render frontend com 4 estados', () => {
+  it('CSS define classes .cal-cell.pago-integral / pago-manha / pago-tarde / cancelado', () => {
+    expect(obrasHtml).toMatch(/\.cal-cell\.pago-integral\s*\{[^}]+border-color:\s*#3b82f6/);
+    expect(obrasHtml).toMatch(/\.cal-cell\.pago-manha\s*\{[^}]+border-color:\s*#60a5fa/);
+    expect(obrasHtml).toMatch(/\.cal-cell\.pago-tarde\s*\{[^}]+border-color:\s*#60a5fa/);
+    expect(obrasHtml).toMatch(/\.cal-cell\.cancelado\s*\{[^}]+text-decoration:\s*line-through/);
+  });
+
+  it('checkmark ✓ aparece em celulas pagas (canto inferior direito)', () => {
+    expect(obrasHtml).toMatch(/\.cal-cell\.pago-integral::after[\s\S]+?content:\s*['"]✓['"]/);
+  });
+
+  it('legenda atualizada com 4 estados (Pago + Cancelado adicionados)', () => {
+    const legenda = obrasHtml.match(/<div class="cal-legend">[\s\S]+?<\/div>/);
+    expect(legenda).not.toBeNull();
+    expect(legenda![0]).toMatch(/Integral pendente/);
+    expect(legenda![0]).toMatch(/Meia \(manhã\)/);
+    expect(legenda![0]).toMatch(/Meia \(tarde\)/);
+    expect(legenda![0]).toMatch(/🔵 Pago/);
+    expect(legenda![0]).toMatch(/⚫ Cancelado/);
+  });
+
+  it('desenharCalendario constroi statusPorData a partir do status_fechamento', () => {
+    const fn = obrasHtml.match(/function desenharCalendario\(\)[\s\S]+?grid\.innerHTML = html;/);
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+    expect(body).toMatch(/const statusPorData = \{\}/);
+    expect(body).toMatch(/d\.status_fechamento/);
+    expect(body).toMatch(/const rankStatus = \{ ['"]paga['"]:\s*3,\s*['"]cancelada['"]:\s*2,\s*['"]aberta['"]:\s*1\s*\}/);
+  });
+
+  it('loop de render usa status pra aplicar classe pago/cancelado/pendente', () => {
+    const fn = obrasHtml.match(/function desenharCalendario\(\)[\s\S]+?grid\.innerHTML = html;/);
+    const body = fn![0];
+    expect(body).toMatch(/status === ['"]cancelada['"]/);
+    expect(body).toMatch(/status === ['"]paga['"]/);
+    expect(body).toMatch(/cls = ['"]pago-integral['"]/);
+    expect(body).toMatch(/cls = ['"]pago-manha['"]/);
+    expect(body).toMatch(/cls = ['"]pago-tarde['"]/);
+    expect(body).toMatch(/cls = ['"]cancelado['"]/);
+  });
+});


### PR DESCRIPTION
…os dias

Modal de marcacao de dias (Gestao de Obras > Marcar Dias > calendario do funcionario) ganha 2 ajustes UX:

1. X do canto direito tinha area de toque ~16px (font-size:22px sem padding), abaixo dos 44px iOS HIG. Substituido por 2 botoes "◀ Voltar":
   - #calVoltarTop no header (esquerda)
   - #calVoltarBottom no rodape (mobile — nao precisa rolar pro topo) Nova classe .cal-voltar-btn com min-height/width 44x88. Handler _calFechar unificado: 2 botoes + ESC + click no overlay.

2. Diferenciacao visual de dias pagos/cancelados/pendentes no calendario:
   - Pago integral: azul escuro (#3b82f6) + ✓ no canto
   - Pago manha/tarde: azul claro (#60a5fa) + ✓ no canto
   - Cancelado: cinza com line-through
   - Pendente: mantem verde/amarelo atual

   Backend: listarDiasFuncionario ganha LEFT JOIN com folha_fechamento_itens
   e retorna fechamento_id + status_fechamento + data_pagamento em cada dia.
   Frontend: desenharCalendario constroi statusPorData (rank paga > cancelada
   > aberta) e aplica classe por estado.

NAO precisou criar coluna `pago` em romatec_obra_funcionario_dias como o brief sugeria. Modelo atual via folha_fechamento_itens.status_pagamento e' superior — pagamento e' por ITEM de fechamento (quinzena inteira do funcionario), nao dia-a-dia. Bate com a regra de negocio real.

Legenda atualizada com 4 estados:
🟢 Integral pendente · 🟡 Meia (manhã) · 🟡 Meia (tarde) · 🔵 Pago · ⚫ Cancelado

12 smoke tests novos em src/test/quinzena-ux-pago-status.test.ts garantem que X foi removido, Voltar tem tap target 44x44, handler ESC/overlay, backend faz o JOIN, payload tem os 3 campos novos, CSS dos 4 estados, checkmark via ::after e legenda atualizada.

Total: 499 passing / 1 skipped / 0 failures (era 487 -> +12).