### PR TITLE
feat(projeto-executivo): area do terreno + taxa de ocupacao + program…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.6",
+  "version": "3.24.8",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/constants/comodosEdificacao.ts
+++ b/src/constants/comodosEdificacao.ts
@@ -1,0 +1,120 @@
+// v3.24.8: Catalogo de comodos de edificacao usado no Programa de Necessidades
+// da Proposta de Projeto Executivo. 6 categorias + 49 comodos.
+//
+// Cada comodo tem `ordem_pdf` pra controlar a ordem no documento final (menores
+// numeros aparecem primeiro). Numeracao com gap (10/11/12.../20/21...) deixa
+// margem pra inserir novos comodos no meio sem renumerar tudo.
+
+export type CategoriaComodo =
+  | 'social'
+  | 'intimo'
+  | 'servico'
+  | 'externo'
+  | 'comercial'
+  | 'tecnico';
+
+export interface ComodoCatalogo {
+  codigo: string;
+  nome: string;
+  nome_plural: string;
+  categoria: CategoriaComodo;
+  icone: string;
+  ordem_pdf: number;
+  observacao_padrao?: string;
+}
+
+export const CATEGORIAS_LABEL: Record<CategoriaComodo, string> = {
+  social:    '🛋 Area Social',
+  intimo:    '🛏 Area Intima',
+  servico:   '🍳 Area de Servico',
+  externo:   '🌳 Area Externa',
+  comercial: '🏪 Area Comercial',
+  tecnico:   '⚙ Areas Tecnicas',
+};
+
+export const COMODOS_CATALOGO: ComodoCatalogo[] = [
+  // ===== SOCIAL =====
+  { codigo: 'sala_estar',       nome: 'Sala de Estar',       nome_plural: 'Salas de Estar',       categoria: 'social', icone: '🛋', ordem_pdf: 10 },
+  { codigo: 'sala_jantar',      nome: 'Sala de Jantar',      nome_plural: 'Salas de Jantar',      categoria: 'social', icone: '🍽', ordem_pdf: 11 },
+  { codigo: 'sala_tv',          nome: 'Sala de TV',          nome_plural: 'Salas de TV',          categoria: 'social', icone: '📺', ordem_pdf: 12 },
+  { codigo: 'sala_integrada',   nome: 'Sala Integrada',      nome_plural: 'Salas Integradas',     categoria: 'social', icone: '🏠', ordem_pdf: 13, observacao_padrao: 'Estar/Jantar conjugados' },
+  { codigo: 'home_office',      nome: 'Home Office',         nome_plural: 'Home Offices',         categoria: 'social', icone: '💻', ordem_pdf: 14 },
+  { codigo: 'escritorio',       nome: 'Escritorio',          nome_plural: 'Escritorios',          categoria: 'social', icone: '📚', ordem_pdf: 15 },
+  { codigo: 'hall_entrada',     nome: 'Hall de Entrada',     nome_plural: 'Halls de Entrada',     categoria: 'social', icone: '🚪', ordem_pdf: 16 },
+  { codigo: 'lavabo',           nome: 'Lavabo',              nome_plural: 'Lavabos',              categoria: 'social', icone: '🚻', ordem_pdf: 17 },
+  { codigo: 'sala_jogos',       nome: 'Sala de Jogos',       nome_plural: 'Salas de Jogos',       categoria: 'social', icone: '🎮', ordem_pdf: 18 },
+
+  // ===== INTIMO =====
+  { codigo: 'suite_master',     nome: 'Suite Master',        nome_plural: 'Suites Master',        categoria: 'intimo', icone: '👑', ordem_pdf: 20, observacao_padrao: 'Com banheiro privativo e closet' },
+  { codigo: 'suite_closet',     nome: 'Suite com Closet',    nome_plural: 'Suites com Closet',    categoria: 'intimo', icone: '🚪', ordem_pdf: 21 },
+  { codigo: 'suite_simples',    nome: 'Suite Simples',       nome_plural: 'Suites Simples',       categoria: 'intimo', icone: '🛏', ordem_pdf: 22, observacao_padrao: 'Com banheiro privativo' },
+  { codigo: 'quarto_casal',     nome: 'Quarto de Casal',     nome_plural: 'Quartos de Casal',     categoria: 'intimo', icone: '💑', ordem_pdf: 23 },
+  { codigo: 'quarto_solteiro',  nome: 'Quarto de Solteiro',  nome_plural: 'Quartos de Solteiro',  categoria: 'intimo', icone: '🧒', ordem_pdf: 24 },
+  { codigo: 'quarto',           nome: 'Quarto',              nome_plural: 'Quartos',              categoria: 'intimo', icone: '🛌', ordem_pdf: 25 },
+  { codigo: 'quarto_hospede',   nome: 'Quarto de Hospedes',  nome_plural: 'Quartos de Hospedes',  categoria: 'intimo', icone: '🛎', ordem_pdf: 26 },
+  { codigo: 'closet',           nome: 'Closet',              nome_plural: 'Closets',              categoria: 'intimo', icone: '👔', ordem_pdf: 27 },
+  { codigo: 'banheiro_social',  nome: 'Banheiro Social',     nome_plural: 'Banheiros Sociais',    categoria: 'intimo', icone: '🚿', ordem_pdf: 28 },
+  { codigo: 'banheiro_suite',   nome: 'Banheiro de Suite',   nome_plural: 'Banheiros de Suite',   categoria: 'intimo', icone: '🛁', ordem_pdf: 29 },
+
+  // ===== SERVICO =====
+  { codigo: 'cozinha',          nome: 'Cozinha',             nome_plural: 'Cozinhas',             categoria: 'servico', icone: '🍳', ordem_pdf: 40 },
+  { codigo: 'cozinha_americana',nome: 'Cozinha Americana',   nome_plural: 'Cozinhas Americanas',  categoria: 'servico', icone: '🥘', ordem_pdf: 41 },
+  { codigo: 'cozinha_gourmet',  nome: 'Cozinha Gourmet',     nome_plural: 'Cozinhas Gourmet',     categoria: 'servico', icone: '👨‍🍳', ordem_pdf: 42 },
+  { codigo: 'copa',             nome: 'Copa',                nome_plural: 'Copas',                categoria: 'servico', icone: '🥄', ordem_pdf: 43 },
+  { codigo: 'area_servico',     nome: 'Area de Servico',     nome_plural: 'Areas de Servico',     categoria: 'servico', icone: '🧺', ordem_pdf: 44 },
+  { codigo: 'lavanderia',       nome: 'Lavanderia',          nome_plural: 'Lavanderias',          categoria: 'servico', icone: '🧼', ordem_pdf: 45 },
+  { codigo: 'despensa',         nome: 'Despensa',            nome_plural: 'Despensas',            categoria: 'servico', icone: '🥫', ordem_pdf: 46 },
+  { codigo: 'dce',              nome: 'DCE',                 nome_plural: 'DCEs',                 categoria: 'servico', icone: '🧹', ordem_pdf: 47, observacao_padrao: 'Dependencia Completa de Empregada' },
+
+  // ===== EXTERNO =====
+  { codigo: 'varanda',          nome: 'Varanda',             nome_plural: 'Varandas',             categoria: 'externo', icone: '🌅', ordem_pdf: 60 },
+  { codigo: 'sacada',           nome: 'Sacada',              nome_plural: 'Sacadas',              categoria: 'externo', icone: '🌇', ordem_pdf: 61 },
+  { codigo: 'terraco',          nome: 'Terraco',             nome_plural: 'Terracos',             categoria: 'externo', icone: '🏙', ordem_pdf: 62 },
+  { codigo: 'area_gourmet',     nome: 'Area Gourmet',        nome_plural: 'Areas Gourmet',        categoria: 'externo', icone: '🍖', ordem_pdf: 63 },
+  { codigo: 'churrasqueira',    nome: 'Churrasqueira',       nome_plural: 'Churrasqueiras',       categoria: 'externo', icone: '🔥', ordem_pdf: 64 },
+  { codigo: 'piscina',          nome: 'Piscina',             nome_plural: 'Piscinas',             categoria: 'externo', icone: '🏊', ordem_pdf: 65 },
+  { codigo: 'jardim',           nome: 'Jardim',              nome_plural: 'Jardins',              categoria: 'externo', icone: '🌳', ordem_pdf: 66 },
+  { codigo: 'quintal',          nome: 'Quintal',             nome_plural: 'Quintais',             categoria: 'externo', icone: '🌿', ordem_pdf: 67 },
+  { codigo: 'garagem',          nome: 'Garagem',             nome_plural: 'Garagens',             categoria: 'externo', icone: '🚗', ordem_pdf: 68 },
+  { codigo: 'vaga_coberta',     nome: 'Vaga Coberta',        nome_plural: 'Vagas Cobertas',       categoria: 'externo', icone: '🅿', ordem_pdf: 69 },
+  { codigo: 'edicula',          nome: 'Edicula',             nome_plural: 'Ediculas',             categoria: 'externo', icone: '🏚', ordem_pdf: 70 },
+
+  // ===== COMERCIAL =====
+  { codigo: 'salao_comercial',  nome: 'Salao Comercial',     nome_plural: 'Saloes Comerciais',    categoria: 'comercial', icone: '🏪', ordem_pdf: 80 },
+  { codigo: 'loja',             nome: 'Loja',                nome_plural: 'Lojas',                categoria: 'comercial', icone: '🛍', ordem_pdf: 81 },
+  { codigo: 'recepcao',         nome: 'Recepcao',            nome_plural: 'Recepcoes',            categoria: 'comercial', icone: '🛎', ordem_pdf: 82 },
+  { codigo: 'sala_atendimento', nome: 'Sala de Atendimento', nome_plural: 'Salas de Atendimento', categoria: 'comercial', icone: '💼', ordem_pdf: 83 },
+  { codigo: 'sala_reuniao',     nome: 'Sala de Reuniao',     nome_plural: 'Salas de Reuniao',     categoria: 'comercial', icone: '👥', ordem_pdf: 84 },
+  { codigo: 'almoxarifado',     nome: 'Almoxarifado',        nome_plural: 'Almoxarifados',        categoria: 'comercial', icone: '📦', ordem_pdf: 85 },
+  { codigo: 'deposito',         nome: 'Deposito',            nome_plural: 'Depositos',            categoria: 'comercial', icone: '🗄', ordem_pdf: 86 },
+  { codigo: 'banheiro_pne',     nome: 'Banheiro PNE',        nome_plural: 'Banheiros PNE',        categoria: 'comercial', icone: '♿', ordem_pdf: 87, observacao_padrao: 'Acessivel conforme NBR 9050' },
+
+  // ===== TECNICO =====
+  { codigo: 'casa_maquinas',    nome: 'Casa de Maquinas',    nome_plural: 'Casas de Maquinas',    categoria: 'tecnico', icone: '⚙', ordem_pdf: 90 },
+  { codigo: 'reservatorio',     nome: 'Reservatorio',        nome_plural: 'Reservatorios',        categoria: 'tecnico', icone: '💧', ordem_pdf: 91, observacao_padrao: "Caixa d'agua superior/inferior" },
+  { codigo: 'subsolo',          nome: 'Subsolo',             nome_plural: 'Subsolos',             categoria: 'tecnico', icone: '🕳', ordem_pdf: 92 },
+  { codigo: 'circulacao',       nome: 'Circulacao',          nome_plural: 'Circulacoes',          categoria: 'tecnico', icone: '↔', ordem_pdf: 93 },
+  { codigo: 'escada',           nome: 'Escada',              nome_plural: 'Escadas',              categoria: 'tecnico', icone: '🪜', ordem_pdf: 94 },
+  { codigo: 'mezanino',         nome: 'Mezanino',            nome_plural: 'Mezaninos',            categoria: 'tecnico', icone: '🏗', ordem_pdf: 95 },
+];
+
+export function buscarComodo(codigo: string): ComodoCatalogo | undefined {
+  return COMODOS_CATALOGO.find(c => c.codigo === codigo);
+}
+
+export function listarComodosPorCategoria(): Record<CategoriaComodo, ComodoCatalogo[]> {
+  const out: Record<CategoriaComodo, ComodoCatalogo[]> = {
+    social: [], intimo: [], servico: [], externo: [], comercial: [], tecnico: [],
+  };
+  for (const c of COMODOS_CATALOGO) out[c.categoria].push(c);
+  // Garante ordenacao por ordem_pdf dentro de cada categoria
+  for (const k of Object.keys(out) as CategoriaComodo[]) {
+    out[k].sort((a, b) => a.ordem_pdf - b.ordem_pdf);
+  }
+  return out;
+}
+
+// v3.24.8: ordem padrao de exibicao das categorias no PDF/UI
+export const ORDEM_CATEGORIAS: CategoriaComodo[] = [
+  'social', 'intimo', 'servico', 'externo', 'comercial', 'tecnico',
+];

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -531,25 +531,45 @@ export function renderProjetoExecutivoBody(
   const ufObra = (di.uf_obra as string) || 'MA';
   const tipoEdif = ((di.tipo_edificacao as string) || 'residencial').toUpperCase();
   const area = Number(di.area_construir) || 0;
+  // v3.24.8: area do terreno + taxa de ocupacao (opcional)
+  const areaTerreno = Number(di.area_terreno) || 0;
+  const taxaOcup = (di.taxa_ocupacao_percentual != null && areaTerreno > 0)
+    ? Number(di.taxa_ocupacao_percentual)
+    : (areaTerreno > 0 ? Math.round((area / areaTerreno) * 10000) / 100 : 0);
   const valorM2 = Number(di.valor_m2) || 25;
   const taxaEsboco = Number(di.taxa_esboco) || 750;
   const projetosLista = Array.isArray(di.projetos_selecionados)
     ? (di.projetos_selecionados as Array<{ codigo: string; nome: string; selecionado: boolean; detalhamento_entrega: string }>).filter(x => x.selecionado)
     : [];
+  // v3.24.8: Programa de Necessidades — comodos selecionados
+  const programaNecessidades = Array.isArray(di.programa_necessidades)
+    ? (di.programa_necessidades as Array<{ codigo: string; nome: string; nome_plural: string; categoria: string; ordem_pdf: number; quantidade: number; observacao?: string | null }>)
+    : [];
 
   // ── 1. OBJETO ─────────────────────────────────────────────────────────
+  // v3.24.8: texto inclui terreno + taxa de ocupacao + referencia ao programa
+  // quando esses dados estao disponiveis.
+  const partesObj: string[] = [];
+  partesObj.push(`area total a construir de ${area.toFixed(2)} m²`);
+  if (areaTerreno > 0) {
+    partesObj.push(`implantada em terreno de ${areaTerreno.toFixed(2)} m² (taxa de ocupacao de ${taxaOcup.toFixed(2)}%)`);
+  }
+  const partePrograma = programaNecessidades.length > 0
+    ? ', contemplando o PROGRAMA DE NECESSIDADES descrito a seguir,'
+    : ',';
   doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold')
      .text('1. Objeto', COL_X_INI, doc.y, { width: COL_W });
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.3);
   doc.fontSize(10).fillColor('#222').font('Helvetica')
      .text(
-       `A presente proposta tem por objeto a prestacao de servicos tecnicos especializados para a CONFECCAO DOS PROJETOS EXECUTIVOS DE ARQUITETURA E COMPLEMENTARES da edificacao abaixo identificada, com area total de ${area.toFixed(2)} m², a serem desenvolvidos em conformidade com as Normas Brasileiras (ABNT), legislacao municipal de ${cidadeObra}/${ufObra} e Codigo de Obras vigente, sob responsabilidade tecnica do profissional habilitado.`,
+       `A presente proposta tem por objeto a prestacao de servicos tecnicos especializados para a CONFECCAO DOS PROJETOS EXECUTIVOS DE ARQUITETURA E COMPLEMENTARES da edificacao abaixo identificada, com ${partesObj.join(', ')}${partePrograma} a serem desenvolvidos em conformidade com as Normas Brasileiras (ABNT), legislacao municipal de ${cidadeObra}/${ufObra} e Codigo de Obras vigente, sob responsabilidade tecnica do profissional habilitado.`,
        COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
      );
   doc.moveDown(0.6);
 
   // ── 2. IMOVEL ─────────────────────────────────────────────────────────
+  // v3.24.8: adiciona Area do Terreno e Taxa de Ocupacao quando informadas
   doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('2. Imovel / Obra');
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.3);
@@ -557,8 +577,72 @@ export function renderProjetoExecutivoBody(
   doc.text(`Endereco: ${enderecoObra}`, COL_X_INI, doc.y, { width: COL_W, continued: false });
   doc.text(`Cidade/UF: ${cidadeObra}/${ufObra}`, COL_X_INI, doc.y, { width: COL_W });
   doc.text(`Tipo de edificacao: ${tipoEdif}`, COL_X_INI, doc.y, { width: COL_W });
+  if (areaTerreno > 0) {
+    doc.text(`Area do terreno: ${areaTerreno.toFixed(2)} m²`, COL_X_INI, doc.y, { width: COL_W });
+  }
   doc.text(`Area a construir: ${area.toFixed(2)} m²`, COL_X_INI, doc.y, { width: COL_W });
+  if (areaTerreno > 0) {
+    doc.text(`Taxa de ocupacao: ${taxaOcup.toFixed(2)}%`, COL_X_INI, doc.y, { width: COL_W });
+    if (taxaOcup > 70) {
+      doc.fontSize(8.5).fillColor('#92400e').font('Helvetica-Oblique')
+         .text(
+           '* A taxa de ocupacao informada devera ser validada conforme o Plano Diretor do Municipio de ' +
+           `${cidadeObra}/${ufObra} e a Lei de Uso e Ocupacao do Solo vigente antes da aprovacao do projeto.`,
+           COL_X_INI, doc.y, { width: COL_W, align: 'justify' },
+         );
+      doc.fillColor('#222').font('Helvetica').fontSize(10);
+    }
+  }
   doc.moveDown(0.6);
+
+  // v3.24.8: Programa de Necessidades — listagem de comodos agrupados por categoria
+  if (programaNecessidades.length > 0) {
+    if (doc.y > 620) doc.addPage();
+    doc.x = COL_X_INI;
+    doc.fontSize(12).fillColor(corHex).font('Helvetica-Bold').text('3. Programa de Necessidades');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.3);
+    doc.fontSize(10).fillColor('#222').font('Helvetica')
+       .text('O presente projeto contempla o programa de necessidades abaixo discriminado, composto pelos seguintes comodos:',
+         COL_X_INI, doc.y, { width: COL_W, align: 'justify' });
+    doc.moveDown(0.3);
+
+    // Agrupa por categoria, mantem ordem_pdf interno
+    const CAT_LABEL: Record<string, string> = {
+      social: 'Area Social', intimo: 'Area Intima', servico: 'Area de Servico',
+      externo: 'Area Externa', comercial: 'Area Comercial', tecnico: 'Areas Tecnicas',
+    };
+    const CAT_ORDER = ['social', 'intimo', 'servico', 'externo', 'comercial', 'tecnico'];
+    const grupos: Record<string, typeof programaNecessidades> = {};
+    for (const item of [...programaNecessidades].sort((a, b) => a.ordem_pdf - b.ordem_pdf)) {
+      (grupos[item.categoria] ??= []).push(item);
+    }
+    for (const cat of CAT_ORDER) {
+      const items = grupos[cat];
+      if (!items || items.length === 0) continue;
+      if (doc.y > 720) doc.addPage();
+      doc.x = COL_X_INI;
+      doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+         .text(CAT_LABEL[cat], COL_X_INI, doc.y, { width: COL_W });
+      doc.font('Helvetica').fillColor('#222');
+      for (const it of items) {
+        const nome = it.quantidade > 1 ? it.nome_plural : it.nome;
+        const linha = `  • ${String(it.quantidade).padStart(2, '0')} × ${nome}` +
+                      (it.observacao ? ` — ${it.observacao}` : '');
+        doc.x = COL_X_INI;
+        doc.fontSize(9.5).fillColor('#222')
+           .text(linha, COL_X_INI + 8, doc.y, { width: COL_W - 16, continued: false });
+      }
+      doc.moveDown(0.2);
+    }
+    const totalTipos = programaNecessidades.length;
+    const totalComodos = programaNecessidades.reduce((s, p) => s + p.quantidade, 0);
+    doc.moveDown(0.2);
+    doc.fontSize(9).fillColor('#666').font('Helvetica-Oblique')
+       .text(`Total: ${totalTipos} tipo(s) de comodo, ${totalComodos} ambiente(s) projetado(s).`,
+         COL_X_INI, doc.y, { width: COL_W, align: 'right' });
+    doc.moveDown(0.4);
+  }
 
   // ── 3. ETAPA PRELIMINAR (box amarelo da TAXA DE R$ 750) ───────────────
   if (doc.y > 600) doc.addPage();

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -8645,13 +8645,34 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
         </label>
       </div>
 
+      <!-- v3.24.8: Parametros do Imovel — area terreno + area construir + taxa ocupacao -->
       <div style="margin-top:12px;">
-        <p style="font-weight:600; color:var(--neon); font-size:13px;">📐 Parâmetros de Cálculo</p>
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
-          <label>Área a construir (m²) <input id="peArea" type="number" step="0.01" min="0" value="${di.area_construir||''}" style="width:100%;"></label>
-          <label>Valor R$/m² <input id="peVm2" type="number" step="0.01" min="0" value="${di.valor_m2||25}" style="width:100%;"></label>
+        <p style="font-weight:600; color:var(--neon); font-size:13px;">📐 Parâmetros do Imóvel</p>
+        <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px;">
+          <label>Área do Terreno (m²) <input id="peAreaTer" type="number" step="0.01" min="0" value="${di.area_terreno||''}" placeholder="220,00" style="width:100%;"></label>
+          <label>Área a Construir (m²) * <input id="peArea" type="number" step="0.01" min="0" value="${di.area_construir||''}" placeholder="71,00" style="width:100%;"></label>
+          <div>
+            <label style="font-size:12px; color:var(--text-muted);">Taxa de Ocupação</label>
+            <div id="peTaxaOcupBox" style="padding:8px 10px; border:1px solid var(--border); border-radius:6px; background:var(--bg-elev); min-height:42px; display:flex; flex-direction:column; justify-content:center;">
+              <span id="peTaxaOcupValor" style="font-weight:700; font-size:14px;">—</span>
+              <span id="peTaxaOcupStatus" style="font-size:10px; opacity:0.8;"></span>
+            </div>
+          </div>
         </div>
+        <label style="display:block; margin-top:8px;">Valor R$/m² <input id="peVm2" type="number" step="0.01" min="0" value="${di.valor_m2||25}" style="width:100%;"></label>
         <p id="peValorProjetosLine" style="margin:6px 0 0; font-size:12px; color:var(--text-muted);">Valor dos Projetos: <span id="peValorProjetos">R$ 0,00</span></p>
+      </div>
+
+      <!-- v3.24.8: Programa de Necessidades — comodos da edificacao -->
+      <div style="margin-top:14px; padding:12px; border:1px solid var(--border); border-radius:8px; background:var(--bg-elev);">
+        <p style="margin:0 0 6px; font-weight:600; color:var(--neon); font-size:13px;">🏗 Programa de Necessidades — Cômodos da Edificação</p>
+        <p style="margin:0 0 8px; font-size:11px; color:var(--text-muted);">Marque os cômodos do projeto e ajuste a quantidade. Os selecionados serão listados como parte do objeto contratual.</p>
+        <div id="peComodosResumo" style="padding:8px 10px; background:rgba(0,255,136,0.08); border-left:3px solid var(--neon); border-radius:4px; margin-bottom:10px; font-size:12px;">
+          <strong>Nenhum cômodo selecionado ainda.</strong>
+        </div>
+        <div id="peComodosCategorias" style="display:flex; flex-direction:column; gap:14px;">
+          <p style="color:var(--text-muted); font-size:11px; font-style:italic;">Carregando catálogo de cômodos…</p>
+        </div>
       </div>
 
       <div style="margin-top:12px;">
@@ -8836,6 +8857,205 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
     }
   }
 
+  // v3.24.8: Taxa de Ocupacao ao vivo + validacao area < terreno
+  function atualizarTaxaOcupacaoPE() {
+    const ac = Number(document.getElementById('peArea').value) || 0;
+    const at = Number(document.getElementById('peAreaTer').value) || 0;
+    const box = document.getElementById('peTaxaOcupBox');
+    const valor = document.getElementById('peTaxaOcupValor');
+    const status = document.getElementById('peTaxaOcupStatus');
+    if (!at || at <= 0) {
+      valor.textContent = '—'; status.textContent = '';
+      box.style.borderColor = 'var(--border)';
+      box.style.background = 'var(--bg-elev)';
+      valor.style.color = 'var(--text)';
+      return;
+    }
+    if (ac > at) {
+      valor.textContent = '⚠ Inválido';
+      status.textContent = 'Construir > terreno';
+      box.style.borderColor = '#f87171';
+      box.style.background = 'rgba(248,113,113,0.10)';
+      valor.style.color = '#fca5a5';
+      return;
+    }
+    const taxa = (ac / at) * 100;
+    valor.textContent = taxa.toFixed(2) + '%';
+    if (taxa <= 50) {
+      status.textContent = 'Ocupação confortável';
+      box.style.borderColor = 'var(--neon)';
+      box.style.background = 'rgba(0,255,136,0.10)';
+      valor.style.color = 'var(--neon)';
+    } else if (taxa <= 70) {
+      status.textContent = 'Dentro do limite usual';
+      box.style.borderColor = 'var(--gold)';
+      box.style.background = 'rgba(212,184,0,0.12)';
+      valor.style.color = 'var(--gold)';
+    } else {
+      status.textContent = '⚠ Verifique o Plano Diretor';
+      box.style.borderColor = '#f87171';
+      box.style.background = 'rgba(248,113,113,0.10)';
+      valor.style.color = '#fca5a5';
+    }
+  }
+
+  // v3.24.8: Programa de Necessidades — carrega catalogo + estado local
+  state.peComodos = new Map(); // Map<codigo, { catalogo, quantidade }>
+  // Reidrata do dados_imovel se editando
+  if (Array.isArray(di.programa_necessidades)) {
+    for (const it of di.programa_necessidades) {
+      state.peComodos.set(it.codigo, {
+        catalogo: it,
+        quantidade: Number(it.quantidade) || 1,
+      });
+    }
+  }
+
+  async function carregarCatalogoComodosPE() {
+    try {
+      const r = await fetch('/api/propostas-consultoria/projeto-executivo/comodos-catalogo', { credentials: 'same-origin' });
+      if (!r.ok) throw new Error('catalogo nao disponivel');
+      const { categorias, comodos, ordem_categorias } = await r.json();
+      renderComodosUI(categorias, comodos, ordem_categorias);
+    } catch (e) {
+      document.getElementById('peComodosCategorias').innerHTML =
+        '<p style="color:var(--danger); font-size:12px;">Erro ao carregar catálogo: ' + escape(e.message) + '</p>';
+    }
+  }
+
+  function renderComodosUI(categorias, comodos, ordemCategorias) {
+    const grupos = {};
+    for (const c of comodos) (grupos[c.categoria] ??= []).push(c);
+    const container = document.getElementById('peComodosCategorias');
+    container.innerHTML = '';
+    for (const catKey of (ordemCategorias || Object.keys(categorias))) {
+      const items = grupos[catKey] || [];
+      if (items.length === 0) continue;
+      const sec = document.createElement('div');
+      sec.innerHTML = `
+        <p style="margin:0 0 6px; color:var(--text-muted); font-size:11px; text-transform:uppercase; letter-spacing:0.5px;">${escape(categorias[catKey])}</p>
+        <div data-cat="${catKey}" style="display:flex; flex-wrap:wrap; gap:6px;"></div>
+      `;
+      const wrap = sec.querySelector('[data-cat]');
+      for (const c of items) {
+        const tag = document.createElement('div');
+        tag.dataset.codigo = c.codigo;
+        tag.dataset.catalogo = JSON.stringify(c);
+        tag.style.cssText = 'display:flex; align-items:center; gap:2px;';
+        tag.innerHTML = `
+          <button type="button" class="peComBtn" data-codigo="${c.codigo}" style="display:flex; align-items:center; gap:4px; background:var(--bg-elev); color:var(--text); border:2px solid var(--border); border-radius:18px; padding:6px 12px; font-size:12px; cursor:pointer; min-height:36px;">
+            ${c.icone} ${escape(c.nome)}
+          </button>
+          <div class="peComQtd" data-codigo="${c.codigo}" style="display:none; align-items:center; gap:2px; background:rgba(0,255,136,0.10); border:1px solid var(--neon); border-radius:14px; padding:1px 4px;">
+            <button type="button" data-act="dec" data-codigo="${c.codigo}" style="background:transparent; border:0; color:var(--neon); font-size:14px; cursor:pointer; padding:0 6px;">−</button>
+            <input type="number" data-codigo="${c.codigo}" min="1" max="20" value="1" style="width:30px; text-align:center; background:transparent; border:0; color:var(--neon); font-weight:700; font-size:12px;">
+            <button type="button" data-act="inc" data-codigo="${c.codigo}" style="background:transparent; border:0; color:var(--neon); font-size:14px; cursor:pointer; padding:0 6px;">+</button>
+          </div>
+        `;
+        wrap.appendChild(tag);
+      }
+      container.appendChild(sec);
+    }
+    // Bind clicks
+    container.querySelectorAll('.peComBtn').forEach(b => b.onclick = () => {
+      const codigo = b.dataset.codigo;
+      const tag = b.closest('[data-codigo]');
+      const catalogo = JSON.parse(tag.dataset.catalogo);
+      if (state.peComodos.has(codigo)) {
+        state.peComodos.delete(codigo);
+      } else {
+        state.peComodos.set(codigo, { catalogo, quantidade: 1 });
+      }
+      refletirTagComodo(codigo);
+      atualizarResumoComodos();
+    });
+    container.querySelectorAll('[data-act]').forEach(b => b.onclick = () => {
+      const codigo = b.dataset.codigo;
+      const entry = state.peComodos.get(codigo);
+      if (!entry) return;
+      const delta = b.dataset.act === 'inc' ? 1 : -1;
+      const nova = Math.max(1, Math.min(20, entry.quantidade + delta));
+      entry.quantidade = nova;
+      refletirTagComodo(codigo);
+      atualizarResumoComodos();
+    });
+    container.querySelectorAll('.peComQtd input').forEach(i => i.onchange = () => {
+      const codigo = i.dataset.codigo;
+      const entry = state.peComodos.get(codigo);
+      if (!entry) return;
+      const n = Math.max(1, Math.min(20, parseInt(i.value, 10) || 1));
+      entry.quantidade = n;
+      refletirTagComodo(codigo);
+      atualizarResumoComodos();
+    });
+    // Re-render estado inicial (caso editando)
+    for (const codigo of state.peComodos.keys()) refletirTagComodo(codigo);
+    atualizarResumoComodos();
+  }
+
+  function refletirTagComodo(codigo) {
+    const btn = document.querySelector(`.peComBtn[data-codigo="${codigo}"]`);
+    const qtdBox = document.querySelector(`.peComQtd[data-codigo="${codigo}"]`);
+    const input = qtdBox ? qtdBox.querySelector('input') : null;
+    const entry = state.peComodos.get(codigo);
+    if (!btn) return;
+    if (entry) {
+      btn.style.background = 'var(--neon)';
+      btn.style.color = '#0a1a0a';
+      btn.style.borderColor = 'var(--neon)';
+      btn.style.fontWeight = '700';
+      qtdBox.style.display = 'flex';
+      if (input) input.value = entry.quantidade;
+    } else {
+      btn.style.background = 'var(--bg-elev)';
+      btn.style.color = 'var(--text)';
+      btn.style.borderColor = 'var(--border)';
+      btn.style.fontWeight = '400';
+      qtdBox.style.display = 'none';
+    }
+  }
+
+  function atualizarResumoComodos() {
+    const resumo = document.getElementById('peComodosResumo');
+    if (state.peComodos.size === 0) {
+      resumo.innerHTML = '<strong>Nenhum cômodo selecionado ainda.</strong>';
+      return;
+    }
+    const arr = Array.from(state.peComodos.values())
+      .sort((a, b) => a.catalogo.ordem_pdf - b.catalogo.ordem_pdf);
+    const total = arr.reduce((s, e) => s + e.quantidade, 0);
+    const pills = arr.map(({ catalogo, quantidade }) => {
+      const nome = quantidade > 1 ? catalogo.nome_plural : catalogo.nome;
+      return `<span style="background:rgba(0,255,136,0.15); color:var(--neon); padding:3px 8px; border-radius:10px; font-size:11px; display:inline-block; margin:2px;">${catalogo.icone} ${quantidade}× ${escape(nome)}</span>`;
+    }).join('');
+    resumo.innerHTML = `
+      <strong>${state.peComodos.size} tipo(s), ${total} cômodo(s):</strong>
+      <div style="margin-top:6px;">${pills}</div>
+    `;
+  }
+
+  function coletarProgramaNecessidades() {
+    return Array.from(state.peComodos.values())
+      .sort((a, b) => a.catalogo.ordem_pdf - b.catalogo.ordem_pdf)
+      .map(({ catalogo, quantidade }) => ({
+        codigo: catalogo.codigo,
+        nome: catalogo.nome,
+        nome_plural: catalogo.nome_plural,
+        categoria: catalogo.categoria,
+        ordem_pdf: catalogo.ordem_pdf,
+        quantidade,
+        observacao: catalogo.observacao_padrao || catalogo.observacao || null,
+      }));
+  }
+
+  // Dispara carregamento + atualiza taxa quando area/terreno mudam
+  carregarCatalogoComodosPE();
+  ['peArea', 'peAreaTer'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener('input', atualizarTaxaOcupacaoPE);
+  });
+  atualizarTaxaOcupacaoPE();
+
   function recalcResumo() {
     const area = Number(document.getElementById('peArea').value) || 0;
     const vm2  = Number(document.getElementById('peVm2').value)  || 0;
@@ -8959,12 +9179,28 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
       detalhamento_entrega: document.querySelector(`[data-pe-detail="${idx}"]`).value.trim(),
     }));
 
+    // v3.24.8: valida area_terreno >= area_construir antes de submeter
+    const areaTer = Number(document.getElementById('peAreaTer').value) || 0;
+    if (areaTer > 0 && area > areaTer) {
+      return alert('Área a construir não pode ser maior que a área do terreno.');
+    }
+    // v3.24.8: alerta se nenhum cômodo selecionado (mas deixa prosseguir)
+    if (state.peComodos.size === 0) {
+      if (!confirm('Nenhum cômodo foi selecionado no Programa de Necessidades. Deseja prosseguir mesmo assim?')) return;
+    }
+    const taxaOcup = areaTer > 0 ? Math.round((area / areaTer) * 10000) / 100 : undefined;
+
     const dados_imovel = {
       endereco_obra: enderecoTxt,
       cidade_obra: document.getElementById('peCidade').value.trim() || 'Açailândia',
       uf_obra: document.getElementById('peUf').value.trim().toUpperCase() || 'MA',
       tipo_edificacao: document.getElementById('peTipo').value,
       area_construir: area,
+      // v3.24.8: terreno + taxa de ocupacao
+      area_terreno: areaTer > 0 ? areaTer : null,
+      taxa_ocupacao_percentual: taxaOcup ?? null,
+      // v3.24.8: programa de necessidades
+      programa_necessidades: coletarProgramaNecessidades(),
       valor_m2: vm2,
       responsabilidade_auto: document.getElementById('peRtAuto').checked,
       responsabilidade_tipo: document.getElementById('peRtTipo').value,

--- a/src/server.ts
+++ b/src/server.ts
@@ -3464,6 +3464,18 @@ app.put   ('/api/propostas-consultoria/:id',
   apiHandle(args => propostasConsultoria.atualizarPropostaConsultoria(args as Parameters<typeof propostasConsultoria.atualizarPropostaConsultoria>[0])));
 app.post  ('/api/propostas-consultoria/preview',
   apiHandle(args => propostasConsultoria.previewCustoConsultoria(args as Parameters<typeof propostasConsultoria.previewCustoConsultoria>[0])));
+
+// v3.24.8: Catalogo de comodos do Programa de Necessidades (Projeto Executivo).
+// Publico (so leitura de constante TS), serve pro front montar tags clicaveis.
+app.get('/api/propostas-consultoria/projeto-executivo/comodos-catalogo', (_req: Request, res: Response) => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const m = require('./constants/comodosEdificacao');
+  res.json({
+    categorias: m.CATEGORIAS_LABEL,
+    comodos: m.COMODOS_CATALOGO,
+    ordem_categorias: m.ORDEM_CATEGORIAS,
+  });
+});
 app.get   ('/api/propostas-consultoria/:id/pdf', async (req: Request, res: Response) => {
   try {
     const id = String(req.params.id);

--- a/src/services/pricing/projetoExecutivo.ts
+++ b/src/services/pricing/projetoExecutivo.ts
@@ -22,6 +22,16 @@ export function round2(n: number): number {
   return Math.round((n + Number.EPSILON) * 100) / 100;
 }
 
+// v3.24.8: helper de Taxa de Ocupacao (TO%) — usado pela engine e exposto
+// pra testes. Quando area_terreno ausente/0/negativa, retorna undefined.
+export function calcularTaxaOcupacao(
+  areaConstruir: number,
+  areaTerreno?: number,
+): number | undefined {
+  if (!areaTerreno || areaTerreno <= 0) return undefined;
+  return round2((areaConstruir / areaTerreno) * 100);
+}
+
 export const DEFAULTS_PROJETO_EXECUTIVO = {
   VALOR_M2: 25.00,
   TAXA_ESBOCO: 750.00,
@@ -220,6 +230,8 @@ export function renderizarFormaPagamento(
 export interface CustosProjetoExecutivoV2 {
   honorarios: {
     area_construir: number;
+    area_terreno?: number;                 // v3.24.8
+    taxa_ocupacao_percentual?: number;     // v3.24.8 (0-100)
     valor_m2: number;
     valor_projetos: number;
     responsabilidade_tipo: 'ART' | 'TRT';
@@ -265,6 +277,13 @@ export async function calcularProjetoExecutivo(
   if (!input.valor_m2 || input.valor_m2 <= 0) {
     throw new Error('valor_m2 deve ser maior que zero');
   }
+  // v3.24.8: valida area_terreno quando informada
+  if (input.area_terreno !== undefined && input.area_terreno > 0) {
+    if (input.area_construir > input.area_terreno) {
+      throw new Error('Area a construir nao pode ser maior que a area do terreno.');
+    }
+  }
+  const taxa_ocupacao_percentual = calcularTaxaOcupacao(input.area_construir, input.area_terreno);
 
   const valorM2 = input.valor_m2;
   const valor_projetos = round2(input.area_construir * valorM2);
@@ -446,6 +465,8 @@ export async function calcularProjetoExecutivo(
     projeto_executivo: {
       honorarios: {
         area_construir: input.area_construir,
+        area_terreno: input.area_terreno,                  // v3.24.8
+        taxa_ocupacao_percentual,                          // v3.24.8
         valor_m2: valorM2,
         valor_projetos,
         responsabilidade_tipo,

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -374,6 +374,17 @@ export interface DespesaAdmItem {
   valor: number;
 }
 
+// v3.24.8: item do Programa de Necessidades (cada cômodo escolhido)
+export interface ProgramaNecessidadesItem {
+  codigo: string;
+  nome: string;
+  nome_plural: string;
+  categoria: 'social' | 'intimo' | 'servico' | 'externo' | 'comercial' | 'tecnico';
+  ordem_pdf: number;
+  quantidade: number;
+  observacao?: string | null;
+}
+
 export interface InputProjetoExecutivo {
   // Imovel/obra
   endereco_obra: string;
@@ -383,7 +394,14 @@ export interface InputProjetoExecutivo {
 
   // Calculo principal (HONORARIOS)
   area_construir: number;       // m²
+  // v3.24.8: area do terreno (opcional). Quando informada, engine calcula
+  // taxa_ocupacao_percentual = area_construir / area_terreno * 100.
+  // Tambem valida: area_construir <= area_terreno (senao throw).
+  area_terreno?: number;        // m²
   valor_m2: number;             // R$/m² (default 25)
+
+  // v3.24.8: Programa de Necessidades — cômodos da edificação
+  programa_necessidades?: ProgramaNecessidadesItem[];
 
   // ART/TRT — auto por area (>80m² ART) com override manual
   responsabilidade_auto?: boolean;       // default true

--- a/src/test/projeto-executivo-programa-necessidades.test.ts
+++ b/src/test/projeto-executivo-programa-necessidades.test.ts
@@ -1,0 +1,198 @@
+// v3.24.8: tests dos novos campos do Projeto Executivo:
+// - area_terreno + taxa_ocupacao_percentual + validacao
+// - Programa de Necessidades (catalogo de comodos)
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularProjetoExecutivo,
+  calcularTaxaOcupacao,
+} from '../services/pricing/projetoExecutivo';
+import {
+  COMODOS_CATALOGO,
+  buscarComodo,
+  listarComodosPorCategoria,
+  CATEGORIAS_LABEL,
+  ORDEM_CATEGORIAS,
+} from '../constants/comodosEdificacao';
+import type { InputProjetoExecutivo } from '../services/pricing/types';
+
+function inputBase(over: Partial<InputProjetoExecutivo> = {}): InputProjetoExecutivo {
+  return {
+    endereco_obra: 'Rua Teste, 123',
+    cidade_obra: 'Acailandia',
+    uf_obra: 'MA',
+    tipo_edificacao: 'residencial',
+    area_construir: 100,
+    valor_m2: 25,
+    forma_pagamento_tag: 'integral',
+    alvara_incluir: false,
+    alvara_valor: 0,
+    placa_incluir: false,
+    placa_valor: 0,
+    ...over,
+  };
+}
+
+describe('calcularTaxaOcupacao (helper puro)', () => {
+  it('71 / 220 = 32.27%', () => {
+    expect(calcularTaxaOcupacao(71, 220)).toBe(32.27);
+  });
+  it('100 / 100 = 100%', () => {
+    expect(calcularTaxaOcupacao(100, 100)).toBe(100);
+  });
+  it('undefined quando area_terreno ausente/0/negativo', () => {
+    expect(calcularTaxaOcupacao(71)).toBeUndefined();
+    expect(calcularTaxaOcupacao(71, 0)).toBeUndefined();
+    expect(calcularTaxaOcupacao(71, -1)).toBeUndefined();
+  });
+  it('arredonda HALF_UP em 2 casas (round2)', () => {
+    expect(calcularTaxaOcupacao(100, 333.33)).toBe(30);
+  });
+});
+
+describe('Engine: area_terreno + taxa_ocupacao_percentual', () => {
+  it('calcula taxa de ocupacao quando area_terreno informada', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 71, area_terreno: 220,
+    }));
+    expect(r.projeto_executivo.honorarios.area_terreno).toBe(220);
+    expect(r.projeto_executivo.honorarios.taxa_ocupacao_percentual).toBe(32.27);
+  });
+
+  it('omite taxa quando area_terreno ausente', async () => {
+    const r = await calcularProjetoExecutivo(inputBase());
+    expect(r.projeto_executivo.honorarios.area_terreno).toBeUndefined();
+    expect(r.projeto_executivo.honorarios.taxa_ocupacao_percentual).toBeUndefined();
+  });
+
+  it('rejeita area_construir > area_terreno', async () => {
+    await expect(calcularProjetoExecutivo(inputBase({
+      area_construir: 300, area_terreno: 220,
+    }))).rejects.toThrow(/maior que a area do terreno/i);
+  });
+
+  it('aceita area_construir = area_terreno (taxa 100%)', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      area_construir: 100, area_terreno: 100,
+    }));
+    expect(r.projeto_executivo.honorarios.taxa_ocupacao_percentual).toBe(100);
+  });
+});
+
+describe('Catalogo de Comodos', () => {
+  it('tem pelo menos 40 comodos cadastrados', () => {
+    expect(COMODOS_CATALOGO.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('todos os codigos sao unicos', () => {
+    const codigos = COMODOS_CATALOGO.map(c => c.codigo);
+    expect(new Set(codigos).size).toBe(codigos.length);
+  });
+
+  it('busca por codigo retorna comodo correto', () => {
+    const c = buscarComodo('suite_master');
+    expect(c?.nome).toBe('Suite Master');
+    expect(c?.categoria).toBe('intimo');
+    expect(c?.nome_plural).toBe('Suites Master');
+  });
+
+  it('busca por codigo inexistente retorna undefined', () => {
+    expect(buscarComodo('inexistente_xyz')).toBeUndefined();
+  });
+
+  it('agrupa por categoria sem perder itens', () => {
+    const g = listarComodosPorCategoria();
+    const totalAgrupado = Object.values(g).reduce((s, arr) => s + arr.length, 0);
+    expect(totalAgrupado).toBe(COMODOS_CATALOGO.length);
+  });
+
+  it('todos tem ordem_pdf > 0 (crescente dentro de cada categoria)', () => {
+    const grupos = listarComodosPorCategoria();
+    for (const arr of Object.values(grupos)) {
+      expect(arr.every(c => typeof c.ordem_pdf === 'number' && c.ordem_pdf > 0)).toBe(true);
+      // Dentro da categoria, ordem_pdf cresce
+      for (let i = 1; i < arr.length; i++) {
+        expect(arr[i].ordem_pdf).toBeGreaterThanOrEqual(arr[i - 1].ordem_pdf);
+      }
+    }
+  });
+
+  it('todas as categorias tem label definida + estao em ORDEM_CATEGORIAS', () => {
+    for (const cat of ORDEM_CATEGORIAS) {
+      expect(CATEGORIAS_LABEL[cat]).toBeDefined();
+      expect(CATEGORIAS_LABEL[cat].length).toBeGreaterThan(2);
+    }
+    expect(ORDEM_CATEGORIAS).toHaveLength(6);
+  });
+
+  it('comodos com observacao_padrao tem texto > 0', () => {
+    const com_obs = COMODOS_CATALOGO.filter(c => c.observacao_padrao);
+    expect(com_obs.length).toBeGreaterThan(0);
+    for (const c of com_obs) {
+      expect(c.observacao_padrao!.length).toBeGreaterThan(3);
+    }
+  });
+
+  it('plural e diferente do singular pra todos os itens', () => {
+    for (const c of COMODOS_CATALOGO) {
+      expect(c.nome_plural).not.toBe(c.nome);
+      expect(c.nome_plural.length).toBeGreaterThan(c.nome.length - 2);
+    }
+  });
+});
+
+describe('Engine: programa_necessidades persistido', () => {
+  it('aceita lista de comodos no input', async () => {
+    const r = await calcularProjetoExecutivo(inputBase({
+      programa_necessidades: [
+        { codigo: 'suite_master', nome: 'Suite Master', nome_plural: 'Suites Master', categoria: 'intimo', ordem_pdf: 20, quantidade: 1 },
+        { codigo: 'quarto', nome: 'Quarto', nome_plural: 'Quartos', categoria: 'intimo', ordem_pdf: 25, quantidade: 2 },
+      ],
+    }));
+    // Nao impacta o calculo financeiro — soh persiste pra renderizacao do PDF
+    expect(r.projeto_executivo.honorarios.valor_projetos).toBe(2500);
+  });
+
+  it('valor_projetos nao depende de programa_necessidades', async () => {
+    const r1 = await calcularProjetoExecutivo(inputBase({ programa_necessidades: [] }));
+    const r2 = await calcularProjetoExecutivo(inputBase());
+    expect(r1.projeto_executivo.honorarios.valor_projetos)
+      .toBe(r2.projeto_executivo.honorarios.valor_projetos);
+  });
+});
+
+describe('Smoke — endpoint catalogo + UI form', () => {
+  it('server.ts registra GET /api/.../comodos-catalogo', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'server.ts'), 'utf8');
+    expect(src).toContain("/api/propostas-consultoria/projeto-executivo/comodos-catalogo");
+  });
+
+  it('obras.html renderiza Programa de Necessidades + Taxa de Ocupacao', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'obras.html'), 'utf8');
+    // Bloco Taxa de Ocupacao
+    expect(src).toMatch(/id="peAreaTer"/);
+    expect(src).toMatch(/id="peTaxaOcupBox"/);
+    expect(src).toMatch(/atualizarTaxaOcupacaoPE/);
+    // Bloco Programa de Necessidades
+    expect(src).toMatch(/id="peComodosCategorias"/);
+    expect(src).toMatch(/carregarCatalogoComodosPE/);
+    expect(src).toMatch(/coletarProgramaNecessidades/);
+  });
+
+  it('PDF renderiza area do terreno + taxa quando informadas', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'integrations', 'propostasConsultoria.ts'), 'utf8');
+    expect(src).toMatch(/Area do terreno/);
+    expect(src).toMatch(/Taxa de ocupacao/);
+    expect(src).toMatch(/Programa de Necessidades/);
+    expect(src).toMatch(/Plano Diretor/);
+  });
+});


### PR DESCRIPTION
…a de necessidades

Patch incremental sobre v3.24.6 (CEO usou v3.24.7 pra fix de equipe, entao essa PR vira v3.24.8).

AJUSTE A — Area do Terreno + Taxa de Ocupacao
- types: InputProjetoExecutivo += area_terreno?, programa_necessidades?
- engine: calcularTaxaOcupacao(ac, at) helper exportado standalone
- engine: valida area_construir <= area_terreno (throw se maior)
- engine: retorna area_terreno e taxa_ocupacao_percentual em honorarios{}
- PDF: bloco Imovel/Obra ganha linhas "Area do terreno" + "Taxa de ocupacao" quando informadas; nota condicional "verificar Plano Diretor" se >70%
- form: 3 colunas (Terreno · Construir · Taxa Ocupacao) com display colorido ao vivo (verde <=50, dourado <=70, vermelho >70 ou invalido)
- texto do "Objeto" inclui "implantada em terreno de X m² (taxa Y%)"

AJUSTE B — Catalogo de Comodos (NOVO modulo)
- src/constants/comodosEdificacao.ts com 49 comodos em 6 categorias: social (9), intimo (10), servico (8), externo (11), comercial (8), tecnico (6)
- Helpers: buscarComodo, listarComodosPorCategoria, ORDEM_CATEGORIAS
- Cada comodo: codigo, nome, nome_plural, categoria, icone (emoji), ordem_pdf (com gap 10) + observacao_padrao opcional
- Endpoint GET /api/propostas-consultoria/projeto-executivo/comodos-catalogo (publico, so leitura de constante estatica) retorna categorias + comodos
  + ordem pra front montar tags

AJUSTE C — Seletor visual no form
- Bloco "🏗 Programa de Necessidades" entre Parametros e Projetos a Entregar
- Carregamento via fetch async no render do form. Tags clicaveis em pill format por categoria. Click ativa/desativa, qtd com botoes +/- e input numerico (1-20). Estado em state.peComodos: Map<codigo, {catalogo, qtd}>.
- Resumo dinamico no topo do bloco: "N tipo(s), M comodo(s)" + pills com cada selecionado (icone + qtd + plural correto)
- Singular/plural automatico: "1 × Suite" vs "2 × Suites"
- Reidrata estado quando editando proposta existente (de_dados_imovel.programa)

AJUSTE D — Listagem no PDF
- Novo bloco "3. Programa de Necessidades" entre Objeto e Etapa Preliminar
- Cabecalho explicativo + lista agrupada por categoria
- Cada item: "  • 01 × Suite Master — Com banheiro privativo e closet"
- Rodape com contagem total de tipos e ambientes
- Texto do Objeto referencia programa quando ha itens

AJUSTE E — Validacoes
- Frontend: alert "Area construir > terreno" antes do submit
- Frontend: confirm "Nenhum comodo selecionado, prosseguir?" se vazio
- Engine: throw "Area a construir nao pode ser maior que a area do terreno" quando area_construir > area_terreno

AJUSTE F — Caption Z-API (pendente, follow-up)
- Documentado no brief mas nao implementado nesta PR — o template atual ja funciona; melhoria fica pra v3.24.9 quando der tempo de revisar enviarPropostaConsultoriaWhatsApp pra projeto_executivo especificamente.

Persistencia dados_imovel JSON:
{
  ..., area_terreno: number | null, taxa_ocupacao_percentual: number | null, programa_necessidades: [ { codigo, nome, nome_plural, categoria, ordem_pdf, quantidade, observacao? }, ... ] }

22 testes novos em src/test/projeto-executivo-programa-necessidades.test.ts:
- calcularTaxaOcupacao (4): 71/220, 100/100, undefined sem terreno, round2
- Engine area/taxa (4): calcula com terreno, omite sem, rejeita >, aceita =
- Catalogo (8): 40+, codigos unicos, busca, agrupamento, ordem_pdf, CATEGORIAS_LABEL, observacao_padrao com texto, plural != singular
- Engine programa (2): aceita lista, nao afeta valor_projetos
- Smoke server.ts + obras.html + PDF (3): endpoint registrado, UI tem campos novos, PDF gera area/taxa/programa/plano-diretor

Total: 622 passing / 1 skipped / 0 failures (era 600 -> +22).