### PR TITLE
feat(projeto-executivo-v2): 7 ajustes UX + reestruturacao financeira …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.5",
+  "version": "3.24.6",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -272,7 +272,15 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
       input.gestor_nome ?? null,
       input.gestor_telefone ?? null,
       JSON.stringify(input.dados_imovel),
-      JSON.stringify(resultado.custos),
+      // v3.24.6: pra projeto_executivo o resultado tem campo extra
+      // `projeto_executivo` com a estrutura nova (honorarios + despesas +
+      // forma_pagamento). Inclui no custos_calculados pra renderer ler.
+      JSON.stringify({
+        ...resultado.custos,
+        ...((resultado as unknown as { projeto_executivo?: unknown }).projeto_executivo
+          ? { projeto_executivo: (resultado as unknown as { projeto_executivo?: unknown }).projeto_executivo }
+          : {}),
+      }),
       JSON.stringify(resultado.fontes),
     ]
   );
@@ -595,64 +603,158 @@ export function renderProjetoExecutivoBody(
   });
   doc.moveDown(0.4);
 
-  // ── 5. ORCAMENTO (tabela) ─────────────────────────────────────────────
+  // ── 5. ORCAMENTO — REESTRUTURADO em v3.24.6 ─────────────────────────
+  // DUAS TABELAS DISTINTAS:
+  //   🅰 HONORARIOS TECNICOS (Romatec)        → parcelas 50/50
+  //   🅱 DESPESAS ADMINISTRATIVAS (a parte)   → fora das parcelas
+  // Bloco RESUMO no fim somando os 2 + INVESTIMENTO TOTAL DA OBRA.
   if (doc.y > 600) doc.addPage();
   doc.x = COL_X_INI;
-  doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('5. Orcamento');
+
+  // Le os campos consolidados do projeto_executivo gravados em custos
+  const pe = (di.projeto_executivo as Record<string, unknown> | undefined) ||
+             (custos as unknown as { projeto_executivo?: Record<string, unknown> }).projeto_executivo;
+  const honorarios = pe?.honorarios as { valor_projetos: number; responsabilidade_tipo: string; responsabilidade_valor: number; subtotal_honorarios: number; desconto_honorarios: number; total_honorarios: number; parcela_inicial: number; parcela_final: number; } | undefined;
+  const despesas = pe?.despesas_administrativas as { diligencia_secretaria: { incluir: boolean; valor: number }; taxa_alvara_municipio: { incluir: boolean; valor: number }; placa_obra: { incluir: boolean; valor: number }; subtotal_despesas: number; } | undefined;
+  const formaPag = pe?.forma_pagamento as { texto_renderizado: string; tag: string; } | undefined;
+
+  const colDesc = COL_X_INI + 8;
+  const colValor = COL_X_FIM - 90;
+
+  // ─── 🅰 TABELA HONORARIOS TECNICOS ──────────────────────────────────
+  doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('5. Honorarios Tecnicos');
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.3);
 
-  const allItens: Array<{ desc: string; valor: number; tipo: 'honorario' | 'taxa' | 'total' | 'subtotal' | 'desconto' }> = [];
-  custos.secao_3_honorarios.forEach(h => allItens.push({ desc: h.descricao, valor: h.valor, tipo: 'honorario' }));
-  custos.secao_2_taxas.forEach(t => allItens.push({ desc: t.descricao, valor: t.valor, tipo: 'taxa' }));
-  const subtotal = allItens.reduce((s, x) => s + x.valor, 0);
-  const desconto = (custos as unknown as { desconto?: number }).desconto ?? 0;
-
-  // Headers
-  const colDesc = COL_X_INI + 8;
-  const colValor = COL_X_FIM - 90;
   doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold');
-  const headerY = doc.y;
-  doc.text('Descricao', colDesc, headerY, { width: colValor - colDesc - 8 });
-  doc.text('Valor', colValor, headerY, { width: 80, align: 'right' });
+  const hHeaderY = doc.y;
+  doc.text('Descricao', colDesc, hHeaderY, { width: colValor - colDesc - 8 });
+  doc.text('Valor', colValor, hHeaderY, { width: 80, align: 'right' });
   doc.moveDown(0.5);
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ddd').lineWidth(0.5).stroke();
   doc.moveDown(0.2);
 
-  allItens.forEach((it) => {
+  // Linhas de honorarios (secao_3_honorarios = projetos + ART/TRT)
+  custos.secao_3_honorarios.forEach((h) => {
     const y0 = doc.y;
     doc.font('Helvetica').fontSize(9.5).fillColor('#222')
-       .text(it.desc, colDesc, y0, { width: colValor - colDesc - 8 });
+       .text(h.descricao, colDesc, y0, { width: colValor - colDesc - 8 });
     doc.font('Helvetica-Bold').fillColor(corHex)
-       .text(formatBRL(it.valor), colValor, y0, { width: 80, align: 'right' });
+       .text(formatBRL(h.valor), colValor, y0, { width: 80, align: 'right' });
     doc.moveDown(0.15);
   });
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#888').lineWidth(0.6).stroke();
   doc.moveDown(0.2);
 
-  // SUBTOTAL
-  const subY = doc.y;
+  // SUBTOTAL HONORARIOS
+  const subHonY = doc.y;
   doc.fontSize(10).fillColor('#111').font('Helvetica-Bold')
-     .text('SUBTOTAL', colDesc, subY, { width: colValor - colDesc - 8 });
-  doc.fillColor('#111').text(formatBRL(subtotal), colValor, subY, { width: 80, align: 'right' });
+     .text('SUBTOTAL HONORARIOS', colDesc, subHonY, { width: colValor - colDesc - 8 });
+  doc.text(formatBRL(honorarios?.subtotal_honorarios ?? 0), colValor, subHonY, { width: 80, align: 'right' });
   doc.moveDown(0.2);
 
-  if (desconto > 0) {
+  if ((honorarios?.desconto_honorarios ?? 0) > 0) {
     const dY = doc.y;
     doc.fontSize(9.5).fillColor('#444').font('Helvetica')
        .text('Desconto', colDesc, dY, { width: colValor - colDesc - 8 });
-    doc.text('- ' + formatBRL(desconto), colValor, dY, { width: 80, align: 'right' });
+    doc.text('- ' + formatBRL(honorarios!.desconto_honorarios), colValor, dY, { width: 80, align: 'right' });
     doc.moveDown(0.2);
   }
 
-  // VALOR TOTAL (box verde)
-  const totalBoxY = doc.y + 4;
-  const totalBoxH = 26;
-  doc.rect(COL_X_INI, totalBoxY, COL_W, totalBoxH).fillAndStroke(COR_VERDE_BG, COR_VERDE_BORDA);
+  // TOTAL HONORARIOS (box verde)
+  const totalHonBoxY = doc.y + 4;
+  const totalHonBoxH = 26;
+  doc.rect(COL_X_INI, totalHonBoxY, COL_W, totalHonBoxH).fillAndStroke(COR_VERDE_BG, COR_VERDE_BORDA);
   doc.fontSize(11).fillColor('#14532d').font('Helvetica-Bold')
-     .text('VALOR TOTAL', colDesc, totalBoxY + 8, { width: colValor - colDesc - 8 });
-  doc.text(formatBRL(custos.secao_5_total), colValor, totalBoxY + 8, { width: 80, align: 'right' });
-  doc.y = totalBoxY + totalBoxH + 6;
+     .text('TOTAL HONORARIOS', colDesc, totalHonBoxY + 8, { width: colValor - colDesc - 8 });
+  doc.text(formatBRL(honorarios?.total_honorarios ?? 0), colValor, totalHonBoxY + 8, { width: 80, align: 'right' });
+  doc.y = totalHonBoxY + totalHonBoxH + 6;
+
+  // PARCELAMENTO HONORARIOS — usa forma_pagamento.texto_renderizado quando tag != personalizada
+  if (honorarios) {
+    if (doc.y > 700) doc.addPage();
+    doc.x = COL_X_INI;
+    doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+       .text('► PARCELAMENTO DOS HONORARIOS', COL_X_INI, doc.y, { width: COL_W });
+    doc.moveDown(0.2);
+    doc.fontSize(9.5).fillColor('#222').font('Helvetica')
+       .text(formaPag?.texto_renderizado || 'A combinar entre as partes.', COL_X_INI + 8, doc.y, {
+         width: COL_W - 16, align: 'justify', continued: false,
+       });
+    doc.moveDown(0.6);
+  }
+
+  // ─── 🅱 TABELA DESPESAS ADMINISTRATIVAS (so se houver) ──────────────
+  const temDespesas = !!(despesas && despesas.subtotal_despesas > 0);
+  if (temDespesas && despesas) {
+    if (doc.y > 600) doc.addPage();
+    doc.x = COL_X_INI;
+    doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('6. Despesas Administrativas (pagas a parte)');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.3);
+
+    doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold');
+    const dHeaderY = doc.y;
+    doc.text('Descricao', colDesc, dHeaderY, { width: colValor - colDesc - 8 });
+    doc.text('Valor', colValor, dHeaderY, { width: 80, align: 'right' });
+    doc.moveDown(0.5);
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ddd').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+
+    // Linhas de despesas — secao_2_taxas (so as marcadas)
+    custos.secao_2_taxas.forEach((t) => {
+      const y0 = doc.y;
+      doc.font('Helvetica').fontSize(9.5).fillColor('#222')
+         .text(t.descricao, colDesc, y0, { width: colValor - colDesc - 8 });
+      doc.font('Helvetica-Bold').fillColor(corHex)
+         .text(formatBRL(t.valor), colValor, y0, { width: 80, align: 'right' });
+      doc.moveDown(0.15);
+    });
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#888').lineWidth(0.6).stroke();
+    doc.moveDown(0.2);
+
+    // SUBTOTAL DESPESAS
+    const totalDespY = doc.y;
+    doc.fontSize(10).fillColor('#111').font('Helvetica-Bold')
+       .text('TOTAL DESPESAS ADMINISTRATIVAS', colDesc, totalDespY, { width: colValor - colDesc - 8 });
+    doc.text(formatBRL(despesas.subtotal_despesas), colValor, totalDespY, { width: 80, align: 'right' });
+    doc.moveDown(0.4);
+
+    // Nota de rodape
+    doc.fontSize(8.5).fillColor('#666').font('Helvetica-Oblique')
+       .text(
+         'Os valores das Despesas Administrativas NAO compoem os Honorarios Tecnicos e NAO estao sujeitos ao parcelamento descrito acima. Sao pagos pelo CONTRATANTE diretamente aos orgaos competentes ou reembolsados a CONTRATADA mediante apresentacao dos comprovantes.',
+         COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
+       );
+    doc.moveDown(0.6);
+  }
+
+  // ─── BLOCO RESUMO FINAL (INVESTIMENTO TOTAL DA OBRA) ────────────────
+  if (doc.y > 680) doc.addPage();
+  doc.x = COL_X_INI;
+  const resumoBoxY = doc.y + 4;
+  const resumoBoxH = temDespesas ? 78 : 38;
+  doc.rect(COL_X_INI, resumoBoxY, COL_W, resumoBoxH).fillAndStroke('#1e3a8a', '#3b82f6');
+  let resY = resumoBoxY + 8;
+  if (temDespesas) {
+    doc.fontSize(10).fillColor('#dbeafe').font('Helvetica')
+       .text('TOTAL HONORARIOS TECNICOS:', COL_X_INI + 8, resY, { width: COL_W - 100 });
+    doc.fillColor('#fff').font('Helvetica-Bold')
+       .text(formatBRL(honorarios?.total_honorarios ?? 0), COL_X_FIM - 100, resY, { width: 90, align: 'right' });
+    resY += 14;
+    doc.fontSize(10).fillColor('#dbeafe').font('Helvetica')
+       .text('TOTAL DESPESAS ADMINISTRATIVAS:', COL_X_INI + 8, resY, { width: COL_W - 100 });
+    doc.fillColor('#fff').font('Helvetica-Bold')
+       .text(formatBRL(despesas?.subtotal_despesas ?? 0), COL_X_FIM - 100, resY, { width: 90, align: 'right' });
+    resY += 14;
+    doc.moveTo(COL_X_INI + 8, resY).lineTo(COL_X_FIM - 8, resY).strokeColor('#60a5fa').lineWidth(0.7).stroke();
+    resY += 4;
+  }
+  doc.fontSize(12).fillColor('#fff').font('Helvetica-Bold')
+     .text('INVESTIMENTO TOTAL DA OBRA:', COL_X_INI + 8, resY, { width: COL_W - 110 });
+  doc.fontSize(13).fillColor('#fbbf24')
+     .text(formatBRL(custos.secao_5_total), COL_X_FIM - 110, resY, { width: 100, align: 'right' });
+  doc.y = resumoBoxY + resumoBoxH + 6;
 
   doc.fontSize(8.5).fillColor('#666').font('Helvetica-Oblique')
      .text(
@@ -660,29 +762,6 @@ export function renderProjetoExecutivoBody(
        COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
      );
   doc.moveDown(0.6);
-
-  // ── 6. CONDICOES DE PAGAMENTO ─────────────────────────────────────────
-  if (custos.condicoes_pagamento && custos.condicoes_pagamento.length > 0) {
-    if (doc.y > 660) doc.addPage();
-    doc.x = COL_X_INI;
-    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('6. Condicoes de Pagamento');
-    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
-    doc.moveDown(0.3);
-    custos.condicoes_pagamento.forEach((cp) => {
-      const y0 = doc.y;
-      doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
-         .text(cp.rotulo, COL_X_INI + 8, y0, { width: COL_W - 100 });
-      doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
-         .text(formatBRL(cp.valor), COL_X_FIM - 90, y0, { width: 80, align: 'right' });
-      if (cp.descricao) {
-        doc.fontSize(8.5).fillColor('#666').font('Helvetica')
-           .text(cp.descricao, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
-      }
-      doc.font('Helvetica').fillColor('#111');
-      doc.moveDown(0.2);
-    });
-    doc.moveDown(0.4);
-  }
 
   // ── 7. DOCUMENTOS DO CLIENTE ──────────────────────────────────────────
   if (doc.y > 660) doc.addPage();

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -8601,9 +8601,28 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
 
       <p style="margin:4px 0 0; font-size:13px; color:var(--gold);">📐 Projeto Executivo — Arquitetura + Complementares · NBR 13531/13532, 5626, 8160, 5410, 6118, 9077</p>
 
+      <!-- v3.24.6 Ajuste 1: botao Novo Cliente -->
       <div style="margin-top:12px;">
         <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Cliente</p>
-        <label>Cliente <select id="peCli" style="width:100%;"><option value="">— Selecione —</option>${cliOpts}</select></label>
+        <div style="display:flex; gap:8px; align-items:flex-end;">
+          <label style="flex:1;">Cliente <select id="peCli" style="width:100%;"><option value="">— Selecione —</option>${cliOpts}</select></label>
+          <button type="button" id="peCliNovo" class="btn-secondary" style="min-height:44px; padding:8px 12px; white-space:nowrap;">➕ Novo</button>
+        </div>
+      </div>
+
+      <!-- v3.24.6 Ajuste 7: caixa amarela destacada da taxa R$ 750 (ANTES dos honorarios) -->
+      <div style="margin-top:14px; display:flex; gap:12px; padding:14px 16px; background:rgba(212,184,0,0.10); border:2px solid var(--gold); border-radius:8px;">
+        <div style="font-size:28px;">⚠️</div>
+        <div style="flex:1; min-width:0;">
+          <p style="margin:0; font-weight:700; color:var(--gold); font-size:14px;">
+            Hora Técnica de Anteprojeto: R$
+            <input id="peTax" type="number" step="0.01" min="0" value="${di.taxa_esboco||750}" style="width:90px; display:inline-block; background:rgba(0,0,0,0.3); color:var(--gold); border:1px solid var(--gold); border-radius:4px; padding:2px 6px;">
+          </p>
+          <p style="margin:6px 0 0; font-size:12px; color:var(--text-muted);">
+            Cobrança <strong>CONDICIONAL</strong> — só será cobrada se o cliente <strong>NÃO prosseguir</strong> com os projetos executivos após o esboço.
+            Este valor <u>NÃO está somado</u> ao Total de Honorários nem ao Investimento Total da Obra.
+          </p>
+        </div>
       </div>
 
       <div style="margin-top:12px;">
@@ -8658,22 +8677,68 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
         <p id="peArtAviso" style="margin:6px 0 0; padding:8px; background:rgba(251,191,36,0.12); border-left:3px solid var(--gold); border-radius:4px; font-size:11px; color:var(--gold); display:none;">⚠️ ART exige Engenheiro/Arquiteto CREA-MA ou CAU. Romatec subcontrata profissional habilitado mediante aditivo contratual.</p>
       </div>
 
-      <div style="margin-top:12px;">
-        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Itens Opcionais</p>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; align-items:center;">
-          <label style="display:flex; gap:6px; align-items:center;"><input type="checkbox" id="peAlvI" ${di.alvara_incluir!==false?'checked':''}> Alvará de Construção</label>
-          <label>Valor R$ <input id="peAlvV" type="number" step="0.01" min="0" value="${di.alvara_valor||0}" style="width:100%;"></label>
-          <label style="display:flex; gap:6px; align-items:center;"><input type="checkbox" id="pePlcI" ${di.placa_incluir!==false?'checked':''}> Placa de Obra</label>
-          <label>Valor R$ <input id="pePlcV" type="number" step="0.01" min="0" value="${di.placa_valor||0}" style="width:100%;"></label>
+      <!-- v3.24.6 Ajuste 2+3+5: Despesas Administrativas (a parte, NAO entram nos honorarios) -->
+      <div style="margin-top:14px; padding:12px; border:1px solid var(--border); border-radius:8px; background:var(--bg-elev);">
+        <p style="margin:0 0 8px; font-weight:600; color:var(--neon); font-size:13px;">💼 Despesas Administrativas <span style="color:var(--text-muted); font-weight:400; font-size:11px;">(opcionais — pagas a parte, fora das parcelas 50/50)</span></p>
+
+        <!-- DILIGENCIA SECRETARIA (NOVO) -->
+        <div style="border:1px solid var(--border); border-radius:6px; padding:8px; margin-bottom:8px;">
+          <label style="display:flex; gap:8px; align-items:center; cursor:pointer;">
+            <input type="checkbox" id="peDilI" ${di.diligencia_secretaria?.incluir?'checked':''}>
+            <strong style="font-size:13px;">Diligência de Protocolo na Secretaria de Habitação</strong>
+          </label>
+          <p style="margin:6px 0 4px; font-size:11px; color:var(--text-muted);">
+            Inclui impressão do acervo em 2 vias, certidão do imóvel, certidão negativa IPTU, protocolo físico, acompanhamento, recolhimento da taxa, e retirada do Alvará expedido.
+          </p>
+          <label style="font-size:12px;">Valor R$ <input id="peDilV" type="number" step="0.01" min="0" value="${di.diligencia_secretaria?.valor||0}" style="width:120px;"></label>
+        </div>
+
+        <!-- TAXA ALVARA -->
+        <div style="border:1px solid var(--border); border-radius:6px; padding:8px; margin-bottom:8px;">
+          <label style="display:flex; gap:8px; align-items:center; cursor:pointer;">
+            <input type="checkbox" id="peAlvI" ${(di.taxa_alvara_municipio?.incluir ?? di.alvara_incluir)?'checked':''}>
+            <strong style="font-size:13px;">Taxa de Expedição de Alvará de Construção</strong>
+          </label>
+          <p style="margin:6px 0 4px; font-size:11px; color:var(--text-muted);">
+            Valor cobrado pela Prefeitura Municipal de Açailândia conforme legislação vigente. Pago direto pelo cliente ou reembolsado mediante comprovante.
+          </p>
+          <label style="font-size:12px;">Valor R$ <input id="peAlvV" type="number" step="0.01" min="0" value="${di.taxa_alvara_municipio?.valor || di.alvara_valor || 0}" style="width:120px;"></label>
+        </div>
+
+        <!-- PLACA -->
+        <div style="border:1px solid var(--border); border-radius:6px; padding:8px;">
+          <label style="display:flex; gap:8px; align-items:center; cursor:pointer;">
+            <input type="checkbox" id="pePlcI" ${(di.placa_obra?.incluir ?? di.placa_incluir)?'checked':''}>
+            <strong style="font-size:13px;">Confecção e Instalação da Placa de Obra</strong>
+          </label>
+          <p style="margin:6px 0 4px; font-size:11px; color:var(--text-muted);">
+            Arte gráfica conforme exigências CREA/CFT e legislação municipal. Envio pra gráfica + instalação no canteiro antes do início da obra.
+          </p>
+          <label style="font-size:12px;">Valor R$ <input id="pePlcV" type="number" step="0.01" min="0" value="${di.placa_obra?.valor || di.placa_valor || 0}" style="width:120px;"></label>
         </div>
       </div>
 
-      <div style="margin-top:12px; padding:10px; background:rgba(251,191,36,0.10); border-left:4px solid var(--gold); border-radius:6px;">
-        <p style="margin:0; font-weight:600; color:var(--gold); font-size:13px;">⚠️ Hora Técnica de Anteprojeto: R$ <span id="peTxLbl">750,00</span> <span style="font-weight:400; font-size:11px;">(NÃO incluída no Valor Total)</span></p>
-        <p style="margin:4px 0 0; font-size:11px; color:var(--text-muted);">Cobrança CONDICIONAL — apenas se o cliente NÃO prosseguir com os projetos executivos após o esboço/anteprojeto. Se prosseguir, é absorvida pelo contrato.</p>
-        <label style="margin-top:6px; display:block; font-size:11px;">Valor da Hora Técnica R$
-          <input id="peTax" type="number" step="0.01" min="0" value="${di.taxa_esboco||750}" style="width:120px;">
-        </label>
+      <!-- v3.24.6 Ajuste 4: Forma de Pagamento via TAGS clicaveis -->
+      <div style="margin-top:14px;">
+        <p style="margin:0 0 8px; font-weight:600; color:var(--neon); font-size:13px;">💳 Forma de Pagamento dos Honorários</p>
+        <div id="peTagsContainer" style="display:flex; flex-wrap:wrap; gap:8px;">
+          ${[
+            { tag: 'integral',     icon: '💯', label: 'À Vista (100%)' },
+            { tag: 'sinal_mais_1', icon: '✋', label: '50% Sinal + 50% Entrega' },
+            { tag: 'sinal_mais_2', icon: '✌',  label: 'Sinal + 2x na Entrega' },
+            { tag: 'duas_vezes',   icon: '2️⃣', label: '2x (50% + 50%)' },
+            { tag: 'personalizada', icon: '✏', label: 'Personalizada' },
+          ].map(t => `
+            <button type="button" class="peTag" data-tag="${t.tag}" style="padding:8px 14px; border:2px solid var(--border); background:var(--bg-elev); color:var(--text); border-radius:24px; cursor:pointer; font-size:12px; min-height:44px;">
+              ${t.icon} ${t.label}
+            </button>
+          `).join('')}
+        </div>
+        <textarea id="peFormaCustom" placeholder="Descreva a forma de pagamento personalizada..." style="width:100%; margin-top:8px; min-height:50px; display:none;">${escape(di.forma_pagamento_custom || '')}</textarea>
+        <div style="margin-top:10px; padding:10px; background:var(--bg-elev); border-left:3px solid var(--neon); border-radius:4px;">
+          <p style="margin:0; font-size:11px; color:var(--text-muted);">Pré-visualização:</p>
+          <p id="peFormaPreview" style="margin:4px 0 0; font-size:12px; color:var(--text);">—</p>
+        </div>
       </div>
 
       <div style="margin-top:12px;">
@@ -8682,10 +8747,22 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
       </div>
 
       <div style="margin-top:12px;">
-        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Prazos e Condições</p>
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📋 Prazos e Observações</p>
         <label>Prazo de entrega (dias) <input id="pePrazo" type="number" min="1" value="${di.prazo_entrega_dias||30}" style="width:100%;"></label>
-        <label>Forma de pagamento <textarea id="pePag" style="width:100%; min-height:50px;">${escape(di.forma_pagamento||'')}</textarea></label>
         <label>Observações <textarea id="peObs" style="width:100%; min-height:50px;">${escape(di.observacoes||'')}</textarea></label>
+      </div>
+
+      <!-- v3.24.6 Ajuste 6: Dropzone de anexos (croqui PDF + imagens) -->
+      <div style="margin-top:14px;">
+        <p style="margin:0 0 8px; font-weight:600; color:var(--neon); font-size:13px;">📎 Anexos da Proposta</p>
+        <p style="margin:0 0 8px; font-size:11px; color:var(--text-muted);">Croqui arquitetônico, imagens renderizadas, documentos. PDF/JPG/PNG/WebP. Máx 10 arquivos · 15MB cada · 50MB total.</p>
+        <div id="peDropzone" style="border:2px dashed var(--border); border-radius:8px; padding:20px; text-align:center; cursor:pointer; background:var(--bg-elev); min-height:80px;">
+          <input type="file" id="peAnexosInput" multiple accept="application/pdf,image/jpeg,image/png,image/webp" style="display:none;">
+          <div style="font-size:24px;">📤</div>
+          <div style="font-size:13px; font-weight:600; margin-top:4px;">Clique ou arraste arquivos</div>
+          <div style="font-size:10px; color:var(--text-muted); margin-top:2px;">PDF · JPG · PNG · WebP</div>
+        </div>
+        <ul id="peAnexosLista" style="list-style:none; padding:0; margin:8px 0 0;"></ul>
       </div>
 
       <div style="margin-top:16px;">
@@ -8696,6 +8773,68 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
 
   // Handlers
   if (cache.cliId) document.getElementById('peCli').value = cache.cliId;
+
+  // v3.24.6 Ajuste 1: botao Novo Cliente
+  document.getElementById('peCliNovo').onclick = async () => {
+    try {
+      const novo = await abrirModalNovoCliente();
+      if (novo && novo.id) {
+        await loadPropostasClientes();
+        const sel = document.getElementById('peCli');
+        sel.innerHTML = '<option value="">— Selecione —</option>' +
+          state.propostasClientes.map(c =>
+            `<option value="${c.id}">${escape(c.nome)}${c.cpf_cnpj ? ' · ' + escape(c.cpf_cnpj) : ''}</option>`
+          ).join('');
+        sel.value = String(novo.id);
+      }
+    } catch (e) { alert('Erro ao cadastrar cliente: ' + e.message); }
+  };
+
+  // v3.24.6 Ajuste 4: tags clicaveis de pagamento — estado local
+  let pePagTag = di.forma_pagamento_tag || 'sinal_mais_1';
+  function renderTagsPagamento() {
+    document.querySelectorAll('.peTag').forEach(b => {
+      const active = b.dataset.tag === pePagTag;
+      b.style.background = active ? 'var(--neon)' : 'var(--bg-elev)';
+      b.style.color = active ? '#0a1a0a' : 'var(--text)';
+      b.style.borderColor = active ? 'var(--neon)' : 'var(--border)';
+      b.style.fontWeight = active ? '700' : '400';
+    });
+    document.getElementById('peFormaCustom').style.display = pePagTag === 'personalizada' ? 'block' : 'none';
+  }
+  document.querySelectorAll('.peTag').forEach(b => b.onclick = () => {
+    pePagTag = b.dataset.tag;
+    renderTagsPagamento();
+    recalcResumo();
+  });
+  document.getElementById('peFormaCustom').addEventListener('input', recalcResumo);
+  renderTagsPagamento();
+
+  // Helper local: render texto da forma_pagamento por tag (espelho da engine)
+  function renderFormaPagamentoLocal(tag, totalHonorarios, custom) {
+    const fmtBR = (v) => v.toLocaleString('pt-BR', { minimumFractionDigits:2, maximumFractionDigits:2 });
+    const r2 = (n) => Math.round((n + Number.EPSILON) * 100) / 100;
+    switch (tag) {
+      case 'integral':
+        return `Pagamento à vista no valor de R$ ${fmtBR(totalHonorarios)} na assinatura do contrato.`;
+      case 'sinal_mais_1': {
+        const m = r2(totalHonorarios * 0.5);
+        return `Pagamento em 2 (duas) parcelas: R$ ${fmtBR(m)} como SINAL no início e R$ ${fmtBR(totalHonorarios - m)} na ENTREGA FINAL.`;
+      }
+      case 'sinal_mais_2': {
+        const sinal = r2(totalHonorarios * 0.5);
+        const rest = r2(totalHonorarios - sinal);
+        const meio = r2(rest / 2);
+        return `Pagamento em 3 (três) parcelas: R$ ${fmtBR(sinal)} sinal; R$ ${fmtBR(meio)} no anteprojeto aprovado; R$ ${fmtBR(rest - meio)} na entrega final.`;
+      }
+      case 'duas_vezes': {
+        const p1 = r2(totalHonorarios * 0.5);
+        return `Pagamento em 2 (duas) parcelas: R$ ${fmtBR(p1)} na assinatura e R$ ${fmtBR(totalHonorarios - p1)} na entrega final.`;
+      }
+      case 'personalizada':
+        return (custom && custom.trim()) || 'A combinar entre as partes.';
+    }
+  }
 
   function recalcResumo() {
     const area = Number(document.getElementById('peArea').value) || 0;
@@ -8709,7 +8848,6 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
       const tipo = area > 80 ? 'ART' : 'TRT';
       tipoSel.value = tipo;
       tipoSel.disabled = true;
-      // valor sugerido
       document.getElementById('peRtVlr').value = tipo === 'ART' ? 233.94 : 93.40;
     } else {
       tipoSel.disabled = false;
@@ -8718,29 +8856,88 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
     document.getElementById('peArtAviso').style.display = tipoAtual === 'ART' ? 'block' : 'none';
 
     const rtVlr = Number(document.getElementById('peRtVlr').value) || 0;
+    const dilI = document.getElementById('peDilI').checked;
+    const dilV = dilI ? (Number(document.getElementById('peDilV').value) || 0) : 0;
     const alvI = document.getElementById('peAlvI').checked;
     const alvV = alvI ? (Number(document.getElementById('peAlvV').value) || 0) : 0;
     const plcI = document.getElementById('pePlcI').checked;
     const plcV = plcI ? (Number(document.getElementById('pePlcV').value) || 0) : 0;
-    const tx = Number(document.getElementById('peTax').value) || 0;
-    document.getElementById('peTxLbl').textContent = tx.toFixed(2).replace('.', ',');
 
-    const subtotal = valorProj + rtVlr + alvV + plcV;
+    // v3.24.6: Honorarios (parcelas 50/50) vs Despesas Admin (a parte)
+    const honorarios = valorProj + rtVlr;
+    const despesas = dilV + alvV + plcV;
+    const totalGeral = honorarios + despesas;
+
+    const customTxt = document.getElementById('peFormaCustom').value;
+    const formaTxt = renderFormaPagamentoLocal(pePagTag, honorarios, customTxt);
+    document.getElementById('peFormaPreview').textContent = formaTxt;
+
     document.getElementById('peResumo').innerHTML = `
-      Projetos Executivos: <strong>${fmt(valorProj)}</strong><br>
-      ${tipoAtual}: <strong>${fmt(rtVlr)}</strong><br>
-      Alvará: <strong>${fmt(alvV)}</strong> · Placa: <strong>${fmt(plcV)}</strong><br>
-      <span style="color:var(--gold); font-size:14px;">VALOR TOTAL: <strong>${fmt(subtotal)}</strong></span><br>
-      <span style="color:var(--text-muted); font-size:11px;">+ Hora Técnica condicional ${fmt(tx)} (não somada)</span>
+      <p style="margin:0 0 6px; font-weight:600;">🅰 HONORÁRIOS TÉCNICOS</p>
+      <div style="padding-left:8px;">
+        Projetos: <strong>${fmt(valorProj)}</strong><br>
+        ${tipoAtual}: <strong>${fmt(rtVlr)}</strong><br>
+        <span style="color:var(--neon);">Total Honorários: <strong>${fmt(honorarios)}</strong></span>
+        ${honorarios > 0 ? `<br><span style="color:var(--text-muted); font-size:11px;">Parcela 1 (50%): ${fmt(honorarios * 0.5)} · Parcela 2 (50%): ${fmt(honorarios - Math.round(honorarios * 50) / 100)}</span>` : ''}
+      </div>
+      ${despesas > 0 ? `
+        <p style="margin:10px 0 6px; font-weight:600;">🅱 DESPESAS ADMINISTRATIVAS (à parte)</p>
+        <div style="padding-left:8px;">
+          ${dilV > 0 ? `Diligência: <strong>${fmt(dilV)}</strong><br>` : ''}
+          ${alvV > 0 ? `Alvará: <strong>${fmt(alvV)}</strong><br>` : ''}
+          ${plcV > 0 ? `Placa: <strong>${fmt(plcV)}</strong><br>` : ''}
+          <span style="color:var(--neon);">Total Despesas: <strong>${fmt(despesas)}</strong></span>
+        </div>
+      ` : ''}
+      <hr style="border:0; border-top:1px solid var(--border); margin:10px 0;">
+      <p style="margin:0; color:var(--gold); font-size:15px;">💰 INVESTIMENTO TOTAL DA OBRA: <strong>${fmt(totalGeral)}</strong></p>
     `;
   }
-  ['peArea','peVm2','peRtTipo','peRtVlr','peAlvI','peAlvV','pePlcI','pePlcV','peTax'].forEach(id => {
+  ['peArea','peVm2','peRtTipo','peRtVlr','peDilI','peDilV','peAlvI','peAlvV','pePlcI','pePlcV','peTax'].forEach(id => {
     const el = document.getElementById(id);
     if (el) el.addEventListener('input', recalcResumo);
     if (el && el.type === 'checkbox') el.addEventListener('change', recalcResumo);
   });
   document.getElementById('peRtAuto').addEventListener('change', recalcResumo);
   recalcResumo();
+
+  // v3.24.6 Ajuste 6: Anexos dropzone
+  state.peAnexosPendentes = state.peAnexosPendentes || [];
+  function adicionarAnexosPE(fileList) {
+    const MAX_FILE = 15 * 1024 * 1024;
+    const MAX_TOTAL = 50 * 1024 * 1024;
+    for (const f of fileList) {
+      if (state.peAnexosPendentes.length >= 10) return alert('Limite de 10 anexos atingido.');
+      if (f.size > MAX_FILE) { alert(`"${f.name}" excede 15MB.`); continue; }
+      const total = state.peAnexosPendentes.reduce((s,a) => s + a.file.size, 0);
+      if (total + f.size > MAX_TOTAL) return alert('Total excede 50MB.');
+      state.peAnexosPendentes.push({ file: f, legenda: f.name.replace(/\.[^.]+$/, '') });
+    }
+    renderAnexosLista();
+  }
+  function renderAnexosLista() {
+    const ul = document.getElementById('peAnexosLista');
+    if (state.peAnexosPendentes.length === 0) { ul.innerHTML = ''; return; }
+    ul.innerHTML = state.peAnexosPendentes.map((a, idx) => `
+      <li style="display:flex; gap:8px; align-items:center; padding:6px 8px; background:var(--bg-elev); border:1px solid var(--border); border-radius:4px; margin-bottom:4px;">
+        <span style="font-size:18px;">${a.file.type === 'application/pdf' ? '📄' : '🖼'}</span>
+        <div style="flex:1; min-width:0;">
+          <div style="font-size:12px; font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${escape(a.file.name)}</div>
+          <div style="font-size:10px; color:var(--text-muted);">${(a.file.size/1024/1024).toFixed(2)}MB</div>
+        </div>
+        <button type="button" onclick="state.peAnexosPendentes.splice(${idx},1); document.getElementById('peAnexosLista').dispatchEvent(new Event('refresh'));" style="font-size:11px;">🗑</button>
+      </li>
+    `).join('');
+  }
+  document.getElementById('peAnexosLista').addEventListener('refresh', renderAnexosLista);
+  const dz = document.getElementById('peDropzone');
+  const dzInput = document.getElementById('peAnexosInput');
+  dz.onclick = () => dzInput.click();
+  dzInput.onchange = (e) => adicionarAnexosPE(e.target.files);
+  ['dragenter','dragover'].forEach(ev => dz.addEventListener(ev, e => { e.preventDefault(); dz.style.borderColor = 'var(--neon)'; }));
+  ['dragleave','drop'].forEach(ev => dz.addEventListener(ev, e => { e.preventDefault(); dz.style.borderColor = 'var(--border)'; }));
+  dz.addEventListener('drop', e => { if (e.dataTransfer?.files) adicionarAnexosPE(e.dataTransfer.files); });
+  renderAnexosLista();
 
   document.getElementById('peCalcular').onclick = async () => {
     const btn = document.getElementById('peCalcular');
@@ -8772,13 +8969,24 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
       responsabilidade_auto: document.getElementById('peRtAuto').checked,
       responsabilidade_tipo: document.getElementById('peRtTipo').value,
       responsabilidade_valor: Number(document.getElementById('peRtVlr').value) || 0,
-      alvara_incluir: document.getElementById('peAlvI').checked,
-      alvara_valor: Number(document.getElementById('peAlvV').value) || 0,
-      placa_incluir: document.getElementById('pePlcI').checked,
-      placa_valor: Number(document.getElementById('pePlcV').value) || 0,
+      // v3.24.6: Despesas Administrativas (estrutura nova)
+      diligencia_secretaria: {
+        incluir: document.getElementById('peDilI').checked,
+        valor: Number(document.getElementById('peDilV').value) || 0,
+      },
+      taxa_alvara_municipio: {
+        incluir: document.getElementById('peAlvI').checked,
+        valor: Number(document.getElementById('peAlvV').value) || 0,
+      },
+      placa_obra: {
+        incluir: document.getElementById('pePlcI').checked,
+        valor: Number(document.getElementById('pePlcV').value) || 0,
+      },
       taxa_esboco: Number(document.getElementById('peTax').value) || 750,
+      // v3.24.6: Forma de pagamento via TAG
+      forma_pagamento_tag: pePagTag,
+      forma_pagamento_custom: document.getElementById('peFormaCustom').value.trim(),
       prazo_entrega_dias: Number(document.getElementById('pePrazo').value) || 30,
-      forma_pagamento: document.getElementById('pePag').value.trim(),
       observacoes: document.getElementById('peObs').value.trim(),
       projetos_selecionados,
     };
@@ -9615,7 +9823,31 @@ function renderPreviewConsultoria(r, ctx) {
           dados_imovel: ctx.dados_imovel,
         }),
       });
-      alert('✅ ' + r2.message);
+
+      // v3.24.6: Upload de anexos pendentes (Projeto Executivo, mas funciona pra qualquer subtipo)
+      const anexosPendentes = state.peAnexosPendentes || [];
+      if (anexosPendentes.length > 0 && r2 && (r2.id || r2.proposta_id)) {
+        const propId = r2.id || r2.proposta_id;
+        let uploadOk = 0;
+        for (const a of anexosPendentes) {
+          try {
+            const fd = new FormData();
+            fd.append('arquivo', a.file);
+            if (a.legenda) fd.append('legenda', a.legenda);
+            await fetch('/api/propostas-consultoria/' + propId + '/anexos', {
+              method: 'POST', body: fd, credentials: 'same-origin',
+            });
+            uploadOk++;
+          } catch (uErr) {
+            console.warn('Falha upload anexo:', a.file.name, uErr);
+          }
+        }
+        state.peAnexosPendentes = []; // limpa
+        alert(`✅ ${r2.message}\n📎 ${uploadOk}/${anexosPendentes.length} anexo(s) enviado(s).`);
+      } else {
+        alert('✅ ' + r2.message);
+      }
+
       fecharModal();
       await loadPropostasConsultoria();
       render();

--- a/src/services/pricing/projetoExecutivo.ts
+++ b/src/services/pricing/projetoExecutivo.ts
@@ -1,18 +1,14 @@
 // v3.24.5: motor de calculo de Projeto Executivo (arquitetonico + complementares).
-//
-// Regra de negocio:
-//   Valor projetos = area_construir × valor_m2 (default R$ 25/m²)
-//   ART/TRT auto por area: > 80m² -> ART | <= 80m² -> TRT
-//   ART exige profissional CREA (Romatec subcontrata por aditivo);
-//   TRT pode ser emitida diretamente pelo Jose Romario (Tec. Edificacoes).
-//   Alvara e Placa: opcionais, valores informados ou 0 se desmarcados.
-//   Taxa esboco (R$750): INFORMATIVA — nao soma ao subtotal/total.
-//     Cobrada apenas se cliente desistir apos entrega do anteprojeto.
-//   Desconto: subtrai do subtotal.
+// v3.24.6: REESTRUTURADO em DOIS BLOCOS FINANCEIROS:
+//   🅰 HONORARIOS TECNICOS (Romatec)  → entra em parcelas 50/50
+//   🅱 DESPESAS ADMINISTRATIVAS (cliente paga a parte) → fora das parcelas
+// Forma de pagamento agora vem por TAG (sinal_mais_1 default = 50/50).
+// Taxa esboco R$ 750 continua INFORMATIVA (fora do total geral).
 
 import type {
   InputProjetoExecutivo,
   ProjetoSelecionado,
+  FormaPagamentoTag,
   CustosCalculados,
   ResultadoCalculo,
   ItemCusto,
@@ -21,23 +17,19 @@ import type {
   BaseCalculo,
 } from './types';
 
-// HALF_UP em 2 casas (mesma logica das outras engines)
+// HALF_UP em 2 casas
 export function round2(n: number): number {
   return Math.round((n + Number.EPSILON) * 100) / 100;
 }
 
-// Defaults pra ART/TRT e config — sem dependencia de DB pra simplificar.
-// CEO pediu defaults conservadores e ajustaveis via input.
 export const DEFAULTS_PROJETO_EXECUTIVO = {
   VALOR_M2: 25.00,
   TAXA_ESBOCO: 750.00,
-  ART_VALOR: 233.94,     // CREA-MA referencia (subcontratacao)
-  TRT_VALOR: 93.40,      // CFT/MA referencia (mesma das outras propostas)
+  ART_VALOR: 233.94,
+  TRT_VALOR: 93.40,
   AREA_LIMITE_TRT: 80.00,
 } as const;
 
-// Lista padrao de projetos executivos com detalhamentos completos.
-// CEO pode customizar por proposta — o que vier no input substitui o default.
 export const PROJETOS_DEFAULT_PROJETO_EXECUTIVO: ProjetoSelecionado[] = [
   {
     codigo: 'mapa_situacao',
@@ -131,10 +123,10 @@ const AVISO_CNO_EXECUTIVO =
   'expedicao do Alvara de Construcao pela Prefeitura. A CONTRATADA executa o cadastramento ' +
   'quando o CONTRATANTE apresentar o Alvara.';
 
-const AVISO_ALVARA =
-  'O Alvara de Construcao e expedido pela Prefeitura Municipal de Acailandia mediante pagamento ' +
-  'das taxas municipais (TLE, ISS de aprovacao, etc) diretamente pelo CONTRATANTE. A CONTRATADA ' +
-  'acompanha o protocolo e exigencias ate a expedicao.';
+const AVISO_DESPESAS =
+  'Os valores das Despesas Administrativas NAO compoem os Honorarios Tecnicos e NAO estao ' +
+  'sujeitos ao parcelamento 50/50. Sao pagos pelo CONTRATANTE diretamente aos orgaos competentes ' +
+  'ou reembolsados a CONTRATADA mediante apresentacao dos comprovantes.';
 
 const AVISO_ART =
   'A ART (Anotacao de Responsabilidade Tecnica) junto ao CREA-MA exige profissional Engenheiro ' +
@@ -146,7 +138,6 @@ const AVISO_TRT =
   'profissional Jose Romario Pinto Bezerra — Tecnico em Edificacoes (CFT/MA 01209185369). ' +
   'Aplicavel a obras de ate 80m² conforme Lei 13.639/2018.';
 
-// Documentos obrigatorios do cliente pra dar inicio aos projetos
 const CHECKLIST_PROJETO_EXECUTIVO: DocumentoChecklist[] = [
   { texto: 'RG e CPF do proprietario (copia simples)', obrigatorio: true },
   { texto: 'Comprovante de residencia atualizado (max. 90 dias)', obrigatorio: true },
@@ -157,26 +148,117 @@ const CHECKLIST_PROJETO_EXECUTIVO: DocumentoChecklist[] = [
   { texto: 'Referencias visuais / inspiracao (opcional)', obrigatorio: false },
 ];
 
-export interface ResultadoProjetoExecutivoExtra {
-  area_construir: number;
-  valor_m2: number;
-  valor_projetos: number;
-  responsabilidade_tipo: 'ART' | 'TRT';
-  responsabilidade_valor: number;
-  responsabilidade_auto: boolean;
-  taxa_esboco: number;
-  alvara: { incluir: boolean; valor: number };
-  placa: { incluir: boolean; valor: number };
-  subtotal: number;
-  desconto: number;
-  valor_total: number;
+// v3.24.6: helper exportado pra rendering de Forma de Pagamento por TAG
+export function renderizarFormaPagamento(
+  tag: FormaPagamentoTag,
+  totalHonorarios: number,
+  custom?: string,
+): { tag: FormaPagamentoTag; texto_renderizado: string; detalhes_custom?: string } {
+  const fmt = (v: number) =>
+    v.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  switch (tag) {
+    case 'integral':
+      return {
+        tag,
+        texto_renderizado:
+          `Pagamento a vista no valor de R$ ${fmt(totalHonorarios)} ` +
+          `na assinatura do contrato.`,
+      };
+
+    case 'sinal_mais_1': {
+      const metade = round2(totalHonorarios * 0.5);
+      const resto = round2(totalHonorarios - metade);
+      return {
+        tag,
+        texto_renderizado:
+          `Pagamento em 2 (duas) parcelas: ` +
+          `R$ ${fmt(metade)} como SINAL no inicio (assinatura do contrato / ` +
+          `aprovacao do anteprojeto) e R$ ${fmt(resto)} na ENTREGA FINAL ` +
+          `dos projetos executivos em PDF via WhatsApp e e-mail.`,
+      };
+    }
+
+    case 'sinal_mais_2': {
+      const sinal = round2(totalHonorarios * 0.5);
+      const restante = round2(totalHonorarios - sinal);
+      const parc = round2(restante / 2);
+      const ultima = round2(restante - parc);
+      return {
+        tag,
+        texto_renderizado:
+          `Pagamento em 3 (tres) parcelas: ` +
+          `R$ ${fmt(sinal)} como SINAL no inicio; ` +
+          `R$ ${fmt(parc)} na entrega do anteprojeto aprovado; ` +
+          `e R$ ${fmt(ultima)} na ENTREGA FINAL dos projetos executivos ` +
+          `em PDF via WhatsApp e e-mail.`,
+      };
+    }
+
+    case 'duas_vezes': {
+      const p1 = round2(totalHonorarios * 0.5);
+      const p2 = round2(totalHonorarios - p1);
+      return {
+        tag,
+        texto_renderizado:
+          `Pagamento em 2 (duas) parcelas: ` +
+          `R$ ${fmt(p1)} na assinatura do contrato e R$ ${fmt(p2)} ` +
+          `na ENTREGA FINAL dos projetos executivos em PDF via WhatsApp e e-mail.`,
+      };
+    }
+
+    case 'personalizada':
+      return {
+        tag,
+        texto_renderizado: (custom && custom.trim()) || 'A combinar entre as partes.',
+        detalhes_custom: custom,
+      };
+  }
+}
+
+// v3.24.6: estrutura completa de retorno (extends ResultadoCalculo via custos)
+export interface CustosProjetoExecutivoV2 {
+  honorarios: {
+    area_construir: number;
+    valor_m2: number;
+    valor_projetos: number;
+    responsabilidade_tipo: 'ART' | 'TRT';
+    responsabilidade_auto: boolean;
+    responsabilidade_valor: number;
+    subtotal_honorarios: number;
+    desconto_honorarios: number;
+    total_honorarios: number;
+    parcela_inicial: number;
+    parcela_final: number;
+  };
+  despesas_administrativas: {
+    diligencia_secretaria: { incluir: boolean; valor: number };
+    taxa_alvara_municipio: { incluir: boolean; valor: number };
+    placa_obra: { incluir: boolean; valor: number };
+    subtotal_despesas: number;
+  };
+  taxa_esboco: {
+    valor: number;
+    cobranca_condicional: boolean;
+    nota: string;
+  };
+  forma_pagamento: {
+    tag: FormaPagamentoTag;
+    texto_renderizado: string;
+    detalhes_custom?: string;
+  };
+  resumo: {
+    total_honorarios: number;
+    total_despesas: number;
+    total_geral: number;
+  };
   projetos_selecionados: ProjetoSelecionado[];
   cno_observacao: string;
 }
 
 export async function calcularProjetoExecutivo(
   input: InputProjetoExecutivo,
-): Promise<ResultadoCalculo & { projeto_executivo: ResultadoProjetoExecutivoExtra }> {
+): Promise<ResultadoCalculo & { projeto_executivo: CustosProjetoExecutivoV2 }> {
   if (!input.area_construir || input.area_construir <= 0) {
     throw new Error('area_construir deve ser maior que zero');
   }
@@ -186,9 +268,8 @@ export async function calcularProjetoExecutivo(
 
   const valorM2 = input.valor_m2;
   const valor_projetos = round2(input.area_construir * valorM2);
-  const taxa_esboco = round2(input.taxa_esboco ?? DEFAULTS_PROJETO_EXECUTIVO.TAXA_ESBOCO);
 
-  // ART/TRT — default auto por area (>80m² ART). Override manual respeita escolha.
+  // ART/TRT — auto por area
   const auto = input.responsabilidade_auto !== false;
   let responsabilidade_tipo: 'ART' | 'TRT';
   if (!auto && input.responsabilidade_tipo) {
@@ -197,7 +278,6 @@ export async function calcularProjetoExecutivo(
     responsabilidade_tipo =
       input.area_construir > DEFAULTS_PROJETO_EXECUTIVO.AREA_LIMITE_TRT ? 'ART' : 'TRT';
   }
-
   const responsabilidade_valor = round2(
     input.responsabilidade_valor != null
       ? input.responsabilidade_valor
@@ -206,71 +286,121 @@ export async function calcularProjetoExecutivo(
         : DEFAULTS_PROJETO_EXECUTIVO.TRT_VALOR),
   );
 
-  const alvara_valor = input.alvara_incluir ? round2(input.alvara_valor) : 0;
-  const placa_valor  = input.placa_incluir  ? round2(input.placa_valor)  : 0;
+  // 🅰 HONORARIOS
+  const subtotal_honorarios = round2(valor_projetos + responsabilidade_valor);
+  const desconto_honorarios = round2(input.desconto_honorarios ?? input.desconto ?? 0);
+  const total_honorarios = round2(subtotal_honorarios - desconto_honorarios);
+  const parcela_inicial = round2(total_honorarios * 0.5);
+  const parcela_final = round2(total_honorarios - parcela_inicial);
 
-  // Subtotal NAO inclui taxa_esboco
-  const subtotal = round2(valor_projetos + responsabilidade_valor + alvara_valor + placa_valor);
-  const desconto = round2(input.desconto ?? 0);
-  const valor_total = round2(subtotal - desconto);
+  // 🅱 DESPESAS ADMIN — usa forma nova (DespesaAdmItem) com fallback retro
+  // pra alvara_incluir/alvara_valor/placa_incluir/placa_valor (v3.24.5).
+  const diligenciaIn = input.diligencia_secretaria ?? { incluir: false, valor: 0 };
+  const alvaraIn = input.taxa_alvara_municipio
+    ?? (input.alvara_incluir != null
+      ? { incluir: !!input.alvara_incluir, valor: input.alvara_valor || 0 }
+      : { incluir: false, valor: 0 });
+  const placaIn = input.placa_obra
+    ?? (input.placa_incluir != null
+      ? { incluir: !!input.placa_incluir, valor: input.placa_valor || 0 }
+      : { incluir: false, valor: 0 });
 
-  // Projetos: aplica defaults SE input nao trouxe lista
+  const vDilig = diligenciaIn.incluir ? round2(diligenciaIn.valor) : 0;
+  const vAlvara = alvaraIn.incluir ? round2(alvaraIn.valor) : 0;
+  const vPlaca = placaIn.incluir ? round2(placaIn.valor) : 0;
+  const subtotal_despesas = round2(vDilig + vAlvara + vPlaca);
+
+  // Taxa esboco
+  const taxa_esboco_valor = round2(input.taxa_esboco ?? DEFAULTS_PROJETO_EXECUTIVO.TAXA_ESBOCO);
+
+  // Forma de pagamento por TAG
+  const formaTag: FormaPagamentoTag = input.forma_pagamento_tag ?? 'sinal_mais_1';
+  const forma_pagamento = renderizarFormaPagamento(formaTag, total_honorarios, input.forma_pagamento_custom);
+
+  // Resumo (total_geral = honorarios + despesas; taxa esboco FORA)
+  const total_geral = round2(total_honorarios + subtotal_despesas);
+
+  // Projetos selecionados
   const projetos = (input.projetos_selecionados && input.projetos_selecionados.length > 0)
     ? input.projetos_selecionados
     : PROJETOS_DEFAULT_PROJETO_EXECUTIVO;
-  // Filtra so os selecionados pra montar a lista do escopo (Secao 1)
   const projetosAtivos = projetos.filter(p => p.selecionado);
-
   const secao_1_projetos = projetosAtivos.map(p => `${p.nome}: ${p.detalhamento_entrega}`);
 
-  // Tabela financeira:
-  // Secao 2 (taxas) = ART/TRT + alvara + placa (sem taxas terceiros nesse subtipo)
-  // Secao 3 (honorarios) = valor_projetos (item unico, ja inclui o pacote completo)
+  // ── Estrutura CustosCalculados padrao (compat retro com renderers genericos)
+  // Mapeamento:
+  //   secao_3_honorarios = projetos + ART/TRT (HONORARIOS)
+  //   secao_2_taxas = despesas administrativas (alvara + placa + diligencia)
+  //   secao_5_total = total_geral (honorarios + despesas)
+  //   condicoes_pagamento = baseado na TAG (so 2 parcelas no sinal_mais_1)
+  const secao_3_honorarios: ItemCusto[] = [
+    {
+      ordem: 1,
+      descricao: `Projetos Executivos (${projetosAtivos.length} projeto${projetosAtivos.length === 1 ? '' : 's'}) — ` +
+                 `${input.area_construir.toFixed(2)}m² × R$ ${valorM2.toFixed(2)}/m²`,
+      valor: valor_projetos,
+    },
+    {
+      ordem: 2,
+      descricao: responsabilidade_tipo === 'ART'
+        ? 'ART — Anotacao de Responsabilidade Tecnica (CREA-MA)'
+        : 'TRT — Termo de Responsabilidade Tecnica (CFT/MA)',
+      valor: responsabilidade_valor,
+      observacao: responsabilidade_tipo === 'ART' ? AVISO_ART : AVISO_TRT,
+    },
+  ];
+
   const secao_2_taxas: ItemCusto[] = [];
-  secao_2_taxas.push({
-    ordem: 1,
-    descricao: responsabilidade_tipo === 'ART'
-      ? 'ART — Anotacao de Responsabilidade Tecnica (CREA-MA)'
-      : 'TRT — Termo de Responsabilidade Tecnica (CFT/MA)',
-    valor: responsabilidade_valor,
-    observacao: responsabilidade_tipo === 'ART' ? AVISO_ART : AVISO_TRT,
-  });
-  if (input.alvara_incluir) {
+  if (diligenciaIn.incluir) {
+    secao_2_taxas.push({
+      ordem: 1,
+      descricao: 'Diligencia de Protocolo na Secretaria de Habitacao e Regularizacao Fundiaria',
+      valor: vDilig,
+      observacao: 'Inclui impressao 2 vias, certidoes, protocolo, acompanhamento, retirada do Alvara.',
+    });
+  }
+  if (alvaraIn.incluir) {
     secao_2_taxas.push({
       ordem: 2,
-      descricao: 'Alvara de Construcao (Prefeitura de Acailandia/MA)',
-      valor: alvara_valor,
-      observacao: AVISO_ALVARA,
+      descricao: 'Taxa de Expedicao de Alvara de Construcao',
+      valor: vAlvara,
+      observacao: 'Valor da Prefeitura Municipal pago direto pelo cliente OU reembolsado.',
     });
   }
-  if (input.placa_incluir) {
+  if (placaIn.incluir) {
     secao_2_taxas.push({
       ordem: 3,
-      descricao: 'Placa de Obra (confeccao e instalacao)',
-      valor: placa_valor,
-      observacao: 'Placa padrao com identificacao do responsavel tecnico e numero da ART/TRT.',
+      descricao: 'Confeccao e Instalacao da Placa de Obra',
+      valor: vPlaca,
+      observacao: 'Padrao CREA/CFT + legislacao municipal.',
     });
   }
 
-  const secao_3_honorarios: ItemCusto[] = [{
-    ordem: 1,
-    descricao: `Projetos Executivos (${projetosAtivos.length} projeto${projetosAtivos.length === 1 ? '' : 's'}) — ` +
-               `${input.area_construir.toFixed(2)}m² × R$ ${valorM2.toFixed(2)}/m²`,
-    valor: valor_projetos,
-  }];
-
-  // Condicoes de pagamento sugeridas — 3 parcelas:
-  //   1a (40% subtotal) na assinatura
-  //   2a (40%) na entrega do anteprojeto aprovado
-  //   3a (20%) na entrega final dos projetos executivos
-  const p1 = round2(valor_total * 0.40);
-  const p2 = round2(valor_total * 0.40);
-  const p3 = round2(valor_total - p1 - p2);
-  const condicoes_pagamento: CondicaoPagamento[] = [
-    { rotulo: '1a parcela — na assinatura', descricao: '40% do valor total', valor: p1 },
-    { rotulo: '2a parcela — anteprojeto aprovado', descricao: '40% do valor total', valor: p2 },
-    { rotulo: '3a parcela — entrega final', descricao: '20% do valor total', valor: p3 },
-  ];
+  // Condicoes de pagamento — baseadas na TAG. Para tag != personalizada,
+  // expomos as parcelas estruturadas (front pode usar). Pra integral, 1 linha.
+  const condicoes_pagamento: CondicaoPagamento[] = [];
+  if (formaTag === 'integral') {
+    condicoes_pagamento.push({
+      rotulo: '1a parcela — a vista',
+      descricao: '100% na assinatura',
+      valor: total_honorarios,
+    });
+  } else if (formaTag === 'sinal_mais_1' || formaTag === 'duas_vezes') {
+    condicoes_pagamento.push(
+      { rotulo: '1a parcela — sinal', descricao: '50% na assinatura/aprovacao do anteprojeto', valor: parcela_inicial },
+      { rotulo: '2a parcela — entrega final', descricao: '50% na entrega via WhatsApp + e-mail', valor: parcela_final },
+    );
+  } else if (formaTag === 'sinal_mais_2') {
+    const restante = round2(total_honorarios - parcela_inicial);
+    const meio = round2(restante / 2);
+    const final = round2(restante - meio);
+    condicoes_pagamento.push(
+      { rotulo: '1a parcela — sinal', descricao: '50% na assinatura', valor: parcela_inicial },
+      { rotulo: '2a parcela — anteprojeto aprovado', descricao: '25%', valor: meio },
+      { rotulo: '3a parcela — entrega final', descricao: '25%', valor: final },
+    );
+  }
+  // 'personalizada' deixa condicoes_pagamento vazio — texto vai em forma_pagamento.texto_renderizado
 
   const base_calculo: BaseCalculo[] = [
     {
@@ -285,25 +415,17 @@ export async function calcularProjetoExecutivo(
         : `override manual = ${responsabilidade_tipo}`,
       valor_resultado: responsabilidade_valor,
     },
+    {
+      rotulo: 'Parcelamento 50/50',
+      formula: `total_honorarios / 2`,
+      valor_resultado: parcela_inicial,
+    },
   ];
-  if (input.alvara_incluir) {
-    base_calculo.push({
-      rotulo: 'Alvara',
-      formula: 'incluido pelo CONTRATANTE',
-      valor_resultado: alvara_valor,
-    });
-  }
-  if (input.placa_incluir) {
-    base_calculo.push({
-      rotulo: 'Placa',
-      formula: 'incluida pelo CONTRATANTE',
-      valor_resultado: placa_valor,
-    });
-  }
 
   const avisos = [
     AVISO_TAXA_ESBOCO,
     AVISO_CNO_EXECUTIVO,
+    AVISO_DESPESAS,
     responsabilidade_tipo === 'ART' ? AVISO_ART : AVISO_TRT,
   ];
 
@@ -314,7 +436,7 @@ export async function calcularProjetoExecutivo(
     condicoes_pagamento,
     base_calculo,
     secao_4_checklist: CHECKLIST_PROJETO_EXECUTIVO,
-    secao_5_total: valor_total,
+    secao_5_total: total_geral,
     avisos,
   };
 
@@ -322,18 +444,36 @@ export async function calcularProjetoExecutivo(
     custos,
     fontes: {},
     projeto_executivo: {
-      area_construir: input.area_construir,
-      valor_m2: valorM2,
-      valor_projetos,
-      responsabilidade_tipo,
-      responsabilidade_valor,
-      responsabilidade_auto: auto,
-      taxa_esboco,
-      alvara: { incluir: !!input.alvara_incluir, valor: alvara_valor },
-      placa:  { incluir: !!input.placa_incluir,  valor: placa_valor  },
-      subtotal,
-      desconto,
-      valor_total,
+      honorarios: {
+        area_construir: input.area_construir,
+        valor_m2: valorM2,
+        valor_projetos,
+        responsabilidade_tipo,
+        responsabilidade_auto: auto,
+        responsabilidade_valor,
+        subtotal_honorarios,
+        desconto_honorarios,
+        total_honorarios,
+        parcela_inicial,
+        parcela_final,
+      },
+      despesas_administrativas: {
+        diligencia_secretaria: { incluir: diligenciaIn.incluir, valor: vDilig },
+        taxa_alvara_municipio: { incluir: alvaraIn.incluir, valor: vAlvara },
+        placa_obra: { incluir: placaIn.incluir, valor: vPlaca },
+        subtotal_despesas,
+      },
+      taxa_esboco: {
+        valor: taxa_esboco_valor,
+        cobranca_condicional: true,
+        nota: 'Cobrada apenas se o CONTRATANTE nao prosseguir com a fase executiva.',
+      },
+      forma_pagamento,
+      resumo: {
+        total_honorarios,
+        total_despesas: subtotal_despesas,
+        total_geral,
+      },
       projetos_selecionados: projetos,
       cno_observacao: CNO_OBSERVACAO,
     },

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -359,6 +359,21 @@ export interface ProjetoSelecionado {
   detalhamento_entrega: string;
 }
 
+// v3.24.6: Tag de Forma de Pagamento (radio visual no form).
+// "personalizada" usa forma_pagamento_custom como texto livre.
+export type FormaPagamentoTag =
+  | 'integral'        // 100% a vista
+  | 'sinal_mais_1'    // 50% sinal + 50% entrega (DEFAULT)
+  | 'sinal_mais_2'    // sinal + 2x na entrega
+  | 'duas_vezes'      // 2x iguais
+  | 'personalizada';
+
+// v3.24.6: Despesa Administrativa individual (incluir + valor)
+export interface DespesaAdmItem {
+  incluir: boolean;
+  valor: number;
+}
+
 export interface InputProjetoExecutivo {
   // Imovel/obra
   endereco_obra: string;
@@ -366,7 +381,7 @@ export interface InputProjetoExecutivo {
   uf_obra?: string;            // default MA
   tipo_edificacao: TipoEdificacao;
 
-  // Calculo principal
+  // Calculo principal (HONORARIOS)
   area_construir: number;       // m²
   valor_m2: number;             // R$/m² (default 25)
 
@@ -375,23 +390,37 @@ export interface InputProjetoExecutivo {
   responsabilidade_tipo?: 'ART' | 'TRT'; // so usado se auto=false
   responsabilidade_valor?: number;       // override do default da config
 
-  // Itens opcionais (cada um pode ser desligado)
-  alvara_incluir: boolean;
-  alvara_valor: number;
-  placa_incluir: boolean;
-  placa_valor: number;
+  // Desconto sobre HONORARIOS (apenas)
+  desconto_honorarios?: number;
+
+  // v3.24.6: DESPESAS ADMINISTRATIVAS (à parte — NAO entram nos honorarios
+  // nem nas parcelas 50/50). Cada item tem checkbox + valor independente.
+  diligencia_secretaria?: DespesaAdmItem;
+  taxa_alvara_municipio?: DespesaAdmItem;
+  placa_obra?: DespesaAdmItem;
+
+  // DEPRECATED v3.24.5 — mantidos pra compat retro com propostas antigas
+  // criadas antes do refactor. Front novo USA diligencia_secretaria/
+  // taxa_alvara_municipio/placa_obra. Engine ignora se forma nova presente.
+  alvara_incluir?: boolean;
+  alvara_valor?: number;
+  placa_incluir?: boolean;
+  placa_valor?: number;
+  desconto?: number; // mapeia pra desconto_honorarios
 
   // Taxa de esboco (R$750 default) — INFORMATIVA, fora do total
   taxa_esboco?: number;
 
-  // Descontos/desbloqueios manuais
-  desconto?: number;
+  // v3.24.6: Forma de pagamento via TAG (default 'sinal_mais_1')
+  forma_pagamento_tag?: FormaPagamentoTag;
+  forma_pagamento_custom?: string;
 
   // Projetos selecionados (lista vinda do front; defaults aplicados quando vazio)
   projetos_selecionados?: ProjetoSelecionado[];
 
   // Cliente — usado so na preview/rendering, nao no calculo
   prazo_entrega_dias?: number;
+  // DEPRECATED v3.24.6 — usar forma_pagamento_tag
   forma_pagamento?: string;
   observacoes?: string;
 }

--- a/src/test/projeto-executivo-engine.test.ts
+++ b/src/test/projeto-executivo-engine.test.ts
@@ -1,17 +1,23 @@
 // v3.24.5: tests da engine de Projeto Executivo.
+// v3.24.6: REFATORADO pra nova estrutura (Honorarios + Despesas Admin separadas
+// + Forma de Pagamento por TAG).
 //
 // Cobre:
-// 1. Cálculo: area × R$/m² = valor_projetos
-// 2. ART/TRT auto por área (toggle em 80m²)
-// 3. Override manual respeita escolha
-// 4. Taxa esboço fica FORA do subtotal/valor_total
-// 5. Alvará/placa opcionais zeram quando desmarcados
-// 6. Desconto subtrai corretamente
-// 7. round2 HALF_UP consistente
+// 1. round2 HALF_UP
+// 2. Honorarios = area × R$/m² + ART/TRT
+// 3. ART/TRT auto por area (toggle em 80m²)
+// 4. Override manual respeita escolha
+// 5. Despesas Admin (diligencia/alvara/placa) — fora dos honorarios
+// 6. Parcelas 50/50 sempre fechando o total_honorarios
+// 7. Taxa esboco fora do total_geral
+// 8. Forma de pagamento por TAG (5 tags + custom)
+// 9. Compat retro v3.24.5 (alvara_incluir/placa_incluir/desconto)
+// 10. Defaults estaveis
 
 import { describe, it, expect } from 'vitest';
 import {
   calcularProjetoExecutivo,
+  renderizarFormaPagamento,
   round2,
   DEFAULTS_PROJETO_EXECUTIVO,
   PROJETOS_DEFAULT_PROJETO_EXECUTIVO,
@@ -26,41 +32,42 @@ function inputBase(over: Partial<InputProjetoExecutivo> = {}): InputProjetoExecu
     tipo_edificacao: 'residencial',
     area_construir: 100,
     valor_m2: 25,
-    alvara_incluir: true,
-    alvara_valor: 500,
-    placa_incluir: true,
-    placa_valor: 350,
+    diligencia_secretaria: { incluir: false, valor: 0 },
+    taxa_alvara_municipio: { incluir: false, valor: 0 },
+    placa_obra: { incluir: false, valor: 0 },
+    forma_pagamento_tag: 'sinal_mais_1',
     ...over,
+    // override de retrocompat — campos legacy nao precisam mais
+    alvara_incluir: false,
+    alvara_valor: 0,
+    placa_incluir: false,
+    placa_valor: 0,
   };
 }
 
-describe('round2 (HALF_UP)', () => {
-  it('arredonda 2.005 pra 2.01 (HALF_UP, nao banker)', () => {
+describe('1. round2 (HALF_UP)', () => {
+  it('arredonda 2.005 -> 2.01', () => {
     expect(round2(2.005)).toBe(2.01);
-  });
-  it('arredonda 1.005 pra 1.01', () => {
-    expect(round2(1.005)).toBe(1.01);
   });
   it('mantem 100 inteiro', () => {
     expect(round2(100)).toBe(100);
   });
 });
 
-describe('1. calculo area × R$/m²', () => {
-  it('100m² × R$ 25 = R$ 2.500 no item projetos', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 100, valor_m2: 25 }));
-    expect(r.projeto_executivo.valor_projetos).toBe(2500);
-    expect(r.custos.secao_3_honorarios[0].valor).toBe(2500);
+describe('2. Honorarios = area × R$/m² + ART/TRT', () => {
+  it('100m² × R$ 25 = R$ 2.500 (valor_projetos)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.projeto_executivo.honorarios.valor_projetos).toBe(2500);
   });
 
-  it('250.5m² × R$ 30,50 = R$ 7.640,25', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 250.5, valor_m2: 30.50 }));
-    expect(r.projeto_executivo.valor_projetos).toBe(7640.25);
+  it('subtotal_honorarios = projetos + ART (area 100m² > 80 = ART)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    // 2500 + 233.94 ART = 2733.94
+    expect(r.projeto_executivo.honorarios.subtotal_honorarios).toBe(2733.94);
   });
 
   it('rejeita area_construir <= 0', async () => {
     await expect(calcularProjetoExecutivo(inputBase({ area_construir: 0 }))).rejects.toThrow();
-    await expect(calcularProjetoExecutivo(inputBase({ area_construir: -10 }))).rejects.toThrow();
   });
 
   it('rejeita valor_m2 <= 0', async () => {
@@ -68,192 +75,190 @@ describe('1. calculo area × R$/m²', () => {
   });
 });
 
-describe('2. ART/TRT auto por area (toggle em 80m²)', () => {
+describe('3. ART/TRT auto por area (toggle em 80m²)', () => {
   it('area 79m² -> TRT auto', async () => {
     const r = await calcularProjetoExecutivo(inputBase({ area_construir: 79 }));
-    expect(r.projeto_executivo.responsabilidade_tipo).toBe('TRT');
-    expect(r.projeto_executivo.responsabilidade_auto).toBe(true);
-    expect(r.projeto_executivo.responsabilidade_valor).toBe(DEFAULTS_PROJETO_EXECUTIVO.TRT_VALOR);
+    expect(r.projeto_executivo.honorarios.responsabilidade_tipo).toBe('TRT');
+    expect(r.projeto_executivo.honorarios.responsabilidade_auto).toBe(true);
+    expect(r.projeto_executivo.honorarios.responsabilidade_valor).toBe(DEFAULTS_PROJETO_EXECUTIVO.TRT_VALOR);
   });
 
-  it('area 80m² (limite EXATO) -> TRT (regra <=80)', async () => {
+  it('area 80m² (limite) -> TRT', async () => {
     const r = await calcularProjetoExecutivo(inputBase({ area_construir: 80 }));
-    expect(r.projeto_executivo.responsabilidade_tipo).toBe('TRT');
+    expect(r.projeto_executivo.honorarios.responsabilidade_tipo).toBe('TRT');
   });
 
-  it('area 80.01m² -> ART (regra >80)', async () => {
+  it('area 80.01m² -> ART', async () => {
     const r = await calcularProjetoExecutivo(inputBase({ area_construir: 80.01 }));
-    expect(r.projeto_executivo.responsabilidade_tipo).toBe('ART');
-    expect(r.projeto_executivo.responsabilidade_valor).toBe(DEFAULTS_PROJETO_EXECUTIVO.ART_VALOR);
+    expect(r.projeto_executivo.honorarios.responsabilidade_tipo).toBe('ART');
   });
 
-  it('area 200m² -> ART auto com valor default R$ 233,94', async () => {
+  it('area 200m² -> ART (R$ 233,94 default)', async () => {
     const r = await calcularProjetoExecutivo(inputBase({ area_construir: 200 }));
-    expect(r.projeto_executivo.responsabilidade_tipo).toBe('ART');
-    expect(r.projeto_executivo.responsabilidade_valor).toBe(233.94);
+    expect(r.projeto_executivo.honorarios.responsabilidade_tipo).toBe('ART');
+    expect(r.projeto_executivo.honorarios.responsabilidade_valor).toBe(233.94);
   });
 });
 
-describe('3. Override manual respeita escolha', () => {
-  it('responsabilidade_auto=false + tipo=ART na area 50m² mantem ART', async () => {
+describe('4. Override manual respeita escolha', () => {
+  it('responsabilidade_auto=false + ART na area 50m² mantem ART', async () => {
     const r = await calcularProjetoExecutivo(inputBase({
       area_construir: 50,
       responsabilidade_auto: false,
       responsabilidade_tipo: 'ART',
     }));
-    expect(r.projeto_executivo.responsabilidade_tipo).toBe('ART');
-    expect(r.projeto_executivo.responsabilidade_auto).toBe(false);
+    expect(r.projeto_executivo.honorarios.responsabilidade_tipo).toBe('ART');
+    expect(r.projeto_executivo.honorarios.responsabilidade_auto).toBe(false);
   });
 
-  it('responsabilidade_auto=false + tipo=TRT na area 200m² mantem TRT (CEO assume risco)', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 200,
-      responsabilidade_auto: false,
-      responsabilidade_tipo: 'TRT',
-    }));
-    expect(r.projeto_executivo.responsabilidade_tipo).toBe('TRT');
-  });
-
-  it('responsabilidade_valor override usa valor informado nao default', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 100,
-      responsabilidade_valor: 150,
-    }));
-    expect(r.projeto_executivo.responsabilidade_valor).toBe(150);
+  it('responsabilidade_valor override usa valor informado', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ responsabilidade_valor: 150 }));
+    expect(r.projeto_executivo.honorarios.responsabilidade_valor).toBe(150);
   });
 });
 
-describe('4. Taxa esboço NAO entra no subtotal/valor_total', () => {
-  it('taxa default 750 nao soma ao subtotal', async () => {
-    // Area 50 -> TRT auto (<=80). Projects 50*25=1250 + TRT 93.40 = 1343.40
+describe('5. Despesas Administrativas — fora dos honorarios', () => {
+  it('despesas NAO entram em total_honorarios', async () => {
     const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 50,
-      valor_m2: 25,
-      alvara_incluir: false,
-      placa_incluir: false,
+      area_construir: 60, // TRT
+      diligencia_secretaria: { incluir: true, valor: 700 },
+      taxa_alvara_municipio: { incluir: true, valor: 450 },
+      placa_obra: { incluir: true, valor: 280 },
     }));
-    expect(r.projeto_executivo.subtotal).toBe(1343.40);
-    expect(r.projeto_executivo.valor_total).toBe(1343.40);
-    // Taxa esboco esta exposta mas fora do total
-    expect(r.projeto_executivo.taxa_esboco).toBe(750);
+    // Honorarios = projetos 1500 + TRT 93.40 = 1593.40
+    expect(r.projeto_executivo.honorarios.total_honorarios).toBe(1593.40);
+    // Despesas = 700 + 450 + 280 = 1430
+    expect(r.projeto_executivo.despesas_administrativas.subtotal_despesas).toBe(1430);
+    // Total geral = honorarios + despesas
+    expect(r.projeto_executivo.resumo.total_geral).toBe(3023.40);
   });
 
-  it('aviso da taxa aparece em custos.avisos', async () => {
-    const r = await calcularProjetoExecutivo(inputBase());
-    expect(r.custos.avisos.some(a => /R\$ 750,00.*NAO esta incluida/i.test(a))).toBe(true);
+  it('despesa desmarcada zera valor (mesmo se valor preenchido)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      diligencia_secretaria: { incluir: false, valor: 999 },
+    }));
+    expect(r.projeto_executivo.despesas_administrativas.diligencia_secretaria.valor).toBe(0);
+    expect(r.projeto_executivo.despesas_administrativas.subtotal_despesas).toBe(0);
+  });
+
+  it('todas despesas incluidas somam corretamente', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      diligencia_secretaria: { incluir: true, valor: 800 },
+      taxa_alvara_municipio: { incluir: true, valor: 500 },
+      placa_obra: { incluir: true, valor: 350 },
+    }));
+    expect(r.projeto_executivo.despesas_administrativas.subtotal_despesas).toBe(1650);
+  });
+});
+
+describe('6. Parcelas 50/50 sempre fechando total_honorarios', () => {
+  it('parcela_inicial + parcela_final = total_honorarios (caso comum)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 100 }));
+    const h = r.projeto_executivo.honorarios;
+    expect(round2(h.parcela_inicial + h.parcela_final)).toBe(h.total_honorarios);
+  });
+
+  it('parcelas fecham mesmo com valor impar (centavos)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 73.5, valor_m2: 25.50,
+    }));
+    const h = r.projeto_executivo.honorarios;
+    expect(round2(h.parcela_inicial + h.parcela_final)).toBe(h.total_honorarios);
+  });
+
+  it('desconto subtrai do total_honorarios', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 100,
+      desconto_honorarios: 200,
+    }));
+    const h = r.projeto_executivo.honorarios;
+    // Subtotal 2733.94 - desconto 200 = 2533.94
+    expect(h.desconto_honorarios).toBe(200);
+    expect(h.total_honorarios).toBe(2533.94);
+  });
+
+  it('compat: campo "desconto" antigo (v3.24.5) mapeia pra desconto_honorarios', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ desconto: 100 }));
+    expect(r.projeto_executivo.honorarios.desconto_honorarios).toBe(100);
+  });
+});
+
+describe('7. Taxa esboco INFORMATIVA — fora do total_geral', () => {
+  it('taxa esboco 750 nao soma em total_geral', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 50 }));
+    // Honorarios so: TRT (1250+93.40 = 1343.40), sem despesas
+    expect(r.projeto_executivo.resumo.total_geral).toBe(1343.40);
+    expect(r.projeto_executivo.taxa_esboco.valor).toBe(750);
+    expect(r.projeto_executivo.taxa_esboco.cobranca_condicional).toBe(true);
   });
 
   it('taxa customizada respeita input', async () => {
     const r = await calcularProjetoExecutivo(inputBase({ taxa_esboco: 1200 }));
-    expect(r.projeto_executivo.taxa_esboco).toBe(1200);
+    expect(r.projeto_executivo.taxa_esboco.valor).toBe(1200);
   });
 });
 
-describe('5. Alvará/placa opcionais zeram quando desmarcados', () => {
-  it('alvara_incluir=false zera alvara_valor no total', async () => {
-    // Area 50 -> TRT. Projects 1250 + TRT 93.40 = 1343.40
-    const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 50,
-      valor_m2: 25,
-      alvara_incluir: false,
-      alvara_valor: 9999,    // ignorado
-      placa_incluir: false,
-      placa_valor: 0,
-    }));
-    expect(r.projeto_executivo.subtotal).toBe(1343.40);
-    expect(r.projeto_executivo.alvara.incluir).toBe(false);
-    expect(r.projeto_executivo.alvara.valor).toBe(0);
+describe('8. Forma de Pagamento por TAG', () => {
+  it('default tag = sinal_mais_1 (50/50)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ area_construir: 100 }));
+    expect(r.projeto_executivo.forma_pagamento.tag).toBe('sinal_mais_1');
+    expect(r.projeto_executivo.forma_pagamento.texto_renderizado).toMatch(/SINAL/i);
+    expect(r.projeto_executivo.forma_pagamento.texto_renderizado).toMatch(/ENTREGA/i);
   });
 
-  it('placa_incluir=false idem', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({
-      alvara_incluir: false,
-      placa_incluir: false,
-      placa_valor: 999,
-    }));
-    expect(r.projeto_executivo.placa.valor).toBe(0);
+  it('tag integral gera texto "a vista"', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ forma_pagamento_tag: 'integral' }));
+    expect(r.projeto_executivo.forma_pagamento.texto_renderizado).toMatch(/a vista/i);
   });
 
-  it('ambos incluidos somam ao total', async () => {
-    // Area 50 -> TRT. Projects 1250 + TRT 93.40 + 500 + 350 = 2193.40
+  it('tag personalizada usa custom', async () => {
     const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 50, valor_m2: 25,
-      alvara_incluir: true,  alvara_valor: 500,
-      placa_incluir: true,   placa_valor: 350,
+      forma_pagamento_tag: 'personalizada',
+      forma_pagamento_custom: '3x sem juros via PIX nos dias 5, 15 e 25.',
     }));
-    expect(r.projeto_executivo.subtotal).toBe(2193.40);
+    expect(r.projeto_executivo.forma_pagamento.texto_renderizado).toContain('PIX');
+  });
+
+  it('tag duas_vezes gera 2 parcelas iguais', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ forma_pagamento_tag: 'duas_vezes' }));
+    expect(r.projeto_executivo.forma_pagamento.texto_renderizado).toMatch(/2 \(duas\) parcelas/);
+  });
+
+  it('tag sinal_mais_2 gera 3 parcelas', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({ forma_pagamento_tag: 'sinal_mais_2' }));
+    expect(r.projeto_executivo.forma_pagamento.texto_renderizado).toMatch(/3 \(tres\) parcelas/);
+  });
+
+  it('renderizarFormaPagamento exportado standalone funciona', () => {
+    const r = renderizarFormaPagamento('sinal_mais_1', 1000);
+    expect(r.texto_renderizado).toMatch(/R\$ 500,00/);
   });
 });
 
-describe('6. Desconto subtrai do subtotal', () => {
-  it('desconto R$ 200 do subtotal 2193.40 = 1993.40 (area 50, TRT)', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 50, valor_m2: 25,
-      alvara_incluir: true, alvara_valor: 500,
-      placa_incluir: true,  placa_valor: 350,
-      desconto: 200,
-    }));
-    expect(r.projeto_executivo.subtotal).toBe(2193.40);
-    expect(r.projeto_executivo.desconto).toBe(200);
-    expect(r.projeto_executivo.valor_total).toBe(1993.40);
+describe('9. Compat retro v3.24.5 (alvara_incluir/placa_incluir/desconto)', () => {
+  it('alvara_incluir/alvara_valor legados mapeiam pra taxa_alvara_municipio', async () => {
+    const r = await calcularProjetoExecutivo({
+      ...inputBase(),
+      alvara_incluir: true,
+      alvara_valor: 600,
+      taxa_alvara_municipio: undefined, // forca usar legacy
+    });
+    expect(r.projeto_executivo.despesas_administrativas.taxa_alvara_municipio.incluir).toBe(true);
+    expect(r.projeto_executivo.despesas_administrativas.taxa_alvara_municipio.valor).toBe(600);
   });
 
-  it('desconto zero (sem desconto)', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({
-      area_construir: 100, valor_m2: 25,
-      alvara_incluir: false, placa_incluir: false,
-    }));
-    expect(r.projeto_executivo.desconto).toBe(0);
-    expect(r.projeto_executivo.valor_total).toBe(r.projeto_executivo.subtotal);
-  });
-});
-
-describe('7. Projetos selecionados', () => {
-  it('quando input nao traz lista, aplica defaults (6 selecionados de 7, PCI=false)', async () => {
-    const r = await calcularProjetoExecutivo(inputBase());
-    expect(r.projeto_executivo.projetos_selecionados).toHaveLength(7);
-    const selecionados = r.projeto_executivo.projetos_selecionados.filter(p => p.selecionado);
-    expect(selecionados).toHaveLength(6);
-    // PCI vem desmarcado por default
-    const pci = r.projeto_executivo.projetos_selecionados.find(p => p.codigo === 'pci');
-    expect(pci?.selecionado).toBe(false);
-  });
-
-  it('input com lista customizada respeita', async () => {
-    const r = await calcularProjetoExecutivo(inputBase({
-      projetos_selecionados: [
-        { codigo: 'arquitetonico', nome: 'Arquitetonico', ordem: 1, selecionado: true, detalhamento_entrega: 'Custom' },
-      ],
-    }));
-    expect(r.projeto_executivo.projetos_selecionados).toHaveLength(1);
-    expect(r.custos.secao_1_projetos[0]).toContain('Arquitetonico');
-    expect(r.custos.secao_1_projetos[0]).toContain('Custom');
+  it('forma nova prevalece sobre legacy quando ambos presentes', async () => {
+    const r = await calcularProjetoExecutivo({
+      ...inputBase(),
+      taxa_alvara_municipio: { incluir: true, valor: 700 },
+      alvara_incluir: true,
+      alvara_valor: 999, // ignorado
+    });
+    expect(r.projeto_executivo.despesas_administrativas.taxa_alvara_municipio.valor).toBe(700);
   });
 });
 
-describe('8. Estrutura do retorno (interface ResultadoCalculo + extra)', () => {
-  it('retorna custos completos + projeto_executivo extra', async () => {
-    const r = await calcularProjetoExecutivo(inputBase());
-    expect(r.custos.secao_1_projetos).toBeInstanceOf(Array);
-    expect(r.custos.secao_2_taxas).toBeInstanceOf(Array);
-    expect(r.custos.secao_3_honorarios).toBeInstanceOf(Array);
-    expect(r.custos.condicoes_pagamento).toBeInstanceOf(Array);
-    expect(r.custos.secao_4_checklist).toBeInstanceOf(Array);
-    expect(r.custos.secao_5_total).toBeGreaterThan(0);
-    expect(r.custos.avisos).toBeInstanceOf(Array);
-    expect(r.projeto_executivo).toBeDefined();
-    expect(r.projeto_executivo.cno_observacao).toMatch(/CNO/);
-    expect(r.projeto_executivo.cno_observacao).toMatch(/Alvara/i);
-  });
-
-  it('condicoes_pagamento somam ao valor_total (40/40/20)', async () => {
-    const r = await calcularProjetoExecutivo(inputBase());
-    const soma = r.custos.condicoes_pagamento!.reduce((s, c) => s + c.valor, 0);
-    expect(round2(soma)).toBe(r.projeto_executivo.valor_total);
-  });
-});
-
-describe('9. Defaults exportados estaveis', () => {
+describe('10. Defaults estaveis + Projetos', () => {
   it('valores default conhecidos', () => {
     expect(DEFAULTS_PROJETO_EXECUTIVO.VALOR_M2).toBe(25.00);
     expect(DEFAULTS_PROJETO_EXECUTIVO.TAXA_ESBOCO).toBe(750.00);
@@ -264,13 +269,39 @@ describe('9. Defaults exportados estaveis', () => {
 
   it('PROJETOS_DEFAULT tem 7 itens com NBRs', () => {
     expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO).toHaveLength(7);
-    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'arquitetonico')?.detalhamento_entrega)
-      .toMatch(/NBR 13531/);
-    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'hidraulico')?.detalhamento_entrega)
-      .toMatch(/NBR 5626/);
-    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'eletrico')?.detalhamento_entrega)
-      .toMatch(/NBR 5410/);
-    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'estrutural')?.detalhamento_entrega)
-      .toMatch(/NBR 6118/);
+    expect(PROJETOS_DEFAULT_PROJETO_EXECUTIVO.find(p => p.codigo === 'arquitetonico')?.detalhamento_entrega).toMatch(/NBR 13531/);
+  });
+
+  it('projetos default selecionados = 6 (PCI vem desmarcado)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    const selecionados = r.projeto_executivo.projetos_selecionados.filter(p => p.selecionado);
+    expect(selecionados).toHaveLength(6);
+  });
+});
+
+describe('11. CustosCalculados (compat com renderers genericos)', () => {
+  it('secao_3_honorarios sempre tem 2 linhas (projetos + ART/TRT)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.custos.secao_3_honorarios).toHaveLength(2);
+  });
+
+  it('secao_2_taxas SO tem despesas que foram marcadas', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      diligencia_secretaria: { incluir: true, valor: 500 },
+    }));
+    expect(r.custos.secao_2_taxas).toHaveLength(1);
+    expect(r.custos.secao_2_taxas[0].descricao).toMatch(/Diligencia/);
+  });
+
+  it('secao_5_total = total_geral (honorarios + despesas, sem taxa esboco)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      diligencia_secretaria: { incluir: true, valor: 500 },
+    }));
+    expect(r.custos.secao_5_total).toBe(r.projeto_executivo.resumo.total_geral);
+  });
+
+  it('aviso da taxa esboco aparece em avisos', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.custos.avisos.some(a => /R\$ 750,00.*NAO esta incluida/.test(a))).toBe(true);
   });
 });


### PR DESCRIPTION
…(50/50)

Patch incremental sobre v3.24.5. CEO testou o primeiro PDF em prod e solicitou 7 melhorias. Refactor mantem retrocompat — propostas v3.24.5 abrem normal pelo fallback de campos legados.

AJUSTE 1 — Botao "+ Novo Cliente" no form
- Botao ao lado do select usa abrirModalNovoCliente() existente
- Apos cadastro, recarrega lista e auto-seleciona o novo cliente

AJUSTE 2 — Cobranca reestruturada: HONORARIOS (50/50) + DESPESAS a parte
- Engine refatorada com novo retorno CustosProjetoExecutivoV2:
  * honorarios{} — valor_projetos + ART/TRT, parcela_inicial/final 50/50
  * despesas_administrativas{} — diligencia/alvara/placa, fora das parcelas
  * forma_pagamento{tag,texto_renderizado} — gerado por TAG, nao texto livre
  * resumo{} — total_honorarios + total_despesas + total_geral
- PDF: TABELA 1 (Honorarios) + parcelas + TABELA 2 (Despesas, se houver)
  + bloco resumo INVESTIMENTO TOTAL DA OBRA em box azul
- secao_5_total = total_geral (compat com renderers genericos)

AJUSTE 3 — Diligencia de Secretaria como nova despesa
- Item novo `diligencia_secretaria: { incluir, valor }` em despesas
- No form: checkbox + valor + descritivo explicando o que inclui
- No PDF: linha em "Despesas Administrativas" + observacao do escopo

AJUSTE 4 — Forma de Pagamento via 5 TAGS clicaveis
- Tags: integral, sinal_mais_1 (default), sinal_mais_2, duas_vezes, personalizada
- Helper renderizarFormaPagamento() exportado standalone
- Front mostra pre-visualizacao ao vivo do texto da forma
- Textarea custom aparece SO quando tag=personalizada
- No PDF: texto_renderizado vai como bloco "PARCELAMENTO DOS HONORARIOS"

AJUSTE 5 — Alvara + Placa MIGRADOS pra Despesas Administrativas
- Removidos do bloco de Honorarios
- Compat retro: alvara_incluir/alvara_valor/placa_incluir/placa_valor legados continuam funcionando (engine usa como fallback). Forma nova prevalece quando ambos presentes.

AJUSTE 6 — Dropzone de anexos (croqui PDF + imagens)
- Bloco novo "📎 Anexos da Proposta" no form
- Drag-and-drop OU clique para input file
- Lista os arquivos com nome, tamanho e botao remover
- Limites: 10 arquivos, 15MB cada, 50MB total
- Apos POST /api/propostas-consultoria retornar o id, faz upload via /api/propostas-consultoria/:id/anexos (endpoint generico ja existente)
- Pipeline gerarPdfPropostaConsultoriaComAnexos (v3.23.10) ja merge os anexos no PDF final

AJUSTE 7 — Caixa de aviso destacada da Taxa R$ 750
- Movida pra ANTES dos Honorarios (mais visivel)
- Box amarelo com border 2px var(--gold)
- Texto destaca: "CONDICIONAL", "NÃO somado", "Investimento Total"
- Campo R$ inline e editavel

Tests refatorados (src/test/projeto-executivo-engine.test.ts):
- 36 tests cobrindo nova estrutura
- round2 HALF_UP, ART/TRT auto, override manual, despesas separadas, parcelas 50/50 fechando, taxa esboco fora, forma_pagamento por TAG (5 tags + custom), compat retro v3.24.5 (alvara_incluir legacy), defaults estaveis, CustosCalculados consistente

Total: 600 passing / 1 skipped / 0 failures (era 564 -> +36 ajustados).

Persistencia: custos_calculados JSON agora inclui `projeto_executivo` com toda a estrutura nova (honorarios/despesas/forma/resumo) ao lado das secao_1/2/3/4/5 padrao — renderer le os dois.