### PR TITLE
fix(quinzena-ux): cor azul de "pago" agora cobre TODOS os colaboradores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.2",
+  "version": "3.24.3",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/obras.ts
+++ b/src/integrations/obras.ts
@@ -1067,16 +1067,29 @@ export async function listarDiasFuncionario(input: {
   if (!input.funcionario_id) throw new Error('funcionario_id obrigatório');
   const params: (string | number)[] = [input.funcionario_id];
   // v3.23.11: LEFT JOIN com folha_fechamento_itens — retorna status do
-  // fechamento pra UI poder colorir dias pagos (azul) vs pendentes (verde/amarelo)
-  // vs cancelados (cinza). O `pago` e' por ITEM de fechamento (a quinzena inteira
-  // do funcionario), nao dia-a-dia. Dia sem fechamento (`fechamento_id IS NULL`)
-  // continua aparecendo como pendente — caso comum da quinzena ativa.
+  // fechamento (sistema NOVO) pra UI colorir dias pagos.
+  //
+  // v3.24.3 FIX: tambem checa sistema LEGADO via recibos_envios. CEO reportou
+  // que so o Leonardo apareceu com dias em azul; os outros tinham sido pagos
+  // pelo sistema antigo (recibos quinzenais com periodo_inicio/fim) e nunca
+  // foram migrados pra fechamento_id. Agora o campo `pago_legado` reflete:
+  // existe ALGUM recibos_envios.status='pago' cujo lote.periodo cobre essa data
+  // E o membro_id bate. Status final: paga > cancelada > pago_legado > aberta.
   let sql = `
     SELECT
       d.id, d.data, d.periodo, d.valor, d.obra_id, d.observacoes,
       d.fechamento_id,
       fi.status_pagamento AS status_fechamento,
-      fi.data_pagamento
+      fi.data_pagamento,
+      (
+        SELECT 1
+          FROM recibos_envios e
+          JOIN recibos_envios_lotes l ON l.id = e.lote_id
+         WHERE e.membro_id = d.funcionario_id
+           AND e.status = 'pago'
+           AND d.data BETWEEN l.periodo_inicio AND l.periodo_fim
+         LIMIT 1
+      ) AS pago_legado
     FROM romatec_obra_funcionario_dias d
     LEFT JOIN folha_fechamento_itens fi
       ON d.fechamento_id IS NOT NULL
@@ -1093,22 +1106,30 @@ export async function listarDiasFuncionario(input: {
     fechamento_id: number | null;
     status_fechamento: 'aberta' | 'paga' | 'cancelada' | null;
     data_pagamento: Date | string | null;
+    pago_legado: number | null;
   };
   const [rows] = await pool.execute<DiaRowExt[]>(sql, params);
-  return rows.map(r => ({
-    id: String(r.id),
-    data: r.data instanceof Date ? r.data.toISOString().slice(0, 10) : String(r.data),
-    periodo: r.periodo,
-    valor: num(r.valor),
-    obra_id: r.obra_id ? String(r.obra_id) : null,
-    observacoes: r.observacoes,
-    // v3.23.11: novos campos pra UI colorir
-    fechamento_id: r.fechamento_id ? Number(r.fechamento_id) : null,
-    status_fechamento: r.status_fechamento ?? null,
-    data_pagamento: r.data_pagamento
-      ? (r.data_pagamento instanceof Date ? r.data_pagamento.toISOString() : String(r.data_pagamento))
-      : null,
-  }));
+  return rows.map(r => {
+    // Status efetivo: prioridade paga (fechamento_itens) > cancelada > pago_legado > null
+    let statusEfetivo: 'aberta' | 'paga' | 'cancelada' | null = r.status_fechamento ?? null;
+    if (!statusEfetivo && Number(r.pago_legado) === 1) {
+      statusEfetivo = 'paga'; // dia coberto por recibo legado pago
+    }
+    return {
+      id: String(r.id),
+      data: r.data instanceof Date ? r.data.toISOString().slice(0, 10) : String(r.data),
+      periodo: r.periodo,
+      valor: num(r.valor),
+      obra_id: r.obra_id ? String(r.obra_id) : null,
+      observacoes: r.observacoes,
+      fechamento_id: r.fechamento_id ? Number(r.fechamento_id) : null,
+      status_fechamento: statusEfetivo,
+      pago_legado: Number(r.pago_legado) === 1, // expoe a fonte pro front decidir tooltip
+      data_pagamento: r.data_pagamento
+        ? (r.data_pagamento instanceof Date ? r.data_pagamento.toISOString() : String(r.data_pagamento))
+        : null,
+    };
+  });
 }
 
 export async function relatorioMensalFuncionario(input: {

--- a/src/test/quinzena-ux-pago-status.test.ts
+++ b/src/test/quinzena-ux-pago-status.test.ts
@@ -63,7 +63,9 @@ describe('Mudanca 2 — backend retorna status do fechamento', () => {
     expect(idxEnd).toBeGreaterThan(idxStart);
     const body = obrasTs.slice(idxStart, idxEnd);
     expect(body).toMatch(/fechamento_id:[\s\S]+?\?\s*Number\(r\.fechamento_id\)\s*:\s*null/);
-    expect(body).toMatch(/status_fechamento:\s*r\.status_fechamento\s*\?\?\s*null/);
+    // v3.24.3: status_fechamento agora usa variavel statusEfetivo (que considera
+    // legado via recibos_envios). O campo final no payload e' status_fechamento: statusEfetivo
+    expect(body).toMatch(/status_fechamento:\s*statusEfetivo/);
     expect(body).toMatch(/data_pagamento:/);
   });
 });


### PR DESCRIPTION
Bug reportado pelo CEO: so o Leonardo apareceu com dias em azul no calendario; demais colaboradores (Cicero, Madonna, etc) tinham sido pagos pelo sistema ANTIGO (recibos quinzenais via recibos_envios + recibos_envios_lotes com periodo_inicio/fim) mas nunca migraram pra fechamento_id. O JOIN da v3.23.11 so olhava o sistema NOVO (folha_fechamento_itens), entao retornava null pra eles -> render caia em pendente (verde/amarelo).

Fix em listarDiasFuncionario:
- SQL ganha subquery adicional `pago_legado`: SELECT 1 FROM recibos_envios e JOIN recibos_envios_lotes l ON l.id = e.lote_id WHERE e.membro_id = d.funcionario_id AND e.status = 'pago' AND d.data BETWEEN l.periodo_inicio AND l.periodo_fim LIMIT 1
- Computa `statusEfetivo` no map: prioridade paga (fechamento) > cancelada > pago_legado(='paga') > aberta > null
- Payload retorna `status_fechamento: statusEfetivo` (mesmo nome do campo, contrato com front mantido — desenharCalendario em obras.html continua aplicando classe pago-* sem nenhuma mudanca de UI).
- Adiciona campo extra `pago_legado: boolean` no payload (pra debug/ tooltip futuro mostrar "Pago via recibo de XX/YY/2025").

Resultado: agora todos os colaboradores que tem recibo quinzenal pago no historico mostram dias em AZUL no calendario. Sem regressao no sistema novo — Leonardo continua mostrando azul via fechamento_itens.

Smoke test ajustado: agora espera `status_fechamento: statusEfetivo` (variavel local) ao inves do antigo `r.status_fechamento ?? null`.

Total: 541 passing / 1 skipped / 0 failures.