### PR TITLE
fix(programa-necessidades): selector de comodos nao selecionava (clos…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.9",
+  "version": "3.24.10",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -9000,10 +9000,15 @@ async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
       }
       container.appendChild(sec);
     }
-    // Bind clicks
+    // Bind clicks — v3.24.10 FIX: b.closest('[data-codigo]') retornava o PROPRIO
+    // botao (que tambem tem data-codigo), nao o div pai com data-catalogo.
+    // Resultado: JSON.parse(undefined) lancava e o click falhava silenciosamente.
+    // Solucao: closest('[data-catalogo]') — busca o ancestral que tem o atributo
+    // serializado.
     container.querySelectorAll('.peComBtn').forEach(b => b.onclick = () => {
       const codigo = b.dataset.codigo;
-      const tag = b.closest('[data-codigo]');
+      const tag = b.closest('[data-catalogo]');
+      if (!tag) { console.warn('[peComodos] tag pai nao encontrada pra', codigo); return; }
       const catalogo = JSON.parse(tag.dataset.catalogo);
       if (state.peComodos.has(codigo)) {
         state.peComodos.delete(codigo);


### PR DESCRIPTION
…est bug)

CEO reportou que os comodos do Programa de Necessidades nao selecionavam quando clicava. Bug do v3.24.8.

Causa: o handler do click usava `b.closest('[data-codigo]')` pra achar o div pai com `data-catalogo` (JSON serializado do catalogo do comodo). Mas o proprio botao TAMBEM tem `data-codigo` (linha 8990), entao closest() retornava o botao em vez do div pai. tag.dataset.catalogo era undefined, JSON.parse(undefined) lancava SyntaxError e o handler falhava sem feedback visual nenhum.

Fix: trocar `closest('[data-codigo]')` por `closest('[data-catalogo]')` — busca especificamente o ancestral com o atributo serializado. Adicionado guard `if (!tag) console.warn` pra falhar visivel caso a estrutura mude no futuro.

Tag pai (div) continua com data-codigo (pra refletirTagComodo achar .peComQtd via dataset) — sem efeito colateral.

Total: 622 passing / 1 skipped / 0 failures.