### PR TITLE
feat(proposta-projeto-executivo): novo subtipo de consultoria — arqui…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.4",
+  "version": "3.24.5",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -148,6 +148,12 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
       subtipo,
       dados: input.dados_imovel as unknown as InputAvaliacaoPTAM,
     });
+  } else if (subtipo === 'projeto_executivo') {
+    // v3.24.5: Projeto Executivo ativo (arquitetonico + complementares)
+    const m = await import('../services/pricing/projetoExecutivo');
+    resultado = await m.calcularProjetoExecutivo(
+      input.dados_imovel as unknown as Parameters<typeof m.calcularProjetoExecutivo>[0],
+    );
   } else {
     throw new Error(`Subtipo ${subtipo} desconhecido.`);
   }
@@ -385,6 +391,22 @@ export async function previewCustoConsultoria(input: {
       fontes: resultado.fontes,
     };
   }
+  // v3.24.5: Projeto Executivo
+  if (subtipo === 'projeto_executivo') {
+    const m = await import('../services/pricing/projetoExecutivo');
+    const resultado = await m.calcularProjetoExecutivo(
+      dados_imovel as unknown as Parameters<typeof m.calcularProjetoExecutivo>[0],
+    );
+    return {
+      ok: true as const,
+      subtipo,
+      valor_total: resultado.custos.secao_5_total,
+      custos: resultado.custos,
+      fontes: resultado.fontes,
+      // Extra (so projeto_executivo): expone area/m2/ART-TRT/totais
+      projeto_executivo: resultado.projeto_executivo,
+    };
+  }
   throw new Error(`Subtipo ${subtipo} desconhecido.`);
 }
 
@@ -473,6 +495,257 @@ const SUBTIPO_LABEL: Record<string, string> = {
 //   - 7. AVISOS E CONDICOES TECNICAS
 // O caller continua com Data/Validade, Responsavel Tecnico, Signature, QR, Footer.
 // v3.23.7: exportada pra ser testavel diretamente via smoke test (pdf-parse).
+// v3.24.5: helper de render do corpo da Proposta de Projeto Executivo.
+// Layout: Identificacao da Obra + Objeto + Etapa Preliminar (box taxa R$750)
+// + Projetos a Entregar (listagem) + Orcamento (tabela com SUBTOTAL/Desconto/
+// VALOR TOTAL) + Condicoes + Documentos do Cliente + Avisos (CNO, ART/TRT).
+export function renderProjetoExecutivoBody(
+  doc: PDFKit.PDFDocument,
+  p: Awaited<ReturnType<typeof buscarPropostaConsultoria>>,
+  dadosImovel: Record<string, unknown>,
+  custos: CustosCalculados,
+  corHex: string,
+): void {
+  const COL_X_INI = 48;
+  const COL_X_FIM = 547;
+  const COL_W = COL_X_FIM - COL_X_INI;
+
+  const COR_DOURADO_BG = '#fef3c7';
+  const COR_DOURADO_BORDA = '#d97706';
+  const COR_CREME_BG = '#fef9c3';
+  const COR_CREME_BORDA = '#ca8a04';
+  const COR_VERDE_BG = '#dcfce7';
+  const COR_VERDE_BORDA = '#16a34a';
+
+  const di = dadosImovel as Record<string, unknown>;
+  const enderecoObra = (di.endereco_obra as string) || (di.endereco as string) || '—';
+  const cidadeObra = (di.cidade_obra as string) || 'Acailandia';
+  const ufObra = (di.uf_obra as string) || 'MA';
+  const tipoEdif = ((di.tipo_edificacao as string) || 'residencial').toUpperCase();
+  const area = Number(di.area_construir) || 0;
+  const valorM2 = Number(di.valor_m2) || 25;
+  const taxaEsboco = Number(di.taxa_esboco) || 750;
+  const projetosLista = Array.isArray(di.projetos_selecionados)
+    ? (di.projetos_selecionados as Array<{ codigo: string; nome: string; selecionado: boolean; detalhamento_entrega: string }>).filter(x => x.selecionado)
+    : [];
+
+  // ── 1. OBJETO ─────────────────────────────────────────────────────────
+  doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold')
+     .text('1. Objeto', COL_X_INI, doc.y, { width: COL_W });
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+  doc.fontSize(10).fillColor('#222').font('Helvetica')
+     .text(
+       `A presente proposta tem por objeto a prestacao de servicos tecnicos especializados para a CONFECCAO DOS PROJETOS EXECUTIVOS DE ARQUITETURA E COMPLEMENTARES da edificacao abaixo identificada, com area total de ${area.toFixed(2)} m², a serem desenvolvidos em conformidade com as Normas Brasileiras (ABNT), legislacao municipal de ${cidadeObra}/${ufObra} e Codigo de Obras vigente, sob responsabilidade tecnica do profissional habilitado.`,
+       COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
+     );
+  doc.moveDown(0.6);
+
+  // ── 2. IMOVEL ─────────────────────────────────────────────────────────
+  doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('2. Imovel / Obra');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+  doc.fontSize(10).fillColor('#222').font('Helvetica');
+  doc.text(`Endereco: ${enderecoObra}`, COL_X_INI, doc.y, { width: COL_W, continued: false });
+  doc.text(`Cidade/UF: ${cidadeObra}/${ufObra}`, COL_X_INI, doc.y, { width: COL_W });
+  doc.text(`Tipo de edificacao: ${tipoEdif}`, COL_X_INI, doc.y, { width: COL_W });
+  doc.text(`Area a construir: ${area.toFixed(2)} m²`, COL_X_INI, doc.y, { width: COL_W });
+  doc.moveDown(0.6);
+
+  // ── 3. ETAPA PRELIMINAR (box amarelo da TAXA DE R$ 750) ───────────────
+  if (doc.y > 600) doc.addPage();
+  const textoTaxa =
+    `ETAPA PRELIMINAR — HORA TECNICA DE ANTEPROJETO E CROQUI\n\n` +
+    `Valor: R$ ${taxaEsboco.toFixed(2).replace('.', ',')} (informativo, NAO incluido no VALOR TOTAL)\n\n` +
+    `A etapa preliminar consiste no desenvolvimento do ESBOCO ARQUITETONICO (anteprojeto) e do CROQUI DE ESTUDO, atividade tecnica que precede e fundamenta toda a documentacao executiva subsequente. Compreende:\n\n` +
+    `  a) Analise tecnica do terreno e levantamento das condicionantes legais (Plano Diretor, Lei de Uso e Ocupacao do Solo, recuos obrigatorios, taxa de ocupacao e coeficiente de aproveitamento);\n` +
+    `  b) Reunioes de briefing com o CONTRATANTE para captacao do programa de necessidades e setorizacao funcional dos ambientes;\n` +
+    `  c) Elaboracao do partido arquitetonico e estudos volumetricos preliminares;\n` +
+    `  d) Confeccao do CROQUI ARQUITETONICO em planta baixa, com layout, areas aproximadas e implantacao no lote, observando insolacao e ventilacao;\n` +
+    `  e) Apresentacao e ajustes do anteprojeto ate a aprovacao do CONTRATANTE para deflagrar a fase executiva.\n\n` +
+    `CONDICAO ESPECIAL DE COBRANCA\n` +
+    `► Caso o CONTRATANTE, apos a entrega e aprovacao do esboco, PROSSIGA com a contratacao integral dos projetos executivos descritos nesta proposta, o valor de R$ ${taxaEsboco.toFixed(2).replace('.', ',')} NAO SERA COBRADO, sendo absorvido pelo valor global do contrato.\n` +
+    `► Caso o CONTRATANTE OPTE POR NAO PROSSEGUIR com a fase executiva apos a entrega do anteprojeto, fica acordado o pagamento da Hora Tecnica de R$ ${taxaEsboco.toFixed(2).replace('.', ',')}, que remunera exclusivamente o tempo tecnico empregado na elaboracao do croqui e estudos preliminares.\n\n` +
+    `Este valor NAO esta incluido no VALOR TOTAL desta proposta (Secao 5), sendo mencionado apenas para clareza contratual.`;
+  const boxY = doc.y;
+  const boxH = doc.heightOfString(textoTaxa, { width: COL_W - 24 }) + 20;
+  doc.rect(COL_X_INI, boxY, COL_W, boxH).fillAndStroke(COR_DOURADO_BG, COR_DOURADO_BORDA);
+  doc.fontSize(9).fillColor('#713f12').font('Helvetica')
+     .text(textoTaxa, COL_X_INI + 12, boxY + 10, { width: COL_W - 24, align: 'justify' });
+  doc.y = boxY + boxH + 8;
+  doc.x = COL_X_INI;
+
+  // ── 4. PROJETOS A ENTREGAR ────────────────────────────────────────────
+  if (doc.y > 600) doc.addPage();
+  doc.x = COL_X_INI;
+  doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold')
+     .text('4. Projetos a Entregar', COL_X_INI, doc.y, { width: COL_W });
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+  projetosLista.forEach((proj, idx) => {
+    doc.x = COL_X_INI;
+    if (doc.y > 720) doc.addPage();
+    doc.fontSize(10).fillColor('#111').font('Helvetica-Bold')
+       .text(`4.${idx + 1} ${proj.nome}`, COL_X_INI, doc.y, { width: COL_W });
+    doc.fontSize(9).fillColor('#444').font('Helvetica')
+       .text(`Conteudo da prancha: ${proj.detalhamento_entrega}`, COL_X_INI + 8, doc.y, {
+         width: COL_W - 16, align: 'justify',
+       });
+    doc.moveDown(0.3);
+  });
+  doc.moveDown(0.4);
+
+  // ── 5. ORCAMENTO (tabela) ─────────────────────────────────────────────
+  if (doc.y > 600) doc.addPage();
+  doc.x = COL_X_INI;
+  doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('5. Orcamento');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+
+  const allItens: Array<{ desc: string; valor: number; tipo: 'honorario' | 'taxa' | 'total' | 'subtotal' | 'desconto' }> = [];
+  custos.secao_3_honorarios.forEach(h => allItens.push({ desc: h.descricao, valor: h.valor, tipo: 'honorario' }));
+  custos.secao_2_taxas.forEach(t => allItens.push({ desc: t.descricao, valor: t.valor, tipo: 'taxa' }));
+  const subtotal = allItens.reduce((s, x) => s + x.valor, 0);
+  const desconto = (custos as unknown as { desconto?: number }).desconto ?? 0;
+
+  // Headers
+  const colDesc = COL_X_INI + 8;
+  const colValor = COL_X_FIM - 90;
+  doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold');
+  const headerY = doc.y;
+  doc.text('Descricao', colDesc, headerY, { width: colValor - colDesc - 8 });
+  doc.text('Valor', colValor, headerY, { width: 80, align: 'right' });
+  doc.moveDown(0.5);
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ddd').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+
+  allItens.forEach((it) => {
+    const y0 = doc.y;
+    doc.font('Helvetica').fontSize(9.5).fillColor('#222')
+       .text(it.desc, colDesc, y0, { width: colValor - colDesc - 8 });
+    doc.font('Helvetica-Bold').fillColor(corHex)
+       .text(formatBRL(it.valor), colValor, y0, { width: 80, align: 'right' });
+    doc.moveDown(0.15);
+  });
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#888').lineWidth(0.6).stroke();
+  doc.moveDown(0.2);
+
+  // SUBTOTAL
+  const subY = doc.y;
+  doc.fontSize(10).fillColor('#111').font('Helvetica-Bold')
+     .text('SUBTOTAL', colDesc, subY, { width: colValor - colDesc - 8 });
+  doc.fillColor('#111').text(formatBRL(subtotal), colValor, subY, { width: 80, align: 'right' });
+  doc.moveDown(0.2);
+
+  if (desconto > 0) {
+    const dY = doc.y;
+    doc.fontSize(9.5).fillColor('#444').font('Helvetica')
+       .text('Desconto', colDesc, dY, { width: colValor - colDesc - 8 });
+    doc.text('- ' + formatBRL(desconto), colValor, dY, { width: 80, align: 'right' });
+    doc.moveDown(0.2);
+  }
+
+  // VALOR TOTAL (box verde)
+  const totalBoxY = doc.y + 4;
+  const totalBoxH = 26;
+  doc.rect(COL_X_INI, totalBoxY, COL_W, totalBoxH).fillAndStroke(COR_VERDE_BG, COR_VERDE_BORDA);
+  doc.fontSize(11).fillColor('#14532d').font('Helvetica-Bold')
+     .text('VALOR TOTAL', colDesc, totalBoxY + 8, { width: colValor - colDesc - 8 });
+  doc.text(formatBRL(custos.secao_5_total), colValor, totalBoxY + 8, { width: 80, align: 'right' });
+  doc.y = totalBoxY + totalBoxH + 6;
+
+  doc.fontSize(8.5).fillColor('#666').font('Helvetica-Oblique')
+     .text(
+       `* A Hora Tecnica de Anteprojeto (R$ ${taxaEsboco.toFixed(2).replace('.', ',')}) descrita na Secao 3 NAO esta incluida neste total e somente sera cobrada na hipotese descrita naquela secao.`,
+       COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
+     );
+  doc.moveDown(0.6);
+
+  // ── 6. CONDICOES DE PAGAMENTO ─────────────────────────────────────────
+  if (custos.condicoes_pagamento && custos.condicoes_pagamento.length > 0) {
+    if (doc.y > 660) doc.addPage();
+    doc.x = COL_X_INI;
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('6. Condicoes de Pagamento');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.3);
+    custos.condicoes_pagamento.forEach((cp) => {
+      const y0 = doc.y;
+      doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+         .text(cp.rotulo, COL_X_INI + 8, y0, { width: COL_W - 100 });
+      doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+         .text(formatBRL(cp.valor), COL_X_FIM - 90, y0, { width: 80, align: 'right' });
+      if (cp.descricao) {
+        doc.fontSize(8.5).fillColor('#666').font('Helvetica')
+           .text(cp.descricao, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+      }
+      doc.font('Helvetica').fillColor('#111');
+      doc.moveDown(0.2);
+    });
+    doc.moveDown(0.4);
+  }
+
+  // ── 7. DOCUMENTOS DO CLIENTE ──────────────────────────────────────────
+  if (doc.y > 660) doc.addPage();
+  doc.x = COL_X_INI;
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold')
+     .text('7. Documentos a Serem Fornecidos pelo Cliente', COL_X_INI, doc.y, { width: COL_W });
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+  doc.fontSize(9.5).fillColor('#111');
+  custos.secao_4_checklist.forEach((d) => {
+    doc.x = COL_X_INI;
+    if (d.imprescindivel) {
+      doc.fillColor('#dc2626').font('Helvetica-Bold')
+         .text(`☐ [IMPRESCINDIVEL] ${d.texto}`, COL_X_INI + 8, doc.y, {
+           width: COL_W - 16, continued: false,
+         });
+      doc.font('Helvetica').fillColor('#111');
+    } else {
+      doc.text(`☐ ${d.texto}${d.obrigatorio ? '' : '  (opcional)'}`, COL_X_INI + 8, doc.y, {
+        width: COL_W - 16, continued: false,
+      });
+    }
+  });
+  doc.moveDown(0.5);
+
+  // ── 8. AVISOS E CONDICOES TECNICAS ────────────────────────────────────
+  if (custos.avisos && custos.avisos.length > 0) {
+    if (doc.y > 660) doc.addPage();
+    doc.x = COL_X_INI;
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold')
+       .text('8. Avisos e Condicoes Tecnicas', COL_X_INI, doc.y, { width: COL_W });
+    doc.font('Helvetica');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+    doc.fontSize(8.5).fillColor('#444');
+    custos.avisos.forEach((a) => {
+      doc.x = COL_X_INI;
+      doc.text(`• ${a}`, COL_X_INI + 8, doc.y, {
+        width: COL_W - 16, align: 'justify', continued: false,
+      });
+      doc.moveDown(0.15);
+    });
+    doc.fillColor('#111');
+    doc.moveDown(0.3);
+  }
+
+  // ── 9. FORO E VALIDADE ────────────────────────────────────────────────
+  if (doc.y > 660) doc.addPage();
+  doc.x = COL_X_INI;
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('9. Foro e Validade');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.3);
+  doc.fontSize(9.5).fillColor('#222').font('Helvetica')
+     .text(
+       `Fica eleito o Foro da Comarca de ${cidadeObra}/${ufObra} para dirimir quaisquer questoes oriundas desta proposta, com renuncia expressa a qualquer outro, por mais privilegiado que seja. Esta proposta tem validade de ${p.validade_dias || 30} (${(p.validade_dias || 30) === 1 ? 'um' : (p.validade_dias || 30).toString()}) dia(s) a contar da data de emissao.`,
+       COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
+     );
+  doc.moveDown(0.6);
+  // Suprime aviso unused vars
+  void COR_CREME_BG; void COR_CREME_BORDA;
+}
+
 export function renderGeorrefRuralBody(
   doc: PDFKit.PDFDocument,
   p: Awaited<ReturnType<typeof buscarPropostaConsultoria>>,
@@ -894,6 +1167,9 @@ export async function gerarPdfPropostaConsultoria(
   // do final da funcao continua valendo pros dois caminhos.
   if (p.subtipo === 'georreferenciamento_rural') {
     renderGeorrefRuralBody(doc, p, dadosImovel, custos, corHex);
+  } else if (p.subtipo === 'projeto_executivo') {
+    // v3.24.5: Projeto Executivo — layout dedicado.
+    renderProjetoExecutivoBody(doc, p, dadosImovel, custos, corHex);
   } else {
 
   // v1.99.16: Remembramento detalhado — tabela de imóveis + área total destacada

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -6522,6 +6522,8 @@ const SUBTIPOS_CONSULTORIA = [
   { slug: 'remembramento',             icone: '🔗', nome: 'Remembramento',            disponivel: true },
   { slug: 'retificacao_area',          icone: '📐', nome: 'Retificação de Área',      disponivel: true },
   { slug: 'avaliacao_ptam',            icone: '💰', nome: 'Avaliação PTAM',           disponivel: true },
+  // v3.24.5: Projeto Executivo (arquitetonico + complementares)
+  { slug: 'projeto_executivo',         icone: '📐', nome: 'Projeto Executivo',        disponivel: true },
   // v1.99.16: stub — Desmembramento de Obra (fracionamento de matricula de construcao) virá em fase posterior
   { slug: 'desmembramento_obra',       icone: '🏗️', nome: 'Desmembramento de Obra (Em breve)', disponivel: false },
 ];
@@ -6670,6 +6672,7 @@ async function renderPropostasConsultoriaLista(v, toggleHTML) {
         'remembramento',
         'retificacao_area',
         'avaliacao_ptam',
+        'projeto_executivo', // v3.24.5
       ]);
       if (!SUBTIPOS_EDITAVEIS.has(subtipo)) {
         return alert(`Edição não disponível para subtipo "${subtipo}".`);
@@ -6855,6 +6858,9 @@ async function renderConsultoriaFormInline(v, toggleHTML, subtipo) {
   }
   if (subtipo === 'avaliacao_ptam') {
     return renderConsultoriaFormPTAM(v, toggleHTML);
+  }
+  if (subtipo === 'projeto_executivo') {
+    return renderConsultoriaFormProjetoExecutivo(v, toggleHTML);
   }
   await loadPropostasClientes();
   const cliOpts = state.propostasClientes.map(c =>
@@ -8525,6 +8531,258 @@ async function renderConsultoriaFormRetificacao(v, toggleHTML) {
     const enderecoTxt = document.getElementById('rxEndereco').value.trim();
 
     const btn = document.getElementById('rxPreview');
+    btn.disabled = true; btn.textContent = 'Calculando...';
+    try {
+      const r = await api('/api/propostas-consultoria/preview', {
+        method: 'POST',
+        body: JSON.stringify({ subtipo, dados_imovel }),
+      });
+      state.consultoriaFormCache = { subtipo, cliId, endereco: enderecoTxt, dados_imovel };
+      state.consultoriaPreviewData = { ctx: { cliId, dados_imovel, subtipo, endereco: enderecoTxt }, resultado: r };
+      setConsultoriaView('preview');
+    } catch (e) {
+      alert('Erro: ' + e.message);
+      btn.disabled = false; btn.textContent = '🧮 Calcular preview';
+    }
+  };
+}
+
+// ── v3.24.5: Form Projeto Executivo ────────────────────────────────────
+// Arquitetonico + complementares (hidraulico, sanitario, eletrico, estrutural,
+// PCI, mapa de situacao). Calculo principal: area × R$/m² + ART/TRT auto
+// + alvara opcional + placa opcional. Taxa esboco R$ 750 e' INFORMATIVA.
+const PROJETOS_PE_DEFAULT_FRONT = [
+  { codigo: 'mapa_situacao', nome: 'Mapa de Situacao e Localizacao',                       selecionado: true,  detalhamento: 'Prancha contendo planta de situacao (quadra/lote), planta de localizacao do imovel, orientacao magnetica (Norte), coordenadas de referencia (SIRGAS2000), confrontantes, vias de acesso, recuos, taxa de ocupacao e coeficiente de aproveitamento conforme legislacao municipal.' },
+  { codigo: 'arquitetonico',  nome: 'Projeto Arquitetonico',                                selecionado: true,  detalhamento: 'Plantas baixas de todos os pavimentos com cotas e areas, planta de cobertura, planta de implantacao, cortes longitudinal e transversal (minimo 2), fachadas (minimo 2), planta de layout, memorial descritivo e quadro de areas, em conformidade com as NBR 13531 e NBR 13532.' },
+  { codigo: 'hidraulico',     nome: 'Projeto Hidraulico (Agua Fria)',                       selecionado: true,  detalhamento: 'Planta baixa hidraulica por pavimento, vistas isometricas dos pontos de consumo, detalhes de barrilete e reservatorio, dimensionamento de tubulacoes, quantitativo de materiais e memorial de calculo conforme NBR 5626.' },
+  { codigo: 'sanitario',      nome: 'Projeto Sanitario (Esgoto e Aguas Pluviais)',          selecionado: true,  detalhamento: 'Planta baixa de esgoto sanitario, planta baixa de aguas pluviais, vistas isometricas, detalhes de caixa de inspecao, fossa septica e sumidouro (quando aplicavel), dimensionamento conforme NBR 8160 e NBR 10844, e quantitativo de materiais.' },
+  { codigo: 'eletrico',       nome: 'Projeto Eletrico',                                     selecionado: true,  detalhamento: 'Planta baixa de pontos eletricos por pavimento, diagrama unifilar, quadro de cargas, dimensionamento de condutores e protecoes, detalhe de entrada de energia conforme padrao da concessionaria (Equatorial Maranhao), memorial descritivo conforme NBR 5410 e quantitativo de materiais.' },
+  { codigo: 'estrutural',     nome: 'Projeto Estrutural',                                   selecionado: true,  detalhamento: 'Planta de locacao de pilares, planta de formas por pavimento, detalhamento de vigas, lajes, pilares e fundacoes, memorial de calculo, especificacao de materiais (concreto e aco), em conformidade com NBR 6118 e NBR 6122.' },
+  { codigo: 'pci',            nome: 'Projeto de Prevencao e Combate a Incendio (PCI)',      selecionado: false, detalhamento: 'Planta baixa de PCI com rotas de fuga, localizacao de extintores, hidrantes, iluminacao de emergencia e sinalizacao, memorial descritivo conforme Normas Tecnicas do CBMMA e NBR 9077, para protocolo junto ao Corpo de Bombeiros Militar do Maranhao.' },
+];
+
+async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
+  await loadPropostasClientes();
+  const cliOpts = state.propostasClientes.map(c =>
+    `<option value="${c.id}">${escape(c.nome)}${c.cpf_cnpj ? ' · ' + escape(c.cpf_cnpj) : ''}</option>`
+  ).join('');
+  const subtipo = 'projeto_executivo';
+  const editando = !!state.consultoriaEditandoId;
+  const tituloHeader = editando
+    ? `Editando ${state.consultoriaPropostaOriginal?.numero || ''}`
+    : 'Nova Proposta de Projeto Executivo';
+  const cache = state.consultoriaFormCache || {};
+  const di = (state.consultoriaPropostaOriginal?.dados_imovel || cache.dados_imovel || {});
+
+  // Estado dos projetos: vem do cache ou defaults
+  const projetosState = Array.isArray(di.projetos_selecionados) && di.projetos_selecionados.length > 0
+    ? di.projetos_selecionados
+    : PROJETOS_PE_DEFAULT_FRONT.map(p => ({ ...p, detalhamento_entrega: p.detalhamento }));
+
+  const projetosHtml = projetosState.map((p, idx) => `
+    <div style="border:1px solid var(--border); border-radius:6px; padding:10px; margin-bottom:6px; background:var(--bg-elev);">
+      <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+        <input type="checkbox" data-pe-proj="${idx}" ${p.selecionado ? 'checked' : ''} style="width:18px; height:18px;">
+        <span style="font-weight:600; font-size:13px;">${escape(p.nome)}</span>
+      </label>
+      <details style="margin-top:6px;">
+        <summary style="font-size:11px; color:var(--text-muted); cursor:pointer;">Editar detalhamento ▼</summary>
+        <textarea data-pe-detail="${idx}" style="width:100%; margin-top:6px; min-height:60px; font-size:11px;">${escape(p.detalhamento_entrega || p.detalhamento || '')}</textarea>
+      </details>
+    </div>
+  `).join('');
+
+  v.innerHTML = `
+    <div class="card">
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap; margin-bottom:8px;">
+        <p class="section-title" style="margin:0;">📐 ${escape(tituloHeader)}</p>
+        ${toggleHTML}
+      </div>
+
+      <p style="margin:4px 0 0; font-size:13px; color:var(--gold);">📐 Projeto Executivo — Arquitetura + Complementares · NBR 13531/13532, 5626, 8160, 5410, 6118, 9077</p>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Cliente</p>
+        <label>Cliente <select id="peCli" style="width:100%;"><option value="">— Selecione —</option>${cliOpts}</select></label>
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">🏢 Imóvel / Obra</p>
+        <label>Endereço da Obra
+          <input id="peEnd" type="text" placeholder="Rua, número, bairro" value="${escape(di.endereco_obra||'')}" style="width:100%;">
+        </label>
+        <div style="display:grid; grid-template-columns:1fr 80px; gap:8px;">
+          <label>Cidade <input id="peCidade" type="text" value="${escape(di.cidade_obra||'Açailândia')}" style="width:100%;"></label>
+          <label>UF <input id="peUf" type="text" maxlength="2" value="${escape(di.uf_obra||'MA')}" style="width:100%;"></label>
+        </div>
+        <label>Tipo de edificação
+          <select id="peTipo" style="width:100%;">
+            <option value="residencial"   ${di.tipo_edificacao==='residencial'?'selected':''}>Residencial</option>
+            <option value="comercial"     ${di.tipo_edificacao==='comercial'?'selected':''}>Comercial</option>
+            <option value="misto"         ${di.tipo_edificacao==='misto'?'selected':''}>Misto</option>
+            <option value="industrial"    ${di.tipo_edificacao==='industrial'?'selected':''}>Industrial</option>
+            <option value="institucional" ${di.tipo_edificacao==='institucional'?'selected':''}>Institucional</option>
+          </select>
+        </label>
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📐 Parâmetros de Cálculo</p>
+        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
+          <label>Área a construir (m²) <input id="peArea" type="number" step="0.01" min="0" value="${di.area_construir||''}" style="width:100%;"></label>
+          <label>Valor R$/m² <input id="peVm2" type="number" step="0.01" min="0" value="${di.valor_m2||25}" style="width:100%;"></label>
+        </div>
+        <p id="peValorProjetosLine" style="margin:6px 0 0; font-size:12px; color:var(--text-muted);">Valor dos Projetos: <span id="peValorProjetos">R$ 0,00</span></p>
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Projetos a Entregar</p>
+        ${projetosHtml}
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">⚖️ Responsabilidade Técnica</p>
+        <label style="display:flex; gap:8px; align-items:center; cursor:pointer;">
+          <input type="checkbox" id="peRtAuto" ${di.responsabilidade_auto===false?'':'checked'}>
+          <span>Automático pela área (≤80m² → TRT · &gt;80m² → ART)</span>
+        </label>
+        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-top:6px;">
+          <label>Tipo
+            <select id="peRtTipo" style="width:100%;">
+              <option value="TRT" ${di.responsabilidade_tipo==='TRT'?'selected':''}>TRT — Técnico (CFT/MA)</option>
+              <option value="ART" ${di.responsabilidade_tipo==='ART'?'selected':''}>ART — Engenheiro/Arquiteto (CREA-MA)</option>
+            </select>
+          </label>
+          <label>Valor <input id="peRtVlr" type="number" step="0.01" min="0" value="${di.responsabilidade_valor||93.40}" style="width:100%;"></label>
+        </div>
+        <p id="peArtAviso" style="margin:6px 0 0; padding:8px; background:rgba(251,191,36,0.12); border-left:3px solid var(--gold); border-radius:4px; font-size:11px; color:var(--gold); display:none;">⚠️ ART exige Engenheiro/Arquiteto CREA-MA ou CAU. Romatec subcontrata profissional habilitado mediante aditivo contratual.</p>
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Itens Opcionais</p>
+        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; align-items:center;">
+          <label style="display:flex; gap:6px; align-items:center;"><input type="checkbox" id="peAlvI" ${di.alvara_incluir!==false?'checked':''}> Alvará de Construção</label>
+          <label>Valor R$ <input id="peAlvV" type="number" step="0.01" min="0" value="${di.alvara_valor||0}" style="width:100%;"></label>
+          <label style="display:flex; gap:6px; align-items:center;"><input type="checkbox" id="pePlcI" ${di.placa_incluir!==false?'checked':''}> Placa de Obra</label>
+          <label>Valor R$ <input id="pePlcV" type="number" step="0.01" min="0" value="${di.placa_valor||0}" style="width:100%;"></label>
+        </div>
+      </div>
+
+      <div style="margin-top:12px; padding:10px; background:rgba(251,191,36,0.10); border-left:4px solid var(--gold); border-radius:6px;">
+        <p style="margin:0; font-weight:600; color:var(--gold); font-size:13px;">⚠️ Hora Técnica de Anteprojeto: R$ <span id="peTxLbl">750,00</span> <span style="font-weight:400; font-size:11px;">(NÃO incluída no Valor Total)</span></p>
+        <p style="margin:4px 0 0; font-size:11px; color:var(--text-muted);">Cobrança CONDICIONAL — apenas se o cliente NÃO prosseguir com os projetos executivos após o esboço/anteprojeto. Se prosseguir, é absorvida pelo contrato.</p>
+        <label style="margin-top:6px; display:block; font-size:11px;">Valor da Hora Técnica R$
+          <input id="peTax" type="number" step="0.01" min="0" value="${di.taxa_esboco||750}" style="width:120px;">
+        </label>
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">💰 Resumo</p>
+        <div id="peResumo" style="font-size:13px; padding:10px; background:var(--bg-elev); border-radius:6px;">—</div>
+      </div>
+
+      <div style="margin-top:12px;">
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Prazos e Condições</p>
+        <label>Prazo de entrega (dias) <input id="pePrazo" type="number" min="1" value="${di.prazo_entrega_dias||30}" style="width:100%;"></label>
+        <label>Forma de pagamento <textarea id="pePag" style="width:100%; min-height:50px;">${escape(di.forma_pagamento||'')}</textarea></label>
+        <label>Observações <textarea id="peObs" style="width:100%; min-height:50px;">${escape(di.observacoes||'')}</textarea></label>
+      </div>
+
+      <div style="margin-top:16px;">
+        <button id="peCalcular" class="btn-primary" style="width:100%;">🧮 Calcular preview</button>
+      </div>
+    </div>
+  `;
+
+  // Handlers
+  if (cache.cliId) document.getElementById('peCli').value = cache.cliId;
+
+  function recalcResumo() {
+    const area = Number(document.getElementById('peArea').value) || 0;
+    const vm2  = Number(document.getElementById('peVm2').value)  || 0;
+    const valorProj = area * vm2;
+    document.getElementById('peValorProjetos').textContent = fmt(valorProj);
+
+    const auto = document.getElementById('peRtAuto').checked;
+    const tipoSel = document.getElementById('peRtTipo');
+    if (auto) {
+      const tipo = area > 80 ? 'ART' : 'TRT';
+      tipoSel.value = tipo;
+      tipoSel.disabled = true;
+      // valor sugerido
+      document.getElementById('peRtVlr').value = tipo === 'ART' ? 233.94 : 93.40;
+    } else {
+      tipoSel.disabled = false;
+    }
+    const tipoAtual = tipoSel.value;
+    document.getElementById('peArtAviso').style.display = tipoAtual === 'ART' ? 'block' : 'none';
+
+    const rtVlr = Number(document.getElementById('peRtVlr').value) || 0;
+    const alvI = document.getElementById('peAlvI').checked;
+    const alvV = alvI ? (Number(document.getElementById('peAlvV').value) || 0) : 0;
+    const plcI = document.getElementById('pePlcI').checked;
+    const plcV = plcI ? (Number(document.getElementById('pePlcV').value) || 0) : 0;
+    const tx = Number(document.getElementById('peTax').value) || 0;
+    document.getElementById('peTxLbl').textContent = tx.toFixed(2).replace('.', ',');
+
+    const subtotal = valorProj + rtVlr + alvV + plcV;
+    document.getElementById('peResumo').innerHTML = `
+      Projetos Executivos: <strong>${fmt(valorProj)}</strong><br>
+      ${tipoAtual}: <strong>${fmt(rtVlr)}</strong><br>
+      Alvará: <strong>${fmt(alvV)}</strong> · Placa: <strong>${fmt(plcV)}</strong><br>
+      <span style="color:var(--gold); font-size:14px;">VALOR TOTAL: <strong>${fmt(subtotal)}</strong></span><br>
+      <span style="color:var(--text-muted); font-size:11px;">+ Hora Técnica condicional ${fmt(tx)} (não somada)</span>
+    `;
+  }
+  ['peArea','peVm2','peRtTipo','peRtVlr','peAlvI','peAlvV','pePlcI','pePlcV','peTax'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener('input', recalcResumo);
+    if (el && el.type === 'checkbox') el.addEventListener('change', recalcResumo);
+  });
+  document.getElementById('peRtAuto').addEventListener('change', recalcResumo);
+  recalcResumo();
+
+  document.getElementById('peCalcular').onclick = async () => {
+    const btn = document.getElementById('peCalcular');
+    const cliId = document.getElementById('peCli').value;
+    if (!cliId) return alert('Selecione um cliente.');
+    const enderecoTxt = document.getElementById('peEnd').value.trim();
+    if (!enderecoTxt) return alert('Endereço da obra é obrigatório.');
+    const area = Number(document.getElementById('peArea').value);
+    if (!area || area <= 0) return alert('Área a construir deve ser maior que zero.');
+    const vm2 = Number(document.getElementById('peVm2').value);
+    if (!vm2 || vm2 <= 0) return alert('Valor R$/m² deve ser maior que zero.');
+
+    // Coleta projetos
+    const projetos_selecionados = projetosState.map((p, idx) => ({
+      codigo: p.codigo,
+      nome: p.nome,
+      ordem: idx + 1,
+      selecionado: document.querySelector(`[data-pe-proj="${idx}"]`).checked,
+      detalhamento_entrega: document.querySelector(`[data-pe-detail="${idx}"]`).value.trim(),
+    }));
+
+    const dados_imovel = {
+      endereco_obra: enderecoTxt,
+      cidade_obra: document.getElementById('peCidade').value.trim() || 'Açailândia',
+      uf_obra: document.getElementById('peUf').value.trim().toUpperCase() || 'MA',
+      tipo_edificacao: document.getElementById('peTipo').value,
+      area_construir: area,
+      valor_m2: vm2,
+      responsabilidade_auto: document.getElementById('peRtAuto').checked,
+      responsabilidade_tipo: document.getElementById('peRtTipo').value,
+      responsabilidade_valor: Number(document.getElementById('peRtVlr').value) || 0,
+      alvara_incluir: document.getElementById('peAlvI').checked,
+      alvara_valor: Number(document.getElementById('peAlvV').value) || 0,
+      placa_incluir: document.getElementById('pePlcI').checked,
+      placa_valor: Number(document.getElementById('pePlcV').value) || 0,
+      taxa_esboco: Number(document.getElementById('peTax').value) || 750,
+      prazo_entrega_dias: Number(document.getElementById('pePrazo').value) || 30,
+      forma_pagamento: document.getElementById('pePag').value.trim(),
+      observacoes: document.getElementById('peObs').value.trim(),
+      projetos_selecionados,
+    };
+
     btn.disabled = true; btn.textContent = 'Calculando...';
     try {
       const r = await api('/api/propostas-consultoria/preview', {

--- a/src/services/pricing/index.ts
+++ b/src/services/pricing/index.ts
@@ -10,12 +10,14 @@ import type {
   InputDesmembramento,
   InputRetificacao,
   InputAvaliacaoPTAM,
+  InputProjetoExecutivo,
 } from './types';
 import { calcularAverbacao } from './averbacao';
 import { calcularGeorreferenciamento } from './georreferenciamento';
 import { calcularDesmembramento } from './desmembramento';
 import { calcularRetificacao } from './retificacao';
 import { calcularAvaliacaoPTAM } from './ptam';
+import { calcularProjetoExecutivo } from './projetoExecutivo';
 
 export type InputConsultoria =
   | { subtipo: 'averbacao_residencial' | 'averbacao_comercial'; dados: InputAverbacao }
@@ -23,7 +25,8 @@ export type InputConsultoria =
   | { subtipo: 'desmembramento';              dados: InputDesmembramento }
   | { subtipo: 'remembramento';               dados: InputDesmembramento }
   | { subtipo: 'retificacao_area';            dados: InputRetificacao }
-  | { subtipo: 'avaliacao_ptam';              dados: InputAvaliacaoPTAM };
+  | { subtipo: 'avaliacao_ptam';              dados: InputAvaliacaoPTAM }
+  | { subtipo: 'projeto_executivo';           dados: InputProjetoExecutivo };
 
 export async function calcularConsultoria(input: InputConsultoria): Promise<ResultadoCalculo> {
   switch (input.subtipo) {
@@ -41,6 +44,8 @@ export async function calcularConsultoria(input: InputConsultoria): Promise<Resu
       return calcularRetificacao(input.dados);
     case 'avaliacao_ptam':
       return calcularAvaliacaoPTAM(input.dados);
+    case 'projeto_executivo':
+      return calcularProjetoExecutivo(input.dados);
   }
 }
 
@@ -54,6 +59,7 @@ export const SUBTIPOS_DISPONIVEIS_FASE1: SubtipoConsultoria[] = [
   'remembramento',
   'retificacao_area',
   'avaliacao_ptam',
+  'projeto_executivo',
 ];
 
 export const TODOS_SUBTIPOS: SubtipoConsultoria[] = [
@@ -64,4 +70,5 @@ export const TODOS_SUBTIPOS: SubtipoConsultoria[] = [
   'remembramento',
   'retificacao_area',
   'avaliacao_ptam',
+  'projeto_executivo',
 ];

--- a/src/services/pricing/projetoExecutivo.ts
+++ b/src/services/pricing/projetoExecutivo.ts
@@ -1,0 +1,341 @@
+// v3.24.5: motor de calculo de Projeto Executivo (arquitetonico + complementares).
+//
+// Regra de negocio:
+//   Valor projetos = area_construir × valor_m2 (default R$ 25/m²)
+//   ART/TRT auto por area: > 80m² -> ART | <= 80m² -> TRT
+//   ART exige profissional CREA (Romatec subcontrata por aditivo);
+//   TRT pode ser emitida diretamente pelo Jose Romario (Tec. Edificacoes).
+//   Alvara e Placa: opcionais, valores informados ou 0 se desmarcados.
+//   Taxa esboco (R$750): INFORMATIVA — nao soma ao subtotal/total.
+//     Cobrada apenas se cliente desistir apos entrega do anteprojeto.
+//   Desconto: subtrai do subtotal.
+
+import type {
+  InputProjetoExecutivo,
+  ProjetoSelecionado,
+  CustosCalculados,
+  ResultadoCalculo,
+  ItemCusto,
+  DocumentoChecklist,
+  CondicaoPagamento,
+  BaseCalculo,
+} from './types';
+
+// HALF_UP em 2 casas (mesma logica das outras engines)
+export function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+// Defaults pra ART/TRT e config — sem dependencia de DB pra simplificar.
+// CEO pediu defaults conservadores e ajustaveis via input.
+export const DEFAULTS_PROJETO_EXECUTIVO = {
+  VALOR_M2: 25.00,
+  TAXA_ESBOCO: 750.00,
+  ART_VALOR: 233.94,     // CREA-MA referencia (subcontratacao)
+  TRT_VALOR: 93.40,      // CFT/MA referencia (mesma das outras propostas)
+  AREA_LIMITE_TRT: 80.00,
+} as const;
+
+// Lista padrao de projetos executivos com detalhamentos completos.
+// CEO pode customizar por proposta — o que vier no input substitui o default.
+export const PROJETOS_DEFAULT_PROJETO_EXECUTIVO: ProjetoSelecionado[] = [
+  {
+    codigo: 'mapa_situacao',
+    nome: 'Mapa de Situacao e Localizacao',
+    ordem: 1,
+    selecionado: true,
+    detalhamento_entrega:
+      'Prancha contendo planta de situacao (quadra/lote), planta de localizacao do imovel, ' +
+      'orientacao magnetica (Norte), coordenadas de referencia (SIRGAS2000), confrontantes, ' +
+      'vias de acesso, recuos, taxa de ocupacao e coeficiente de aproveitamento conforme ' +
+      'legislacao municipal.',
+  },
+  {
+    codigo: 'arquitetonico',
+    nome: 'Projeto Arquitetonico',
+    ordem: 2,
+    selecionado: true,
+    detalhamento_entrega:
+      'Plantas baixas de todos os pavimentos com cotas e areas, planta de cobertura, planta ' +
+      'de implantacao, cortes longitudinal e transversal (minimo 2), fachadas (minimo 2), ' +
+      'planta de layout, memorial descritivo e quadro de areas, em conformidade com as ' +
+      'NBR 13531 e NBR 13532.',
+  },
+  {
+    codigo: 'hidraulico',
+    nome: 'Projeto Hidraulico (Agua Fria)',
+    ordem: 3,
+    selecionado: true,
+    detalhamento_entrega:
+      'Planta baixa hidraulica por pavimento, vistas isometricas dos pontos de consumo, ' +
+      'detalhes de barrilete e reservatorio, dimensionamento de tubulacoes, quantitativo de ' +
+      'materiais e memorial de calculo conforme NBR 5626.',
+  },
+  {
+    codigo: 'sanitario',
+    nome: 'Projeto Sanitario (Esgoto e Aguas Pluviais)',
+    ordem: 4,
+    selecionado: true,
+    detalhamento_entrega:
+      'Planta baixa de esgoto sanitario, planta baixa de aguas pluviais, vistas isometricas, ' +
+      'detalhes de caixa de inspecao, fossa septica e sumidouro (quando aplicavel), ' +
+      'dimensionamento conforme NBR 8160 e NBR 10844, e quantitativo de materiais.',
+  },
+  {
+    codigo: 'eletrico',
+    nome: 'Projeto Eletrico',
+    ordem: 5,
+    selecionado: true,
+    detalhamento_entrega:
+      'Planta baixa de pontos eletricos por pavimento, diagrama unifilar, quadro de cargas, ' +
+      'dimensionamento de condutores e protecoes, detalhe de entrada de energia conforme padrao ' +
+      'da concessionaria (Equatorial Maranhao), memorial descritivo conforme NBR 5410 e ' +
+      'quantitativo de materiais.',
+  },
+  {
+    codigo: 'estrutural',
+    nome: 'Projeto Estrutural',
+    ordem: 6,
+    selecionado: true,
+    detalhamento_entrega:
+      'Planta de locacao de pilares, planta de formas por pavimento, detalhamento de vigas, ' +
+      'lajes, pilares e fundacoes, memorial de calculo, especificacao de materiais (concreto ' +
+      'e aco), em conformidade com NBR 6118 e NBR 6122.',
+  },
+  {
+    codigo: 'pci',
+    nome: 'Projeto de Prevencao e Combate a Incendio (PCI)',
+    ordem: 7,
+    selecionado: false,
+    detalhamento_entrega:
+      'Planta baixa de PCI com rotas de fuga, localizacao de extintores, hidrantes, ' +
+      'iluminacao de emergencia e sinalizacao, memorial descritivo conforme Normas Tecnicas ' +
+      'do CBMMA e NBR 9077, para protocolo junto ao Corpo de Bombeiros Militar do Maranhao.',
+  },
+];
+
+const CNO_OBSERVACAO =
+  'O Cadastro Nacional de Obras (CNO) junto a Receita Federal do Brasil sera gerado e ' +
+  'vinculado a esta obra APOS a expedicao do Alvara de Construcao pelo municipio de ' +
+  'Acailandia/MA, em conformidade com a IN RFB n° 2.021/2021. A CONTRATADA se responsabilizara ' +
+  'pelo cadastramento mediante apresentacao previa do Alvara pelo CONTRATANTE.';
+
+const AVISO_TAXA_ESBOCO =
+  'A Hora Tecnica de Anteprojeto e Croqui (R$ 750,00 — item informativo) NAO esta incluida no ' +
+  'VALOR TOTAL desta proposta. Sera cobrada APENAS se o CONTRATANTE optar por nao prosseguir ' +
+  'com a fase executiva apos a entrega do esboco arquitetonico aprovado. Caso prossiga, este ' +
+  'valor e absorvido pelo contrato.';
+
+const AVISO_CNO_EXECUTIVO =
+  'O CADASTRO NACIONAL DE OBRAS (CNO) na Receita Federal sera vinculado a obra apenas APOS a ' +
+  'expedicao do Alvara de Construcao pela Prefeitura. A CONTRATADA executa o cadastramento ' +
+  'quando o CONTRATANTE apresentar o Alvara.';
+
+const AVISO_ALVARA =
+  'O Alvara de Construcao e expedido pela Prefeitura Municipal de Acailandia mediante pagamento ' +
+  'das taxas municipais (TLE, ISS de aprovacao, etc) diretamente pelo CONTRATANTE. A CONTRATADA ' +
+  'acompanha o protocolo e exigencias ate a expedicao.';
+
+const AVISO_ART =
+  'A ART (Anotacao de Responsabilidade Tecnica) junto ao CREA-MA exige profissional Engenheiro ' +
+  'ou Arquiteto registrado. A Romatec subcontrata o profissional habilitado mediante aditivo ' +
+  'contratual quando esta opcao for selecionada.';
+
+const AVISO_TRT =
+  'O TRT (Termo de Responsabilidade Tecnica) junto ao CFT/MA e emitido diretamente pelo ' +
+  'profissional Jose Romario Pinto Bezerra — Tecnico em Edificacoes (CFT/MA 01209185369). ' +
+  'Aplicavel a obras de ate 80m² conforme Lei 13.639/2018.';
+
+// Documentos obrigatorios do cliente pra dar inicio aos projetos
+const CHECKLIST_PROJETO_EXECUTIVO: DocumentoChecklist[] = [
+  { texto: 'RG e CPF do proprietario (copia simples)', obrigatorio: true },
+  { texto: 'Comprovante de residencia atualizado (max. 90 dias)', obrigatorio: true },
+  { texto: 'Escritura ou matricula atualizada do imovel (max. 90 dias)', obrigatorio: true, imprescindivel: true },
+  { texto: 'IPTU do exercicio atual (com situacao em dia)', obrigatorio: true },
+  { texto: 'Croqui ou levantamento topografico do terreno (se disponivel)', obrigatorio: false },
+  { texto: 'Programa de necessidades — descricao dos ambientes desejados', obrigatorio: true },
+  { texto: 'Referencias visuais / inspiracao (opcional)', obrigatorio: false },
+];
+
+export interface ResultadoProjetoExecutivoExtra {
+  area_construir: number;
+  valor_m2: number;
+  valor_projetos: number;
+  responsabilidade_tipo: 'ART' | 'TRT';
+  responsabilidade_valor: number;
+  responsabilidade_auto: boolean;
+  taxa_esboco: number;
+  alvara: { incluir: boolean; valor: number };
+  placa: { incluir: boolean; valor: number };
+  subtotal: number;
+  desconto: number;
+  valor_total: number;
+  projetos_selecionados: ProjetoSelecionado[];
+  cno_observacao: string;
+}
+
+export async function calcularProjetoExecutivo(
+  input: InputProjetoExecutivo,
+): Promise<ResultadoCalculo & { projeto_executivo: ResultadoProjetoExecutivoExtra }> {
+  if (!input.area_construir || input.area_construir <= 0) {
+    throw new Error('area_construir deve ser maior que zero');
+  }
+  if (!input.valor_m2 || input.valor_m2 <= 0) {
+    throw new Error('valor_m2 deve ser maior que zero');
+  }
+
+  const valorM2 = input.valor_m2;
+  const valor_projetos = round2(input.area_construir * valorM2);
+  const taxa_esboco = round2(input.taxa_esboco ?? DEFAULTS_PROJETO_EXECUTIVO.TAXA_ESBOCO);
+
+  // ART/TRT — default auto por area (>80m² ART). Override manual respeita escolha.
+  const auto = input.responsabilidade_auto !== false;
+  let responsabilidade_tipo: 'ART' | 'TRT';
+  if (!auto && input.responsabilidade_tipo) {
+    responsabilidade_tipo = input.responsabilidade_tipo;
+  } else {
+    responsabilidade_tipo =
+      input.area_construir > DEFAULTS_PROJETO_EXECUTIVO.AREA_LIMITE_TRT ? 'ART' : 'TRT';
+  }
+
+  const responsabilidade_valor = round2(
+    input.responsabilidade_valor != null
+      ? input.responsabilidade_valor
+      : (responsabilidade_tipo === 'ART'
+        ? DEFAULTS_PROJETO_EXECUTIVO.ART_VALOR
+        : DEFAULTS_PROJETO_EXECUTIVO.TRT_VALOR),
+  );
+
+  const alvara_valor = input.alvara_incluir ? round2(input.alvara_valor) : 0;
+  const placa_valor  = input.placa_incluir  ? round2(input.placa_valor)  : 0;
+
+  // Subtotal NAO inclui taxa_esboco
+  const subtotal = round2(valor_projetos + responsabilidade_valor + alvara_valor + placa_valor);
+  const desconto = round2(input.desconto ?? 0);
+  const valor_total = round2(subtotal - desconto);
+
+  // Projetos: aplica defaults SE input nao trouxe lista
+  const projetos = (input.projetos_selecionados && input.projetos_selecionados.length > 0)
+    ? input.projetos_selecionados
+    : PROJETOS_DEFAULT_PROJETO_EXECUTIVO;
+  // Filtra so os selecionados pra montar a lista do escopo (Secao 1)
+  const projetosAtivos = projetos.filter(p => p.selecionado);
+
+  const secao_1_projetos = projetosAtivos.map(p => `${p.nome}: ${p.detalhamento_entrega}`);
+
+  // Tabela financeira:
+  // Secao 2 (taxas) = ART/TRT + alvara + placa (sem taxas terceiros nesse subtipo)
+  // Secao 3 (honorarios) = valor_projetos (item unico, ja inclui o pacote completo)
+  const secao_2_taxas: ItemCusto[] = [];
+  secao_2_taxas.push({
+    ordem: 1,
+    descricao: responsabilidade_tipo === 'ART'
+      ? 'ART — Anotacao de Responsabilidade Tecnica (CREA-MA)'
+      : 'TRT — Termo de Responsabilidade Tecnica (CFT/MA)',
+    valor: responsabilidade_valor,
+    observacao: responsabilidade_tipo === 'ART' ? AVISO_ART : AVISO_TRT,
+  });
+  if (input.alvara_incluir) {
+    secao_2_taxas.push({
+      ordem: 2,
+      descricao: 'Alvara de Construcao (Prefeitura de Acailandia/MA)',
+      valor: alvara_valor,
+      observacao: AVISO_ALVARA,
+    });
+  }
+  if (input.placa_incluir) {
+    secao_2_taxas.push({
+      ordem: 3,
+      descricao: 'Placa de Obra (confeccao e instalacao)',
+      valor: placa_valor,
+      observacao: 'Placa padrao com identificacao do responsavel tecnico e numero da ART/TRT.',
+    });
+  }
+
+  const secao_3_honorarios: ItemCusto[] = [{
+    ordem: 1,
+    descricao: `Projetos Executivos (${projetosAtivos.length} projeto${projetosAtivos.length === 1 ? '' : 's'}) — ` +
+               `${input.area_construir.toFixed(2)}m² × R$ ${valorM2.toFixed(2)}/m²`,
+    valor: valor_projetos,
+  }];
+
+  // Condicoes de pagamento sugeridas — 3 parcelas:
+  //   1a (40% subtotal) na assinatura
+  //   2a (40%) na entrega do anteprojeto aprovado
+  //   3a (20%) na entrega final dos projetos executivos
+  const p1 = round2(valor_total * 0.40);
+  const p2 = round2(valor_total * 0.40);
+  const p3 = round2(valor_total - p1 - p2);
+  const condicoes_pagamento: CondicaoPagamento[] = [
+    { rotulo: '1a parcela — na assinatura', descricao: '40% do valor total', valor: p1 },
+    { rotulo: '2a parcela — anteprojeto aprovado', descricao: '40% do valor total', valor: p2 },
+    { rotulo: '3a parcela — entrega final', descricao: '20% do valor total', valor: p3 },
+  ];
+
+  const base_calculo: BaseCalculo[] = [
+    {
+      rotulo: `Projetos Executivos (${projetosAtivos.length} projeto${projetosAtivos.length === 1 ? '' : 's'})`,
+      formula: `area (${input.area_construir.toFixed(2)} m²) × valor_m2 (R$ ${valorM2.toFixed(2)})`,
+      valor_resultado: valor_projetos,
+    },
+    {
+      rotulo: `${responsabilidade_tipo} ${auto ? 'auto' : 'manual'}`,
+      formula: auto
+        ? `area ${input.area_construir > 80 ? '> 80m² -> ART' : '<= 80m² -> TRT'}`
+        : `override manual = ${responsabilidade_tipo}`,
+      valor_resultado: responsabilidade_valor,
+    },
+  ];
+  if (input.alvara_incluir) {
+    base_calculo.push({
+      rotulo: 'Alvara',
+      formula: 'incluido pelo CONTRATANTE',
+      valor_resultado: alvara_valor,
+    });
+  }
+  if (input.placa_incluir) {
+    base_calculo.push({
+      rotulo: 'Placa',
+      formula: 'incluida pelo CONTRATANTE',
+      valor_resultado: placa_valor,
+    });
+  }
+
+  const avisos = [
+    AVISO_TAXA_ESBOCO,
+    AVISO_CNO_EXECUTIVO,
+    responsabilidade_tipo === 'ART' ? AVISO_ART : AVISO_TRT,
+  ];
+
+  const custos: CustosCalculados = {
+    secao_1_projetos,
+    secao_2_taxas,
+    secao_3_honorarios,
+    condicoes_pagamento,
+    base_calculo,
+    secao_4_checklist: CHECKLIST_PROJETO_EXECUTIVO,
+    secao_5_total: valor_total,
+    avisos,
+  };
+
+  return {
+    custos,
+    fontes: {},
+    projeto_executivo: {
+      area_construir: input.area_construir,
+      valor_m2: valorM2,
+      valor_projetos,
+      responsabilidade_tipo,
+      responsabilidade_valor,
+      responsabilidade_auto: auto,
+      taxa_esboco,
+      alvara: { incluir: !!input.alvara_incluir, valor: alvara_valor },
+      placa:  { incluir: !!input.placa_incluir,  valor: placa_valor  },
+      subtotal,
+      desconto,
+      valor_total,
+      projetos_selecionados: projetos,
+      cno_observacao: CNO_OBSERVACAO,
+    },
+  };
+}

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -8,7 +8,8 @@ export type SubtipoConsultoria =
   | 'desmembramento'
   | 'remembramento'
   | 'retificacao_area'
-  | 'avaliacao_ptam';
+  | 'avaliacao_ptam'
+  | 'projeto_executivo';
 
 export type PadraoConstrutivo = 'popular' | 'normal' | 'alto';
 export type ResponsavelObra = 'PF' | 'PJ_com_contabilidade' | 'PJ_sem_contabilidade';
@@ -326,4 +327,71 @@ export interface InputAvaliacaoPTAM {
 export interface ResultadoCalculo {
   custos: CustosCalculados;
   fontes: FontesConsulta;
+}
+
+// v3.24.5: subtipo Projeto Executivo. Confeccao de projetos arquitetonicos
+// + complementares (hidraulico, sanitario, eletrico, estrutural, PCI, mapa
+// de situacao). Calculo simples: area × R$/m² + ART/TRT auto por area
+// + alvara opcional + placa opcional. Taxa esboco (R$750) e' INFORMATIVA —
+// nao soma ao total (so cobrada se cliente desistir apos esboco).
+
+export type CodigoProjetoExecutivo =
+  | 'mapa_situacao'
+  | 'arquitetonico'
+  | 'hidraulico'
+  | 'sanitario'
+  | 'eletrico'
+  | 'estrutural'
+  | 'pci';
+
+export type TipoEdificacao =
+  | 'residencial'
+  | 'comercial'
+  | 'misto'
+  | 'industrial'
+  | 'institucional';
+
+export interface ProjetoSelecionado {
+  codigo: CodigoProjetoExecutivo;
+  nome: string;
+  ordem: number;
+  selecionado: boolean;
+  detalhamento_entrega: string;
+}
+
+export interface InputProjetoExecutivo {
+  // Imovel/obra
+  endereco_obra: string;
+  cidade_obra?: string;        // default Acailandia
+  uf_obra?: string;            // default MA
+  tipo_edificacao: TipoEdificacao;
+
+  // Calculo principal
+  area_construir: number;       // m²
+  valor_m2: number;             // R$/m² (default 25)
+
+  // ART/TRT — auto por area (>80m² ART) com override manual
+  responsabilidade_auto?: boolean;       // default true
+  responsabilidade_tipo?: 'ART' | 'TRT'; // so usado se auto=false
+  responsabilidade_valor?: number;       // override do default da config
+
+  // Itens opcionais (cada um pode ser desligado)
+  alvara_incluir: boolean;
+  alvara_valor: number;
+  placa_incluir: boolean;
+  placa_valor: number;
+
+  // Taxa de esboco (R$750 default) — INFORMATIVA, fora do total
+  taxa_esboco?: number;
+
+  // Descontos/desbloqueios manuais
+  desconto?: number;
+
+  // Projetos selecionados (lista vinda do front; defaults aplicados quando vazio)
+  projetos_selecionados?: ProjetoSelecionado[];
+
+  // Cliente — usado so na preview/rendering, nao no calculo
+  prazo_entrega_dias?: number;
+  forma_pagamento?: string;
+  observacoes?: string;
 }

--- a/src/test/projeto-executivo-engine.test.ts
+++ b/src/test/projeto-executivo-engine.test.ts
@@ -1,0 +1,276 @@
+// v3.24.5: tests da engine de Projeto Executivo.
+//
+// Cobre:
+// 1. Cálculo: area × R$/m² = valor_projetos
+// 2. ART/TRT auto por área (toggle em 80m²)
+// 3. Override manual respeita escolha
+// 4. Taxa esboço fica FORA do subtotal/valor_total
+// 5. Alvará/placa opcionais zeram quando desmarcados
+// 6. Desconto subtrai corretamente
+// 7. round2 HALF_UP consistente
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularProjetoExecutivo,
+  round2,
+  DEFAULTS_PROJETO_EXECUTIVO,
+  PROJETOS_DEFAULT_PROJETO_EXECUTIVO,
+} from '../services/pricing/projetoExecutivo';
+import type { InputProjetoExecutivo } from '../services/pricing/types';
+
+function inputBase(over: Partial<InputProjetoExecutivo> = {}): InputProjetoExecutivo {
+  return {
+    endereco_obra: 'Rua Teste, 123',
+    cidade_obra: 'Acailandia',
+    uf_obra: 'MA',
+    tipo_edificacao: 'residencial',
+    area_construir: 100,
+    valor_m2: 25,
+    alvara_incluir: true,
+    alvara_valor: 500,
+    placa_incluir: true,
+    placa_valor: 350,
+    ...over,
+  };
+}
+
+describe('round2 (HALF_UP)', () => {
+  it('arredonda 2.005 pra 2.01 (HALF_UP, nao banker)', () => {
+    expect(round2(2.005)).toBe(2.01);
+  });
+  it('arredonda 1.005 pra 1.01', () => {
+    expect(round2(1.005)).toBe(1.01);
+  });
+  it('mantem 100 inteiro', () => {
+    expect(round2(100)).toBe(100);
+  });
+});
+
+describe('1. calculo area × R$/m²', () => {
+  it('100m² × R$ 25 = R$ 2.500 no item projetos', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 100, valor_m2: 25 }));
+    expect(r.projeto_executivo.valor_projetos).toBe(2500);
+    expect(r.custos.secao_3_honorarios[0].valor).toBe(2500);
+  });
+
+  it('250.5m² × R$ 30,50 = R$ 7.640,25', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 250.5, valor_m2: 30.50 }));
+    expect(r.projeto_executivo.valor_projetos).toBe(7640.25);
+  });
+
+  it('rejeita area_construir <= 0', async () => {
+    await expect(calcularProjetoExecutivo(inputBase({ area_construir: 0 }))).rejects.toThrow();
+    await expect(calcularProjetoExecutivo(inputBase({ area_construir: -10 }))).rejects.toThrow();
+  });
+
+  it('rejeita valor_m2 <= 0', async () => {
+    await expect(calcularProjetoExecutivo(inputBase({ valor_m2: 0 }))).rejects.toThrow();
+  });
+});
+
+describe('2. ART/TRT auto por area (toggle em 80m²)', () => {
+  it('area 79m² -> TRT auto', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 79 }));
+    expect(r.projeto_executivo.responsabilidade_tipo).toBe('TRT');
+    expect(r.projeto_executivo.responsabilidade_auto).toBe(true);
+    expect(r.projeto_executivo.responsabilidade_valor).toBe(DEFAULTS_PROJETO_EXECUTIVO.TRT_VALOR);
+  });
+
+  it('area 80m² (limite EXATO) -> TRT (regra <=80)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 80 }));
+    expect(r.projeto_executivo.responsabilidade_tipo).toBe('TRT');
+  });
+
+  it('area 80.01m² -> ART (regra >80)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 80.01 }));
+    expect(r.projeto_executivo.responsabilidade_tipo).toBe('ART');
+    expect(r.projeto_executivo.responsabilidade_valor).toBe(DEFAULTS_PROJETO_EXECUTIVO.ART_VALOR);
+  });
+
+  it('area 200m² -> ART auto com valor default R$ 233,94', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 200 }));
+    expect(r.projeto_executivo.responsabilidade_tipo).toBe('ART');
+    expect(r.projeto_executivo.responsabilidade_valor).toBe(233.94);
+  });
+});
+
+describe('3. Override manual respeita escolha', () => {
+  it('responsabilidade_auto=false + tipo=ART na area 50m² mantem ART', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 50,
+      responsabilidade_auto: false,
+      responsabilidade_tipo: 'ART',
+    }));
+    expect(r.projeto_executivo.responsabilidade_tipo).toBe('ART');
+    expect(r.projeto_executivo.responsabilidade_auto).toBe(false);
+  });
+
+  it('responsabilidade_auto=false + tipo=TRT na area 200m² mantem TRT (CEO assume risco)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 200,
+      responsabilidade_auto: false,
+      responsabilidade_tipo: 'TRT',
+    }));
+    expect(r.projeto_executivo.responsabilidade_tipo).toBe('TRT');
+  });
+
+  it('responsabilidade_valor override usa valor informado nao default', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 100,
+      responsabilidade_valor: 150,
+    }));
+    expect(r.projeto_executivo.responsabilidade_valor).toBe(150);
+  });
+});
+
+describe('4. Taxa esboço NAO entra no subtotal/valor_total', () => {
+  it('taxa default 750 nao soma ao subtotal', async () => {
+    // Area 50 -> TRT auto (<=80). Projects 50*25=1250 + TRT 93.40 = 1343.40
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 50,
+      valor_m2: 25,
+      alvara_incluir: false,
+      placa_incluir: false,
+    }));
+    expect(r.projeto_executivo.subtotal).toBe(1343.40);
+    expect(r.projeto_executivo.valor_total).toBe(1343.40);
+    // Taxa esboco esta exposta mas fora do total
+    expect(r.projeto_executivo.taxa_esboco).toBe(750);
+  });
+
+  it('aviso da taxa aparece em custos.avisos', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.custos.avisos.some(a => /R\$ 750,00.*NAO esta incluida/i.test(a))).toBe(true);
+  });
+
+  it('taxa customizada respeita input', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ taxa_esboco: 1200 }));
+    expect(r.projeto_executivo.taxa_esboco).toBe(1200);
+  });
+});
+
+describe('5. Alvará/placa opcionais zeram quando desmarcados', () => {
+  it('alvara_incluir=false zera alvara_valor no total', async () => {
+    // Area 50 -> TRT. Projects 1250 + TRT 93.40 = 1343.40
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 50,
+      valor_m2: 25,
+      alvara_incluir: false,
+      alvara_valor: 9999,    // ignorado
+      placa_incluir: false,
+      placa_valor: 0,
+    }));
+    expect(r.projeto_executivo.subtotal).toBe(1343.40);
+    expect(r.projeto_executivo.alvara.incluir).toBe(false);
+    expect(r.projeto_executivo.alvara.valor).toBe(0);
+  });
+
+  it('placa_incluir=false idem', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      alvara_incluir: false,
+      placa_incluir: false,
+      placa_valor: 999,
+    }));
+    expect(r.projeto_executivo.placa.valor).toBe(0);
+  });
+
+  it('ambos incluidos somam ao total', async () => {
+    // Area 50 -> TRT. Projects 1250 + TRT 93.40 + 500 + 350 = 2193.40
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 50, valor_m2: 25,
+      alvara_incluir: true,  alvara_valor: 500,
+      placa_incluir: true,   placa_valor: 350,
+    }));
+    expect(r.projeto_executivo.subtotal).toBe(2193.40);
+  });
+});
+
+describe('6. Desconto subtrai do subtotal', () => {
+  it('desconto R$ 200 do subtotal 2193.40 = 1993.40 (area 50, TRT)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 50, valor_m2: 25,
+      alvara_incluir: true, alvara_valor: 500,
+      placa_incluir: true,  placa_valor: 350,
+      desconto: 200,
+    }));
+    expect(r.projeto_executivo.subtotal).toBe(2193.40);
+    expect(r.projeto_executivo.desconto).toBe(200);
+    expect(r.projeto_executivo.valor_total).toBe(1993.40);
+  });
+
+  it('desconto zero (sem desconto)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 100, valor_m2: 25,
+      alvara_incluir: false, placa_incluir: false,
+    }));
+    expect(r.projeto_executivo.desconto).toBe(0);
+    expect(r.projeto_executivo.valor_total).toBe(r.projeto_executivo.subtotal);
+  });
+});
+
+describe('7. Projetos selecionados', () => {
+  it('quando input nao traz lista, aplica defaults (6 selecionados de 7, PCI=false)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.projeto_executivo.projetos_selecionados).toHaveLength(7);
+    const selecionados = r.projeto_executivo.projetos_selecionados.filter(p => p.selecionado);
+    expect(selecionados).toHaveLength(6);
+    // PCI vem desmarcado por default
+    const pci = r.projeto_executivo.projetos_selecionados.find(p => p.codigo === 'pci');
+    expect(pci?.selecionado).toBe(false);
+  });
+
+  it('input com lista customizada respeita', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      projetos_selecionados: [
+        { codigo: 'arquitetonico', nome: 'Arquitetonico', ordem: 1, selecionado: true, detalhamento_entrega: 'Custom' },
+      ],
+    }));
+    expect(r.projeto_executivo.projetos_selecionados).toHaveLength(1);
+    expect(r.custos.secao_1_projetos[0]).toContain('Arquitetonico');
+    expect(r.custos.secao_1_projetos[0]).toContain('Custom');
+  });
+});
+
+describe('8. Estrutura do retorno (interface ResultadoCalculo + extra)', () => {
+  it('retorna custos completos + projeto_executivo extra', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.custos.secao_1_projetos).toBeInstanceOf(Array);
+    expect(r.custos.secao_2_taxas).toBeInstanceOf(Array);
+    expect(r.custos.secao_3_honorarios).toBeInstanceOf(Array);
+    expect(r.custos.condicoes_pagamento).toBeInstanceOf(Array);
+    expect(r.custos.secao_4_checklist).toBeInstanceOf(Array);
+    expect(r.custos.secao_5_total).toBeGreaterThan(0);
+    expect(r.custos.avisos).toBeInstanceOf(Array);
+    expect(r.projeto_executivo).toBeDefined();
+    expect(r.projeto_executivo.cno_observacao).toMatch(/CNO/);
+    expect(r.projeto_executivo.cno_observacao).toMatch(/Alvara/i);
+  });
+
+  it('condicoes_pagamento somam ao valor_total (40/40/20)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    const soma = r.custos.condicoes_pagamento!.reduce((s, c) => s + c.valor, 0);
+    expect(round2(soma)).toBe(r.projeto_executivo.valor_total);
+  });
+});
+
+describe('9. Defaults exportados estaveis', () => {
+  it('valores default conhecidos', () => {
+    expect(DEFAULTS_PROJETO_EXECUTIVO.VALOR_M2).toBe(25.00);
+    expect(DEFAULTS_PROJETO_EXECUTIVO.TAXA_ESBOCO).toBe(750.00);
+    expect(DEFAULTS_PROJETO_EXECUTIVO.ART_VALOR).toBe(233.94);
+    expect(DEFAULTS_PROJETO_EXECUTIVO.TRT_VALOR).toBe(93.40);
+    expect(DEFAULTS_PROJETO_EXECUTIVO.AREA_LIMITE_TRT).toBe(80.00);
+  });
+
+  it('PROJETOS_DEFAULT tem 7 itens com NBRs', () => {
+    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO).toHaveLength(7);
+    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'arquitetonico')?.detalhamento_entrega)
+      .toMatch(/NBR 13531/);
+    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'hidraulico')?.detalhamento_entrega)
+      .toMatch(/NBR 5626/);
+    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'eletrico')?.detalhamento_entrega)
+      .toMatch(/NBR 5410/);
+    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'estrutural')?.detalhamento_entrega)
+      .toMatch(/NBR 6118/);
+  });
+});


### PR DESCRIPTION
…tetonico + complementares

Implementa o 8o subtipo de Proposta de Consultoria (ao lado de Averbacao, Georref, Desmembramento, Remembramento, Retificacao, PTAM): PROJETO EXECUTIVO de arquitetura + complementares (hidraulico, sanitario, eletrico, estrutural, PCI, mapa de situacao).

DECISAO ARQUITETURAL: REUSO TOTAL — em vez das 3-4 tabelas isoladas que o brief sugeria, segue o padrao existente:
- subtipo_consultoria (VARCHAR 40) += 'projeto_executivo'. Sem ALTER ENUM.
- dados_imovel JSON guarda area, valor_m2, projetos_selecionados, alvara, placa, taxa_esboco, etc.
- custos_calculados JSON guarda secao_1/2/3/4/5, condicoes_pagamento, avisos.
- proposta_anexos (BLOB no DB) ja serve croqui PDF + imagens.
- Numeracao mantida PROP-AAAA-NNNN-Rx (compartilhada com outras propostas).
- Endpoints genericos (/preview, /:id/pdf, /:id/enviar-whatsapp, /:id/assinar, /v/:hash/pdf) atendem TODOS os subtipos — sem duplicacao.

ENGINE (src/services/pricing/projetoExecutivo.ts):
- calcularProjetoExecutivo(input) — pura, sem DB
- area_construir × valor_m2 = valor_projetos (item unico, pacote completo)
- ART/TRT AUTO por area: >80m² -> ART (R$ 233,94 default, CREA-MA, Romatec subcontrata); <=80m² -> TRT (R$ 93,40, CFT/MA, Jose Romario emite direto). Override manual respeitado (responsabilidade_auto: false + tipo).
- Alvara e Placa: opcionais, valor zerado se desmarcado.
- Taxa esboco R$ 750: INFORMATIVA, NUNCA soma ao subtotal/valor_total.
- Desconto: subtrai do subtotal.
- Condicoes de pagamento sugeridas: 40/40/20.
- PROJETOS_DEFAULT com 7 itens + detalhamentos com NBRs (13531, 13532, 5626, 8160, 10844, 5410, 6118, 6122, 9077) e referencias regulatorias (CFT/MA, CREA-MA, CBMMA, Equatorial Maranhao).

PDF HELPER (renderProjetoExecutivoBody em propostasConsultoria.ts):
- Secao 1: Objeto + area em m²
- Secao 2: Imovel/Obra (endereco, cidade, tipo)
- Secao 3: ETAPA PRELIMINAR — box amarelo gigante explicando a Hora Tecnica R$ 750, cobranca CONDICIONAL, justificativa juridica completa
- Secao 4: Projetos a Entregar (so os marcados, com detalhamento)
- Secao 5: ORCAMENTO (tabela honorario + taxas + SUBTOTAL + Desconto + box verde VALOR TOTAL). Nota de rodape relembra a taxa esboco fora do total.
- Secao 6: Condicoes de Pagamento
- Secao 7: Documentos do Cliente (checklist)
- Secao 8: Avisos (taxa esboco, CNO, ART vs TRT, etc.)
- Secao 9: Foro e Validade

FORM HTML (renderConsultoriaFormProjetoExecutivo em obras.html):
- Card "📐 Projeto Executivo" no grid de subtipos (apos PTAM)
- Cliente + endereco_obra + cidade/UF + tipo_edificacao
- Area + R$/m² com VALOR projetos auto-recalculado
- 7 checkboxes de projetos com <details> pra editar detalhamento
- ART/TRT auto-toggle por area + aviso amarelo "ART exige Eng/Arq CREA" quando ART selecionada/auto-selecionada
- Alvara + Placa toggles com valores editaveis
- Box amarelo "Hora Tecnica R$ 750" com explicacao curta + campo editavel
- Resumo dinamico ao lado do form
- Prazo, forma pagamento, observacoes
- subtipo entra em SUBTIPOS_EDITAVEIS pra permitir edicao apos criacao

TESTES (src/test/projeto-executivo-engine.test.ts — 28 tests):
1. round2 HALF_UP (3 tests)
2. Calculo area × R$/m² (4 tests, inclui rejeicao de valores invalidos)
3. ART/TRT auto em 80m² (4 tests: 79=TRT, 80=TRT, 80.01=ART, 200=ART)
4. Override manual (3 tests: forca ART em area pequena, TRT em area grande, valor override)
5. Taxa esboco fora do total (3 tests)
6. Alvara/placa opcionais (3 tests)
7. Desconto subtrai (2 tests)
8. Projetos selecionados (2 tests: default vs custom)
9. Estrutura do retorno + condicoes 40/40/20 fechando exato
10. Constantes exportadas estaveis

Total: 592 passing / 1 skipped / 0 failures (era 564 -> +28).

Validacao manual pos-deploy:
1. /obras -> Nova Proposta -> aparece "📐 Projeto Executivo" no grid
2. Form: digita area 100m², R$/m² 25 -> Valor Projetos R$ 2.500
3. ART/TRT toggla automaticamente em 80m² (verifica aviso amarelo aparece em ART)
4. Box amarelo R$ 750 visivel e edita
5. Preview calcula correto. Cria proposta.
6. PDF mostra todas as 9 secoes, box taxa amarelo gigante, tabela orcamento, nota de rodape sobre taxa fora do total
7. Anexar croqui PDF + foto via fluxo de anexos ja existente — vem mesclado no PDF final pelo gerarPdfPropostaConsultoriaComAnexos (v3.23.10)