### PR TITLE
fix(assinatura): anexos sumiam do PDF assinado — agora vao junto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.11",
+  "version": "3.24.12",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -2288,8 +2288,14 @@ async function carregarAnexosProposta(propId: number): Promise<Array<{ filename:
 // v1.66.9: gera PDF da proposta com anexos mergeados ao final.
 // Imagens (PNG/JPG) viram pagina propria do PDF. PDFs anexos sao mergeados
 // pagina por pagina. Usa pdf-lib pra concatenacao real.
-export async function gerarPdfPropostaConsultoriaComAnexos(id: string): Promise<Buffer> {
-  const propostaPdf = await gerarPdfPropostaConsultoria(id);
+// v3.24.12: aceita signatureMeta pra propagar pro PDF principal antes do merge.
+// Necessario porque assinarProposta gerava PDF sem anexos. CEO reportou que os
+// anexos somem no PDF assinado.
+export async function gerarPdfPropostaConsultoriaComAnexos(
+  id: string,
+  signatureMeta?: SignatureVisualMeta,
+): Promise<Buffer> {
+  const propostaPdf = await gerarPdfPropostaConsultoria(id, signatureMeta);
   const anexos = await carregarAnexosProposta(Number(id));
   if (anexos.length === 0) return propostaPdf;
 
@@ -2461,8 +2467,11 @@ export async function assinarProposta(
     throw new Error('Apenas propostas de consultoria sao suportadas neste momento');
   }
 
-  // Gera PDF JA com bloco visual + assina
-  const pdfBuffer = await gerarPdfPropostaConsultoria(String(propostaId), signatureMeta);
+  // Gera PDF JA com bloco visual + assina.
+  // v3.24.12 FIX: usa ComAnexos pra incluir croqui/imagens no PDF assinado.
+  // Antes usava gerarPdfPropostaConsultoria (sem anexos) — assinatura ficava
+  // so na proposta principal, anexos sumiam do PDF final salvo no banco.
+  const pdfBuffer = await gerarPdfPropostaConsultoriaComAnexos(String(propostaId), signatureMeta);
 
   const signMeta = {
     name: certData.meta.subject_cn ?? `Proposta ${proposta.numero}`,


### PR DESCRIPTION
CEO reportou que apos assinar a proposta digitalmente, os anexos (croqui PDF + imagens) sumiam do PDF assinado. Bug serio: o cliente recebia o PDF final SEM o croqui anexado.

Causa: assinarProposta (linha 2465) chamava gerarPdfPropostaConsultoria() — a versao SEM anexos. O merge com anexos so acontecia nos paths de download (/pdf, /v/:hash/pdf) e envio (WhatsApp, Telegram), mas a assinatura gerava o PDF sem passar pelo merge.

Fix em 2 partes:
1. gerarPdfPropostaConsultoriaComAnexos() ganha parametro opcional `signatureMeta?: SignatureVisualMeta` que e' propagado pro gerarPdf... interno. Antes nao tinha como pedir o PDF assinado COM anexos.
2. assinarProposta agora chama a versao ComAnexos passando signatureMeta. Pipeline: principal+signatureMeta -> ComAnexos faz merge -> assina o resultado final.

Resultado:
- PDF assinado salvo em propostas.pdf_assinado tem TUDO: proposta com bloco visual de assinatura + anexos mesclados
- /v/:hash/pdf (publico) ja servia anexos desde v3.23.10 — sem mudanca
- Download /pdf?incluir_anexos=1 idem

Sem regressao no fluxo nao-assinado: gerarPdfPropostaConsultoriaComAnexos sem signatureMeta continua igual a antes.

Total: 622 passing / 1 skipped / 0 failures.

Validacao manual pos-deploy:
1. Cria proposta com 1 croqui PDF + 1 foto JPG anexados
2. Assinar com PJ (ou PF)
3. Baixar PDF assinado -> deve ter proposta + croqui + foto
4. Validar no Adobe Reader: assinatura digital ICP-Brasil aparece no primeiro page, e o documento inteiro (incluindo anexos) e' coberto pelo selo