### PR TITLE
feat(auth): botao Sair no header do painel admin /obras

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.16",
+  "version": "3.24.17",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1023,6 +1023,8 @@ window.forcarUpdateApp = forcarUpdate;
       <span class="badge-zayra" id="versionBadge">v...</span>
       <button id="btnCeoToken" title="Login admin/CEO" style="background:transparent; border:1px solid var(--border); color:var(--text-muted); cursor:pointer; padding:6px 10px; border-radius:var(--radius); font-size:12px;">🔒 Admin</button>
       <button id="btnCertsDigitais" title="Certificados digitais ICP-Brasil pra assinatura de recibos" style="background:transparent; border:1px solid var(--border); color:var(--text-muted); cursor:pointer; padding:6px 10px; border-radius:var(--radius); font-size:12px;">🔏 Certs</button>
+      <!-- v3.24.17: botao Sair (logout JWT + redirect /login) -->
+      <button id="btnSairHeader" title="Sair da sessao" style="background:transparent; border:1px solid var(--border); color:var(--text-muted); cursor:pointer; padding:6px 10px; border-radius:var(--radius); font-size:12px;">🚪 Sair</button>
       <a href="/" style="color: var(--text-muted); text-decoration: none; font-size: 13px; padding: 8px 14px; border: 1px solid var(--border); border-radius: var(--radius);">← ZAYRA Chat</a>
     </div>
   </div>
@@ -1254,6 +1256,15 @@ document.addEventListener('DOMContentLoaded', () => {
   // v1.99.3: certificados digitais ICP-Brasil
   const btnCerts = document.getElementById('btnCertsDigitais');
   if (btnCerts) btnCerts.onclick = abrirModalCerts;
+
+  // v3.24.17: botao Sair no header — POST /api/auth/logout + redirect /login
+  const btnSair = document.getElementById('btnSairHeader');
+  if (btnSair) btnSair.onclick = async () => {
+    if (!confirm('Sair da sessao?')) return;
+    try { await fetch('/api/auth/logout', { method: 'POST', credentials: 'same-origin' }); }
+    catch (_) { /* segue mesmo se der erro */ }
+    window.location.href = '/login';
+  };
 });
 
 // ─── v1.99.3: Modal de Certificados Digitais ─────────────────────────────


### PR DESCRIPTION
CEO perguntou onde fica o botao de Sair e o tempo de sessao.
- /minha-quinzena (colaborador) ja tinha botao Sair
- /obras (painel admin) NAO tinha — precisava apagar cookies do browser pra forcar logout manualmente

Adicionado botao "🚪 Sair" no header (entre Certs e ZAYRA Chat) que:
1. Pede confirm "Sair da sessao?"
2. POST /api/auth/logout (blacklista jti via auth service)
3. Redirect window.location.href = '/login'

Tempos de sessao (relembrar):
- Admin: 24h (JWT_EXPIRES_ADMIN em src/services/auth.ts)
- Colaborador: 8h (JWT_EXPIRES_COLABORADOR) Sem timeout por inatividade — so pelo relogio.