### PR TITLE
chore(v3.24.0): bump package.json (esquecido na PR #83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.23.11",
+  "version": "3.24.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {


### PR DESCRIPTION
PR #83 mergeou todo o codigo da v3.24.0 mas o bump do package.json ficou de fora. Sintomas em prod:
- /api/version retorna {"version":"3.23.11"} mesmo com auth-migrations rodando (que so existem em v3.24.0)
- startup log: "ZAYRA v3.23.11 rodando" mesmo com /login route ativa

Causa: npm install de bcrypt/jsonwebtoken/cookie-parser/rate-limit rodou entre o Edit pra 3.24.0 e o git commit, e o package.json foi reescrito perdendo o bump (mas mantendo as deps novas).

Fix trivial: bump explicito 3.23.11 -> 3.24.0.