### PR TITLE
feat(colaborador-avatar): img + fallback iniciais nos cards de Equipe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.3",
+  "version": "3.24.4",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -2008,7 +2008,8 @@ function renderDashboard() {
   let cardEquipe = '';
   if (obra && state.equipe && state.equipe.length > 0) {
     const linhas = state.equipe.map(p => `
-      <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; padding:8px 10px; border-bottom:1px solid var(--border); flex-wrap:wrap;">
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:10px; padding:8px 10px; border-bottom:1px solid var(--border); flex-wrap:wrap;">
+        ${avatarHtml(p, 40)}
         <div style="flex:1; min-width:160px;">
           <p style="margin:0; font-weight:500; font-size:13px;">${escape(p.nome)}</p>
           <p style="margin:2px 0 0; font-size:11px; color:var(--text-muted);">${escape(p.funcao||'sem função')} · ${escape(p.tipo_contrato||'')} · <span style="color:var(--gold);">${fmt(p.valor_dia)}/dia</span></p>
@@ -3842,6 +3843,49 @@ function statusTag(status) {
   const s = STATUS_COLAB[status] || STATUS_COLAB.ativo;
   return `<span class="status-tag" data-status="${status||'ativo'}" style="display:inline-block; padding:2px 8px; border-radius:3px; font-size:10px; font-weight:700; letter-spacing:0.5px; background:${s.bg}; color:${s.fg}; border:1px solid ${s.fg}33;">${s.label}</span>`;
 }
+
+// v3.24.4: avatar do colaborador. Espelho da logica em
+// src/services/colaborador-avatar-helpers.ts (server-side pra PDFs).
+function gerarIniciais(nome) {
+  if (!nome || typeof nome !== 'string') return '?';
+  const limpo = nome.trim().replace(/\s+/g, ' ');
+  if (!limpo) return '?';
+  const partes = limpo.split(' ').filter(Boolean);
+  if (partes.length === 1) return partes[0].slice(0, 2).toUpperCase();
+  return ((partes[0][0] || '') + (partes[partes.length - 1][0] || '')).toUpperCase();
+}
+function corDeFundoPorNome(nome) {
+  if (!nome) return 'hsl(0,0%,30%)';
+  let hash = 0;
+  for (let i = 0; i < nome.length; i++) {
+    hash = ((hash << 5) - hash) + nome.charCodeAt(i);
+    hash |= 0;
+  }
+  return `hsl(${Math.abs(hash) % 360}, 60%, 35%)`;
+}
+// Avatar 56px com fallback de iniciais. onError no <img> esconde a img e
+// mostra o div de iniciais que ja esta no DOM (display none por padrao).
+function avatarHtml(membro, size) {
+  const s = size || 56;
+  const half = Math.floor(s / 2);
+  const fontSize = Math.floor(s * 0.4);
+  const id = membro.id;
+  const nome = membro.nome || '';
+  const tem = !!membro.tem_foto;
+  const cacheBuster = membro.foto_uploaded_em
+    ? new Date(membro.foto_uploaded_em).getTime()
+    : (tem ? Date.now() : 0);
+  const url = tem ? `/api/equipe/${id}/foto?_=${cacheBuster}` : '';
+  const iniciais = gerarIniciais(nome);
+  const bg = corDeFundoPorNome(nome);
+  // Container relativo; img absoluta sobre div de fallback. Se img carregar,
+  // cobre o fallback. Se onerror, esconde a img (fallback aparece).
+  return `
+    <div style="position:relative; width:${s}px; height:${s}px; flex-shrink:0;">
+      <div style="width:${s}px;height:${s}px;border-radius:${half}px;background:${bg};color:#fff;font-weight:700;font-size:${fontSize}px;text-align:center;line-height:${s}px;border:2px solid var(--border, #333);font-family:inherit;">${iniciais}</div>
+      ${tem ? `<img src="${url}" alt="${escape(nome)}" style="position:absolute;top:0;left:0;width:${s}px;height:${s}px;border-radius:${half}px;object-fit:cover;border:2px solid var(--border, #333);background:#000;" onerror="this.style.display='none';">` : ''}
+    </div>`;
+}
 function statusSelectOpts(current) {
   return Object.entries(STATUS_COLAB).map(([k, v]) =>
     `<option value="${k}" ${k===(current||'ativo')?'selected':''}>${v.label}</option>`
@@ -3859,6 +3903,7 @@ function renderEquipe() {
     const tag = statusTag(p.status);
     return `<div class="card">
       <div style="display:flex; justify-content:space-between; gap:8px; align-items:flex-start;">
+        ${avatarHtml(p, 56)}
         <div style="flex:1; min-width:0;">
           <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-bottom:2px;">
             <p style="margin:0; font-weight:500; font-size:15px;">${escape(p.nome)}</p>

--- a/src/services/colaborador-avatar-helpers.ts
+++ b/src/services/colaborador-avatar-helpers.ts
@@ -1,0 +1,72 @@
+// v3.24.4: helpers puros pra fallback de avatar de colaborador.
+//
+// Usados em 2 lugares:
+// 1. Frontend (obras.html) — inline via funcoes JS espelhadas no <script>
+// 2. Backend (folhaFechamentoPdf, reciboPdf) — gera blocos HTML pra <img>+initials
+//
+// Funcoes 100% puras (sem DB, sem HTTP, sem deps). Mesma logica em ambos os
+// lados garante consistencia visual entre UI e PDFs.
+
+/**
+ * Extrai ate 2 iniciais maiusculas do nome completo.
+ * "Cicero da Silva Oliveira" -> "CO" (primeiro + ultimo)
+ * "Madonna" -> "MA" (primeiras 2 letras)
+ * "Ana Maria" -> "AM"
+ */
+export function gerarIniciais(nome: string): string {
+  if (!nome || typeof nome !== 'string') return '?';
+  const limpo = nome.trim().replace(/\s+/g, ' ');
+  if (!limpo) return '?';
+  const partes = limpo.split(' ').filter(Boolean);
+  if (partes.length === 1) {
+    return partes[0].slice(0, 2).toUpperCase();
+  }
+  const primeira = partes[0][0] || '';
+  const ultima = partes[partes.length - 1][0] || '';
+  return (primeira + ultima).toUpperCase();
+}
+
+/**
+ * Gera cor HSL deterministica baseada no nome — mesmo nome sempre da mesma
+ * cor. Hue distribuido em 360°. Saturation 60%, Lightness 35% pra contraste
+ * com texto branco (#fff).
+ */
+export function corDeFundoPorNome(nome: string): string {
+  if (!nome) return 'hsl(0, 0%, 30%)';
+  let hash = 0;
+  for (let i = 0; i < nome.length; i++) {
+    hash = ((hash << 5) - hash) + nome.charCodeAt(i);
+    hash |= 0; // 32-bit int
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 60%, 35%)`;
+}
+
+/**
+ * Monta bloco HTML do avatar — usado nos PDFs. Frontend tem versao espelhada
+ * inline em obras.html.
+ *
+ * Se fotoBase64 fornecido (data URL), renderiza <img>. Senao, div circular
+ * com iniciais sobre cor de fundo deterministica.
+ */
+export function montarBlocoAvatarHtml(input: {
+  nome: string;
+  fotoBase64?: string | null;
+  size?: number; // px, default 64
+}): string {
+  const size = input.size ?? 64;
+  const half = Math.floor(size / 2);
+  const fontSize = Math.floor(size * 0.4);
+  if (input.fotoBase64) {
+    return `<img src="${input.fotoBase64}" alt="${escapeHtmlMin(input.nome)}" style="width:${size}px;height:${size}px;border-radius:${half}px;object-fit:cover;border:2px solid #333;display:inline-block;vertical-align:middle;" />`;
+  }
+  const iniciais = gerarIniciais(input.nome);
+  const bg = corDeFundoPorNome(input.nome);
+  return `<div style="width:${size}px;height:${size}px;border-radius:${half}px;background:${bg};color:#fff;font-weight:700;font-size:${fontSize}px;text-align:center;line-height:${size}px;display:inline-block;vertical-align:middle;border:2px solid #333;font-family:Arial,sans-serif;">${iniciais}</div>`;
+}
+
+function escapeHtmlMin(s: string): string {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] || c,
+  );
+}

--- a/src/services/folhaFechamentoPdf.ts
+++ b/src/services/folhaFechamentoPdf.ts
@@ -367,12 +367,15 @@ export async function gerarPdfFechamento(fechamentoId: number): Promise<Buffer> 
 
     // Faixa verde do header
     doc.save().rect(blocoX, blocoY, blocoW, 22).fillColor(COR.verdeEsc).fill().restore();
-    // v3.16.0: foto do colaborador embed (circular, 40x40) a esquerda do nome se tiver
+    // v3.16.0: foto do colaborador embed (circular, 32x32) a esquerda do nome.
+    // v3.24.4: fallback de iniciais quando NAO tem foto — circulo colorido
+    // (cor deterministica do nome) com letras brancas. Antes pulava direto pro
+    // texto. Agora todo colaborador tem identidade visual no PDF.
+    const cxF = blocoX + 28, cyF = blocoY + 11, rF = 16;
+    const nomeOffsetX = 56;
     const temFoto = !!eq?.foto_b64;
-    const nomeOffsetX = temFoto ? 56 : 8;
     if (temFoto && eq?.foto_b64) {
       try {
-        const cxF = blocoX + 28, cyF = blocoY + 11, rF = 16;
         doc.save();
         doc.circle(cxF, cyF, rF).clip();
         doc.image(eq.foto_b64, cxF - rF, cyF - rF, { fit: [rF * 2, rF * 2] });
@@ -382,6 +385,18 @@ export async function gerarPdfFechamento(fechamentoId: number): Promise<Buffer> 
       } catch (err) {
         console.warn('[folhaFechamentoPdf] embed foto falhou:', (err as Error).message);
       }
+    } else {
+      // Fallback iniciais — usa helpers de src/services/colaborador-avatar-helpers
+      const { gerarIniciais, corDeFundoPorNome } = require('./colaborador-avatar-helpers');
+      const iniciais = gerarIniciais(it.funcionario_nome);
+      const bg = corDeFundoPorNome(it.funcionario_nome);
+      doc.save();
+      doc.circle(cxF, cyF, rF).fillAndStroke(bg, '#fff');
+      doc.restore();
+      doc.save()
+         .font('Helvetica-Bold').fontSize(11).fillColor('#fff')
+         .text(iniciais, cxF - rF, cyF - 6, { width: rF * 2, align: 'center', lineBreak: false });
+      doc.restore();
     }
     doc.font('Helvetica-Bold').fontSize(11).fillColor('#fff')
        .text(it.funcionario_nome, blocoX + nomeOffsetX, blocoY + 6, { width: blocoW - 100 - nomeOffsetX, lineBreak: false });

--- a/src/services/reciboPdf.ts
+++ b/src/services/reciboPdf.ts
@@ -260,22 +260,39 @@ export async function gerarPdfRecibo(
 
   // ── Bloco PAGADOR ───────────────────────────────────────────────────
   // v3.16.0: se tem foto do colaborador (recibo de funcionario), desenha
-  // thumbnail 60x60 a direita do bloco PAGADOR. Padding garante que texto
-  // do PAGADOR nao colide com a foto.
-  const pagadorWidth = fotoColaborador ? 440 : 515;
-  if (fotoColaborador) {
-    try {
+  // thumbnail 60x60 a direita do bloco PAGADOR.
+  // v3.24.4: SE recibo de funcionario MAS sem foto, desenha fallback iniciais
+  // (circulo colorido). Recibos NAO de funcionario continuam sem avatar.
+  // ehReciboColaborador detecta isso via destinatario_nome + tipo='funcionario'
+  const ehReciboColaborador = recibo.tipo === 'funcionario' && !!recibo.destinatario_nome;
+  const desenharAvatar = !!fotoColaborador || ehReciboColaborador;
+  const pagadorWidth = desenharAvatar ? 440 : 515;
+  if (desenharAvatar) {
+    const cx = 510, cyImg = cy + 4, raio = 28;
+    if (fotoColaborador) {
+      try {
+        doc.save();
+        doc.circle(cx, cyImg + raio, raio).clip();
+        doc.image(fotoColaborador, cx - raio, cyImg, { fit: [raio * 2, raio * 2] });
+        doc.restore();
+        doc.save().strokeColor(corDourada).lineWidth(1.5)
+          .circle(cx, cyImg + raio, raio).stroke().restore();
+      } catch (err) {
+        console.warn('[reciboPdf] embed foto colaborador falhou:', (err as Error).message);
+      }
+    } else {
+      // Fallback iniciais
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { gerarIniciais, corDeFundoPorNome } = require('./colaborador-avatar-helpers');
+      const iniciais = gerarIniciais(recibo.destinatario_nome || '');
+      const bg = corDeFundoPorNome(recibo.destinatario_nome || '');
       doc.save();
-      // Mascara circular (clip)
-      const cx = 510, cyImg = cy + 4, raio = 28;
-      doc.circle(cx, cyImg + raio, raio).clip();
-      doc.image(fotoColaborador, cx - raio, cyImg, { fit: [raio * 2, raio * 2] });
+      doc.circle(cx, cyImg + raio, raio).fillAndStroke(bg, corDourada);
       doc.restore();
-      // Borda circular dourada
-      doc.save().strokeColor(corDourada).lineWidth(1.5)
-        .circle(cx, cyImg + raio, raio).stroke().restore();
-    } catch (err) {
-      console.warn('[reciboPdf] embed foto colaborador falhou:', (err as Error).message);
+      doc.save()
+         .font('Helvetica-Bold').fontSize(22).fillColor('#fff')
+         .text(iniciais, cx - raio, cyImg + raio - 12, { width: raio * 2, align: 'center', lineBreak: false });
+      doc.restore();
     }
   }
   doc.fontSize(9).fillColor(corDourada).font('Helvetica-Bold')

--- a/src/test/colaborador-avatar.test.ts
+++ b/src/test/colaborador-avatar.test.ts
@@ -1,0 +1,140 @@
+// v3.24.4: tests dos helpers de avatar (puros) + smoke da UI/PDFs.
+
+import { describe, it, expect } from 'vitest';
+import {
+  gerarIniciais, corDeFundoPorNome, montarBlocoAvatarHtml,
+} from '../services/colaborador-avatar-helpers';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('gerarIniciais', () => {
+  it('"Cicero da Silva Oliveira" -> "CO" (primeiro + ultimo)', () => {
+    expect(gerarIniciais('Cicero da Silva Oliveira')).toBe('CO');
+  });
+  it('"Madonna" -> "MA" (single nome — primeiras 2 letras)', () => {
+    expect(gerarIniciais('Madonna')).toBe('MA');
+  });
+  it('"Ana Maria" -> "AM"', () => {
+    expect(gerarIniciais('Ana Maria')).toBe('AM');
+  });
+  it('"Leonardo da Silva Oliveira" -> "LO"', () => {
+    expect(gerarIniciais('Leonardo da Silva Oliveira')).toBe('LO');
+  });
+  it('handle string vazia / null / undefined', () => {
+    expect(gerarIniciais('')).toBe('?');
+    expect(gerarIniciais(null as unknown as string)).toBe('?');
+    expect(gerarIniciais(undefined as unknown as string)).toBe('?');
+  });
+  it('trim de espaços', () => {
+    expect(gerarIniciais('  Joao  Silva  ')).toBe('JS');
+  });
+  it('sempre uppercase', () => {
+    expect(gerarIniciais('joao silva')).toBe('JS');
+    expect(gerarIniciais('joao SILVA')).toBe('JS');
+  });
+});
+
+describe('corDeFundoPorNome (determinismo)', () => {
+  it('mesmo nome → mesma cor (10 vezes)', () => {
+    const cores = new Set<string>();
+    for (let i = 0; i < 10; i++) cores.add(corDeFundoPorNome('Leonardo da Silva'));
+    expect(cores.size).toBe(1);
+  });
+  it('nomes diferentes geram cores diferentes', () => {
+    const c1 = corDeFundoPorNome('Leonardo');
+    const c2 = corDeFundoPorNome('Cicero');
+    expect(c1).not.toBe(c2);
+  });
+  it('formato HSL valido', () => {
+    expect(corDeFundoPorNome('Ana')).toMatch(/^hsl\(\d+,\s*\d+%,\s*\d+%\)$/);
+  });
+  it('hue dentro de 0-359', () => {
+    for (const nome of ['Leo', 'Ana', 'Cicero', 'Madonna', 'Maria do Carmo']) {
+      const m = corDeFundoPorNome(nome).match(/hsl\((\d+),/);
+      const hue = Number(m![1]);
+      expect(hue).toBeGreaterThanOrEqual(0);
+      expect(hue).toBeLessThan(360);
+    }
+  });
+});
+
+describe('montarBlocoAvatarHtml', () => {
+  it('com fotoBase64 renderiza <img>', () => {
+    const h = montarBlocoAvatarHtml({
+      nome: 'Leonardo',
+      fotoBase64: 'data:image/webp;base64,XXXX',
+    });
+    expect(h).toContain('<img');
+    expect(h).toContain('data:image/webp;base64,XXXX');
+    expect(h).toContain('border-radius:32px'); // default size=64, half=32
+  });
+  it('sem fotoBase64 renderiza div com iniciais + cor', () => {
+    const h = montarBlocoAvatarHtml({ nome: 'Cicero da Silva Oliveira' });
+    expect(h).not.toContain('<img');
+    expect(h).toContain('>CO<');
+    expect(h).toMatch(/background:hsl\(\d+/);
+  });
+  it('size custom propaga pras dimensoes', () => {
+    const h = montarBlocoAvatarHtml({ nome: 'X', size: 80 });
+    expect(h).toContain('width:80px');
+    expect(h).toContain('height:80px');
+  });
+  it('escapa caracteres especiais no alt', () => {
+    const h = montarBlocoAvatarHtml({
+      nome: '<script>x</script>',
+      fotoBase64: 'data:image/webp;base64,XXX',
+    });
+    expect(h).toContain('&lt;script&gt;');
+    expect(h).not.toContain('<script>x</script>');
+  });
+});
+
+describe('Smoke — UI obras.html avatar integrado', () => {
+  const REPO_ROOT = join(__dirname, '..', '..');
+  const obrasHtml = readFileSync(
+    join(REPO_ROOT, 'src', 'public', 'obras.html'), 'utf8',
+  );
+
+  it('funcao avatarHtml definida inline', () => {
+    expect(obrasHtml).toMatch(/function avatarHtml\(membro,\s*size\)/);
+  });
+  it('funcoes auxiliares gerarIniciais + corDeFundoPorNome inline', () => {
+    expect(obrasHtml).toMatch(/function gerarIniciais\(nome\)/);
+    expect(obrasHtml).toMatch(/function corDeFundoPorNome\(nome\)/);
+  });
+  it('card do home (resumo da obra) usa avatarHtml(p, 40)', () => {
+    // Linha 2010 area: state.equipe.map(p => ...). Confere que tem avatarHtml(p, 40)
+    expect(obrasHtml).toMatch(/state\.equipe\.map\(p =>[\s\S]+?avatarHtml\(p,\s*40\)/);
+  });
+  it('card de Equipe (renderEquipe) usa avatarHtml(p, 56)', () => {
+    expect(obrasHtml).toMatch(/renderEquipe[\s\S]+?avatarHtml\(p,\s*56\)/);
+  });
+  it('avatarHtml usa /api/equipe/${id}/foto', () => {
+    expect(obrasHtml).toMatch(/\/api\/equipe\/\$\{id\}\/foto\?_=\$\{cacheBuster\}/);
+  });
+  it('onerror esconde img pra mostrar fallback de iniciais', () => {
+    expect(obrasHtml).toMatch(/onerror="this\.style\.display='none'"/);
+  });
+});
+
+describe('Smoke — PDFs com fallback de iniciais', () => {
+  const REPO_ROOT = join(__dirname, '..', '..');
+  const folhaPdf = readFileSync(
+    join(REPO_ROOT, 'src', 'services', 'folhaFechamentoPdf.ts'), 'utf8',
+  );
+  const reciboPdf = readFileSync(
+    join(REPO_ROOT, 'src', 'services', 'reciboPdf.ts'), 'utf8',
+  );
+
+  it('folhaFechamentoPdf — fallback chama gerarIniciais + corDeFundoPorNome', () => {
+    // Aceita require dinamico ou import nomeado — projeto e' commonjs
+    expect(folhaPdf).toMatch(/colaborador-avatar-helpers/);
+    expect(folhaPdf).toMatch(/gerarIniciais/);
+    expect(folhaPdf).toMatch(/corDeFundoPorNome/);
+  });
+  it('reciboPdf — fallback iniciais em recibo de funcionario sem foto', () => {
+    expect(reciboPdf).toMatch(/colaborador-avatar-helpers/);
+    expect(reciboPdf).toMatch(/ehReciboColaborador/);
+    expect(reciboPdf).toMatch(/gerarIniciais/);
+  });
+});


### PR DESCRIPTION
… + PDFs

CEO pediu foto do colaborador visivel em todo lugar. Investigacao revelou que upload de foto JA EXISTIA (foto_b64 em romatec_obra_equipe, rotas /api/equipe/:id/foto, multer ja instalado, integrations em obras.ts:706+). Faltava so o RENDER nos cards da UI e o FALLBACK de iniciais nos PDFs quando colaborador nao tem foto.

src/services/colaborador-avatar-helpers.ts (NOVO) — helpers puros:
- gerarIniciais(nome): "Cicero da Silva Oliveira" -> "CO", "Madonna" -> "MA"
- corDeFundoPorNome(nome): HSL deterministico — mesmo nome sempre mesma cor
- montarBlocoAvatarHtml({nome, fotoBase64?, size?}): bloco HTML pronto pra injecao em templates externos (fallback ou img)

src/public/obras.html — JS espelhado inline + integracao:
- gerarIniciais / corDeFundoPorNome / avatarHtml definidos no <script> (mesma logica que o helper TS, garante consistencia visual UI <-> PDF)
- avatarHtml(membro, size) usa /api/equipe/${id}/foto?_=<cacheBuster> com onerror que esconde <img> e revela o div de iniciais que ja esta no DOM (mesmo container relativo) — sem flicker
- Card resumo da obra (state.equipe.map): avatar 40px adicionado a esquerda
- Card aba Equipe (renderEquipe): avatar 56px adicionado a esquerda do nome

src/services/folhaFechamentoPdf.ts — antes pulava avatar quando sem foto. Agora desenha circulo HSL com iniciais brancas (ate 2 letras). Posicao, tamanho e borda iguais ao caso com foto — visualmente uniforme.

src/services/reciboPdf.ts — mesma logica, mas so pra recibos de funcionario (tipo='funcionario' && destinatario_nome). Recibos de cliente/parcela/despesa continuam sem avatar (faz sentido).

src/test/colaborador-avatar.test.ts — 23 tests:
- gerarIniciais (7): cenarios reais (Cicero/Madonna/Ana Maria/Leonardo)
  + edge cases (vazio, null, trim, case)
- corDeFundoPorNome (4): determinismo 10x, cores diferentes pra nomes diferentes, formato HSL valido, hue 0-359
- montarBlocoAvatarHtml (4): img quando fotoBase64, div+iniciais sem, size custom, escape de caracteres especiais
- Smoke UI obras.html (6): avatarHtml definido, helpers inline, cards usam avatarHtml com size correto, URL da foto, onerror fallback
- Smoke PDFs (2): folhaFechamentoPdf + reciboPdf importam helpers e usam gerarIniciais no fallback

NAO instalei `sharp` (que o brief sugeria pra resize/thumb). Razao: dep nativa que pode quebrar build Railway, e a foto raw (foto_b64) ja vem do upload do usuario — basta limitar tamanho no front-end (ja tem max 5MB em obras.ts:702). Se ficar pesado nos PDFs, otimizo depois com lib pure-JS.

NAO criei `colaboradorFotoService.ts` standalone como o brief sugeria — lógica ja esta em obras.ts:706+ e funciona ha varias releases. Reescrever seria duplicacao sem ganho.

Total: 564 passing / 1 skipped / 0 failures (era 541 -> +23).