### PR TITLE
feat(config): aba Configuracoes com gestao de usuarios + permissoes g…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.24.19",
+  "version": "3.25.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/constants/permissoesSistema.ts
+++ b/src/constants/permissoesSistema.ts
@@ -1,0 +1,237 @@
+// v3.25.0: Catalogo de permissoes granulares do sistema.
+//
+// Formato da chave: `<modulo>:<acao>` (ex: 'proposta:criar', 'equipe:excluir')
+//
+// USO:
+//   - Persistido em users.permissions JSON (array de strings)
+//   - Quando users.permissions = NULL → usa defaults do role (DEFAULT_PERMISSIONS_BY_ROLE)
+//   - Quando users.permissions = [] → user nao tem NENHUMA permissao alem das obrigatorias do role
+//   - Quando users.permissions = [...] → exatamente essas permissoes (NAO faz merge com defaults)
+//
+// ENFORCEMENT (futuro v3.25.x): middleware requirePermission('key') nas rotas relevantes.
+// Por ora (v3.25.0) so e' persistido + exibido no front pra UX de configuracao.
+
+export type RoleNome = 'admin' | 'owner' | 'gestor' | 'colaborador';
+
+export interface CategoriaPermissoes {
+  modulo: string;
+  icone: string;
+  label: string;
+  itens: { key: string; label: string; descricao?: string }[];
+}
+
+export const CATEGORIAS_PERMISSOES: CategoriaPermissoes[] = [
+  {
+    modulo: 'proposta',
+    icone: '📑',
+    label: 'Propostas',
+    itens: [
+      { key: 'proposta:ver',        label: 'Visualizar lista e detalhes' },
+      { key: 'proposta:criar',      label: 'Criar nova proposta' },
+      { key: 'proposta:editar',     label: 'Editar proposta em rascunho' },
+      { key: 'proposta:excluir',    label: 'Excluir proposta',  descricao: 'Soft-delete, reversivel via SQL' },
+      { key: 'proposta:assinar',    label: 'Assinar digitalmente (PAdES/ICP-Brasil)' },
+      { key: 'proposta:enviar',     label: 'Enviar via WhatsApp/Telegram/Email' },
+      { key: 'proposta:anexos',     label: 'Gerenciar anexos (croqui, fotos)' },
+      { key: 'proposta:revisar',    label: 'Criar revisao R1->R2 (ja enviada)' },
+    ],
+  },
+  {
+    modulo: 'cliente',
+    icone: '👤',
+    label: 'Clientes',
+    itens: [
+      { key: 'cliente:ver',     label: 'Visualizar clientes' },
+      { key: 'cliente:criar',   label: 'Cadastrar novo cliente' },
+      { key: 'cliente:editar',  label: 'Editar dados do cliente' },
+      { key: 'cliente:excluir', label: 'Excluir cliente (soft)' },
+    ],
+  },
+  {
+    modulo: 'equipe',
+    icone: '👥',
+    label: 'Equipe (Colaboradores)',
+    itens: [
+      { key: 'equipe:ver',          label: 'Visualizar equipe' },
+      { key: 'equipe:criar',        label: 'Cadastrar novo membro' },
+      { key: 'equipe:editar',       label: 'Editar dados do membro' },
+      { key: 'equipe:excluir',      label: 'Excluir membro' },
+      { key: 'equipe:foto',         label: 'Upload/remover foto' },
+      { key: 'equipe:pix',          label: 'Gerenciar chave PIX' },
+      { key: 'equipe:acesso',       label: 'Criar/desativar acesso de login' },
+    ],
+  },
+  {
+    modulo: 'recibo',
+    icone: '🧾',
+    label: 'Recibos',
+    itens: [
+      { key: 'recibo:ver',     label: 'Visualizar recibos' },
+      { key: 'recibo:criar',   label: 'Criar rascunho' },
+      { key: 'recibo:emitir',  label: 'Emitir (gera numero definitivo)' },
+      { key: 'recibo:assinar', label: 'Assinar digitalmente' },
+      { key: 'recibo:enviar',  label: 'Enviar via WhatsApp' },
+      { key: 'recibo:editar',  label: 'Editar rascunho' },
+      { key: 'recibo:cancelar', label: 'Cancelar recibo emitido' },
+    ],
+  },
+  {
+    modulo: 'folha',
+    icone: '💰',
+    label: 'Folha Mensal / Quinzenal',
+    itens: [
+      { key: 'folha:ver',       label: 'Visualizar folha' },
+      { key: 'folha:fechar',    label: 'Fechar quinzena/mes' },
+      { key: 'folha:reverter',  label: 'Reverter fechamento' },
+      { key: 'folha:exportar',  label: 'Exportar PDF/Excel' },
+      { key: 'folha:ajuste',    label: 'Adicionar bonus/desconto/vale' },
+    ],
+  },
+  {
+    modulo: 'dias',
+    icone: '📅',
+    label: 'Marcar Dias Trabalhados',
+    itens: [
+      { key: 'dias:ver',       label: 'Ver calendario de presenca' },
+      { key: 'dias:marcar',    label: 'Marcar dia trabalhado' },
+      { key: 'dias:desmarcar', label: 'Desmarcar dia' },
+      { key: 'dias:editar_passado', label: 'Editar dias de meses anteriores' },
+    ],
+  },
+  {
+    modulo: 'material',
+    icone: '🧱',
+    label: 'Materiais',
+    itens: [
+      { key: 'material:ver',      label: 'Visualizar materiais' },
+      { key: 'material:registrar', label: 'Registrar entrada/uso' },
+      { key: 'material:editar',   label: 'Editar registro' },
+      { key: 'material:excluir',  label: 'Excluir registro' },
+    ],
+  },
+  {
+    modulo: 'despesa',
+    icone: '💸',
+    label: 'Despesas Extras',
+    itens: [
+      { key: 'despesa:ver',      label: 'Visualizar despesas' },
+      { key: 'despesa:registrar', label: 'Registrar despesa' },
+      { key: 'despesa:editar',   label: 'Editar despesa' },
+      { key: 'despesa:excluir',  label: 'Excluir despesa' },
+      { key: 'despesa:comprovante', label: 'Anexar/remover comprovante' },
+    ],
+  },
+  {
+    modulo: 'financeiro',
+    icone: '🏦',
+    label: 'Financeiro (Transações)',
+    itens: [
+      { key: 'financeiro:ver',     label: 'Ver lancamentos' },
+      { key: 'financeiro:lancar',  label: 'Lancar nova transacao' },
+      { key: 'financeiro:editar',  label: 'Editar transacao' },
+      { key: 'financeiro:excluir', label: 'Excluir transacao' },
+      { key: 'financeiro:exportar', label: 'Exportar relatorios' },
+    ],
+  },
+  {
+    modulo: 'laudo',
+    icone: '📐',
+    label: 'Laudos de Demarcação',
+    itens: [
+      { key: 'laudo:ver',       label: 'Visualizar laudos' },
+      { key: 'laudo:criar',     label: 'Criar laudo novo' },
+      { key: 'laudo:editar',    label: 'Editar laudo' },
+      { key: 'laudo:gerar_pdf', label: 'Gerar PDF/KML/DWG' },
+      { key: 'laudo:assinar',   label: 'Assinar digitalmente' },
+      { key: 'laudo:excluir',   label: 'Excluir laudo' },
+    ],
+  },
+  {
+    modulo: 'loteamento',
+    icone: '🏘',
+    label: 'Loteamentos',
+    itens: [
+      { key: 'loteamento:ver',    label: 'Visualizar loteamentos' },
+      { key: 'loteamento:criar',  label: 'Criar loteamento' },
+      { key: 'loteamento:editar', label: 'Editar loteamento' },
+      { key: 'loteamento:lotes',  label: 'Gerenciar lotes/quadras' },
+    ],
+  },
+  {
+    modulo: 'vistoria',
+    icone: '🔎',
+    label: 'Vistorias (VTO)',
+    itens: [
+      { key: 'vistoria:ver',     label: 'Visualizar vistorias' },
+      { key: 'vistoria:criar',   label: 'Criar nova vistoria' },
+      { key: 'vistoria:editar',  label: 'Editar vistoria' },
+      { key: 'vistoria:assinar', label: 'Assinar digitalmente' },
+      { key: 'vistoria:gerar_pdf', label: 'Gerar PDF do relatorio' },
+    ],
+  },
+  {
+    modulo: 'galeria',
+    icone: '📷',
+    label: 'Galeria de Fotos',
+    itens: [
+      { key: 'galeria:ver',     label: 'Visualizar fotos' },
+      { key: 'galeria:upload',  label: 'Upload de fotos' },
+      { key: 'galeria:editar',  label: 'Editar legenda/categoria' },
+      { key: 'galeria:excluir', label: 'Excluir foto' },
+    ],
+  },
+  {
+    modulo: 'calculo',
+    icone: '🧮',
+    label: 'Cálculos Técnicos',
+    itens: [
+      { key: 'calculo:ver',      label: 'Ver historico de calculos' },
+      { key: 'calculo:executar', label: 'Executar novos calculos' },
+    ],
+  },
+  {
+    modulo: 'config',
+    icone: '⚙',
+    label: 'Configurações do Sistema',
+    itens: [
+      { key: 'config:usuarios',     label: 'Gerenciar usuarios e permissoes' },
+      { key: 'config:auditoria',    label: 'Ver logs de auditoria' },
+      { key: 'config:certificados', label: 'Gerenciar certificados digitais' },
+      { key: 'config:obras',        label: 'Criar/editar/excluir obras' },
+    ],
+  },
+];
+
+// Lista flat de todas as permission keys validas (gerada do catalogo)
+export const PERMISSIONS_VALIDAS: Set<string> = new Set(
+  CATEGORIAS_PERMISSOES.flatMap(c => c.itens.map(i => i.key)),
+);
+
+// Defaults por role quando users.permissions = NULL.
+// Admin/owner = TODAS as permissoes (acesso total).
+// Gestor = quase tudo, exceto configuracoes e algumas operacoes destrutivas.
+// Colaborador = so /minha-quinzena (sem acesso a /obras).
+export const DEFAULT_PERMISSIONS_BY_ROLE: Record<RoleNome, string[]> = {
+  admin: Array.from(PERMISSIONS_VALIDAS),
+  owner: Array.from(PERMISSIONS_VALIDAS),
+  gestor: Array.from(PERMISSIONS_VALIDAS).filter(p =>
+    !p.startsWith('config:') &&
+    !p.endsWith(':excluir') &&
+    p !== 'financeiro:excluir' &&
+    p !== 'folha:reverter'
+  ),
+  colaborador: [], // colaborador nao tem acesso ao /obras de modo geral
+};
+
+// Resolve permissoes EFETIVAS de um user: se permissions custom NULL, usa default do role.
+export function resolverPermissoesEfetivas(role: RoleNome, custom?: string[] | null): string[] {
+  if (custom === null || custom === undefined) {
+    return DEFAULT_PERMISSIONS_BY_ROLE[role] || [];
+  }
+  // Quando custom = [] explicito, retorna [] (user sem permissoes)
+  return custom.filter(k => PERMISSIONS_VALIDAS.has(k));
+}
+
+export function temPermissao(role: RoleNome, custom: string[] | null | undefined, key: string): boolean {
+  return resolverPermissoesEfetivas(role, custom).includes(key);
+}

--- a/src/database/migrations-auth.ts
+++ b/src/database/migrations-auth.ts
@@ -89,4 +89,42 @@ export async function runAuthMigrations(): Promise<void> {
     // Nao critico — se a coluna comment nao puder ser setada por permissao
     console.warn('[auth-migrations] aviso COMMENT users:', (err as Error).message);
   }
+
+  // 4) v3.25.0: users.permissions (JSON granular) + users.active + users.created_by
+  //    permissions: array de strings tipo ["proposta:criar","proposta:assinar",...]
+  //                 quando NULL = usa permissoes default do role (admin = tudo,
+  //                 gestor = quase tudo, colaborador = so /minha-quinzena)
+  //    active: soft-disable de user (mantem dados pra audit, bloqueia login)
+  //    created_by: user_id de quem criou (auditoria)
+  try {
+    if (!(await columnExists('users', 'permissions'))) {
+      await pool.execute(
+        `ALTER TABLE users ADD COLUMN permissions JSON NULL
+           COMMENT 'v3.25.0: array de strings com permissoes granulares. NULL = usa defaults do role'`,
+      );
+      console.log('[auth-migrations] OK: ADD COLUMN users.permissions');
+    } else {
+      console.log('[auth-migrations] ja existe (OK): users.permissions');
+    }
+    if (!(await columnExists('users', 'active'))) {
+      await pool.execute(
+        `ALTER TABLE users ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1
+           COMMENT 'v3.25.0: soft-disable. 0 = bloqueado pra login'`,
+      );
+      console.log('[auth-migrations] OK: ADD COLUMN users.active');
+    } else {
+      console.log('[auth-migrations] ja existe (OK): users.active');
+    }
+    if (!(await columnExists('users', 'created_by'))) {
+      await pool.execute(
+        `ALTER TABLE users ADD COLUMN created_by INT NULL
+           COMMENT 'v3.25.0: id do admin que criou este user'`,
+      );
+      console.log('[auth-migrations] OK: ADD COLUMN users.created_by');
+    } else {
+      console.log('[auth-migrations] ja existe (OK): users.created_by');
+    }
+  } catch (err) {
+    console.error('[auth-migrations] FALHA users.permissions/active/created_by:', (err as Error).message);
+  }
 }

--- a/src/integrations/adminUsers.ts
+++ b/src/integrations/adminUsers.ts
@@ -1,0 +1,271 @@
+// v3.25.0: CRUD de usuarios + permissoes granulares pra aba Configuracoes.
+//
+// Restricoes:
+//   - Todas as funcoes assumem que requireRole('admin') ja validou no caller
+//   - hashPassword usa bcrypt cost 12 (igual /api/auth/login)
+//   - users.permissions JSON => string[] (null = usa defaults do role)
+//   - Soft-delete: users.deleted_at + users.active=0
+
+import pool from '../database/connection';
+import type { ResultSetHeader, RowDataPacket } from 'mysql2';
+import { hashPassword } from '../services/auth';
+import {
+  PERMISSIONS_VALIDAS,
+  type RoleNome,
+} from '../constants/permissoesSistema';
+
+export interface UserAdminRow extends RowDataPacket {
+  id: number;
+  email: string;
+  name: string;
+  phone: string | null;
+  role: RoleNome | null;
+  active: 0 | 1;
+  permissions: string | null; // JSON string
+  last_login_at: Date | null;
+  created_at: Date;
+  tenant_role: RoleNome | null;
+  equipe_id: number | null;
+  equipe_nome: string | null;
+}
+
+/**
+ * Lista todos os users com role do tenant_users + nome do colaborador vinculado.
+ * Inclui inativos pra admin poder reativar.
+ */
+export async function listarUsuariosAdmin() {
+  const [rows] = await pool.execute<UserAdminRow[]>(`
+    SELECT u.id, u.email, u.name, u.phone,
+           COALESCE(u.role, tu.role) AS role,
+           u.active, u.permissions, u.last_login_at, u.created_at,
+           tu.role AS tenant_role, tu.equipe_id,
+           e.nome AS equipe_nome
+      FROM users u
+      LEFT JOIN tenant_users tu ON tu.user_id = u.id AND tu.tenant_id = 1
+      LEFT JOIN romatec_obra_equipe e ON e.id = tu.equipe_id
+     WHERE u.deleted_at IS NULL
+     ORDER BY u.active DESC, u.created_at DESC
+  `);
+  return rows.map(r => ({
+    id: r.id,
+    email: r.email,
+    name: r.name,
+    phone: r.phone,
+    role: r.role || 'colaborador',
+    active: !!r.active,
+    permissions: r.permissions ? safeJsonParse(r.permissions) : null,
+    last_login_at: r.last_login_at,
+    created_at: r.created_at,
+    equipe_id: r.equipe_id,
+    equipe_nome: r.equipe_nome,
+  }));
+}
+
+function safeJsonParse(s: string): string[] | null {
+  try { const v = JSON.parse(s); return Array.isArray(v) ? v : null; }
+  catch { return null; }
+}
+
+function gerarSenhaTemporaria(): string {
+  // 12 chars, mistura mai/min/dig/simbolo. Evita chars confusos (0/O/l/1).
+  const sets = [
+    'ABCDEFGHJKLMNPQRSTUVWXYZ',
+    'abcdefghjkmnpqrstuvwxyz',
+    '23456789',
+    '!@#$%&*-+',
+  ];
+  const chars: string[] = [];
+  for (const s of sets) for (let i = 0; i < 3; i++) chars.push(s[Math.floor(Math.random() * s.length)]);
+  // Embaralha
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return chars.join('');
+}
+
+export async function criarUsuarioAdmin(input: {
+  email: string;
+  name: string;
+  phone?: string;
+  role: RoleNome;
+  equipe_id?: number | null;
+  permissions?: string[] | null;
+  senha?: string; // se nao vier, gera temporaria
+  created_by?: number;
+}) {
+  if (!input.email || !input.name) throw new Error('email e name obrigatorios');
+  if (!['admin','gestor','colaborador'].includes(input.role)) {
+    throw new Error('role invalido (admin/gestor/colaborador)');
+  }
+  const emailLower = input.email.trim().toLowerCase();
+  // Verifica duplicata
+  const [exist] = await pool.execute<RowDataPacket[]>(
+    `SELECT id FROM users WHERE LOWER(email) = ? AND deleted_at IS NULL LIMIT 1`,
+    [emailLower],
+  );
+  if (exist.length > 0) throw new Error('Email ja cadastrado');
+
+  const senhaUsada = input.senha || gerarSenhaTemporaria();
+  const hash = await hashPassword(senhaUsada);
+
+  const permsValidadas = input.permissions
+    ? input.permissions.filter(k => PERMISSIONS_VALIDAS.has(k))
+    : null;
+
+  const openId = `app-${input.role}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  // INSERT com fallback: tenta schema completo, cai pro legacy se colunas faltarem
+  let insertId: number;
+  try {
+    const [r] = await pool.execute<ResultSetHeader>(
+      `INSERT INTO users (openId, email, name, phone, loginMethod, role, password_hash,
+                          permissions, active, created_by)
+       VALUES (?, ?, ?, ?, 'password', ?, ?, ?, 1, ?)`,
+      [openId, emailLower, input.name.trim(), input.phone || null, input.role, hash,
+       permsValidadas ? JSON.stringify(permsValidadas) : null,
+       input.created_by ?? null],
+    );
+    insertId = r.insertId;
+  } catch (err) {
+    if (/Unknown column/i.test((err as Error).message)) {
+      // Schema sem permissions/active/created_by — usa legacy
+      const [r] = await pool.execute<ResultSetHeader>(
+        `INSERT INTO users (openId, email, name, phone, loginMethod, role, password_hash)
+         VALUES (?, ?, ?, ?, 'password', ?, ?)`,
+        [openId, emailLower, input.name.trim(), input.phone || null, input.role, hash],
+      );
+      insertId = r.insertId;
+    } else {
+      throw err;
+    }
+  }
+
+  // Vincula em tenant_users (idempotente — se ja vinculado, ON DUPLICATE atualiza role)
+  await pool.execute(
+    `INSERT INTO tenant_users (tenant_id, user_id, role, equipe_id, accepted_at)
+     VALUES (1, ?, ?, ?, NOW())
+     ON DUPLICATE KEY UPDATE role = VALUES(role), equipe_id = VALUES(equipe_id)`,
+    [insertId, input.role, input.equipe_id ?? null],
+  );
+
+  return {
+    ok: true as const,
+    id: insertId,
+    email: emailLower,
+    name: input.name.trim(),
+    role: input.role,
+    senha_temporaria: senhaUsada,
+    message: `Usuario "${input.name}" criado com role ${input.role}. Senha temporaria gerada.`,
+  };
+}
+
+export async function atualizarUsuarioAdmin(input: {
+  id: number;
+  name?: string;
+  phone?: string;
+  role?: RoleNome;
+  equipe_id?: number | null;
+  permissions?: string[] | null; // null = usa defaults do role; [] = sem permissoes
+  active?: boolean;
+}) {
+  if (!input.id) throw new Error('id obrigatorio');
+  const fields: string[] = [];
+  const params: (string | number | null)[] = [];
+  if (input.name !== undefined) { fields.push('name = ?'); params.push(input.name); }
+  if (input.phone !== undefined) { fields.push('phone = ?'); params.push(input.phone || null); }
+  if (input.role !== undefined) { fields.push('role = ?'); params.push(input.role); }
+  if (input.active !== undefined) {
+    try { fields.push('active = ?'); params.push(input.active ? 1 : 0); }
+    catch { /* coluna pode nao existir */ }
+  }
+  if (input.permissions !== undefined) {
+    const valid = input.permissions === null
+      ? null
+      : input.permissions.filter(k => PERMISSIONS_VALIDAS.has(k));
+    fields.push('permissions = ?');
+    params.push(valid === null ? null : JSON.stringify(valid));
+  }
+  if (fields.length > 0) {
+    params.push(input.id);
+    try {
+      await pool.execute<ResultSetHeader>(
+        `UPDATE users SET ${fields.join(', ')} WHERE id = ? AND deleted_at IS NULL`,
+        params,
+      );
+    } catch (err) {
+      // Fallback se permissions/active nao existir em prod
+      if (/Unknown column/i.test((err as Error).message)) {
+        const fLegacy: string[] = [];
+        const pLegacy: (string | number | null)[] = [];
+        if (input.name !== undefined) { fLegacy.push('name = ?'); pLegacy.push(input.name); }
+        if (input.phone !== undefined) { fLegacy.push('phone = ?'); pLegacy.push(input.phone || null); }
+        if (input.role !== undefined) { fLegacy.push('role = ?'); pLegacy.push(input.role); }
+        if (fLegacy.length > 0) {
+          pLegacy.push(input.id);
+          await pool.execute(
+            `UPDATE users SET ${fLegacy.join(', ')} WHERE id = ? AND deleted_at IS NULL`,
+            pLegacy,
+          );
+        }
+      } else { throw err; }
+    }
+  }
+  // Atualiza tenant_users se role/equipe_id mudaram
+  if (input.role !== undefined || input.equipe_id !== undefined) {
+    await pool.execute(
+      `UPDATE tenant_users SET role = COALESCE(?, role), equipe_id = ?
+        WHERE user_id = ? AND tenant_id = 1`,
+      [input.role ?? null, input.equipe_id ?? null, input.id],
+    );
+  }
+  return { ok: true as const, id: input.id, message: 'Usuario atualizado.' };
+}
+
+export async function excluirUsuarioAdmin(id: number) {
+  if (!id) throw new Error('id obrigatorio');
+  // Soft-delete + desativar
+  try {
+    await pool.execute(
+      `UPDATE users SET deleted_at = NOW(), active = 0 WHERE id = ? AND deleted_at IS NULL`,
+      [id],
+    );
+  } catch (err) {
+    if (/Unknown column/i.test((err as Error).message)) {
+      await pool.execute(
+        `UPDATE users SET deleted_at = NOW() WHERE id = ? AND deleted_at IS NULL`,
+        [id],
+      );
+    } else { throw err; }
+  }
+  return { ok: true as const, message: 'Usuario desativado (soft-delete).' };
+}
+
+export async function resetarSenhaUsuario(id: number, novaSenha?: string) {
+  if (!id) throw new Error('id obrigatorio');
+  const senha = novaSenha || gerarSenhaTemporaria();
+  const hash = await hashPassword(senha);
+  await pool.execute(
+    `UPDATE users SET password_hash = ?, updated_at = NOW() WHERE id = ? AND deleted_at IS NULL`,
+    [hash, id],
+  );
+  return {
+    ok: true as const,
+    id,
+    senha_temporaria: senha,
+    message: 'Senha resetada. Envie a nova senha pro usuario.',
+  };
+}
+
+// Lista os 100 logs mais recentes pra aba Auditoria
+export async function listarAuditoriaRecente(limite = 100) {
+  const [rows] = await pool.execute<RowDataPacket[]>(`
+    SELECT al.id, al.user_id, al.login_attempt, al.ip,
+           al.sucesso, al.motivo_falha, al.created_at,
+           u.name AS user_name, u.email AS user_email
+      FROM auth_logs al
+      LEFT JOIN users u ON u.id = al.user_id
+     ORDER BY al.created_at DESC
+     LIMIT ?
+  `, [Number(limite)]);
+  return rows;
+}

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1046,9 +1046,11 @@ window.forcarUpdateApp = forcarUpdate;
     <button class="tab" data-tab="galeria">📷 Galeria</button>
     <button class="tab" data-tab="proposta">Proposta</button>
     <button class="tab" data-tab="calculos">🧮 Cálculos</button>
+    <button class="tab" data-tab="config">⚙️ Configurações</button>
   </div>
 
   <div id="view-dashboard" class="view active"></div>
+  <div id="view-config" class="view"></div>
   <div id="view-obras" class="view"></div>
   <div id="view-cronograma" class="view"></div>
   <div id="view-despesas" class="view"></div>
@@ -1620,6 +1622,8 @@ async function render() {
       laudos:  async () => { await loadLaudos(); renderLaudos(); },
       loteamentos: async () => { await loadLoteamentos(); renderLoteamentos(); },
       galeria: async () => { await renderGaleria(); },
+      // v3.25.0: Configuracoes > Usuarios + Permissoes + Auditoria
+      config: async () => { await renderConfiguracoes(); },
     };
     await fns[state.currentTab]();
   } catch (e) {
@@ -21421,6 +21425,328 @@ function readImageFile(file) {
     fr.onerror = rej;
     fr.readAsDataURL(file);
   });
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// v3.25.0: Aba CONFIGURACOES — Usuarios + Permissoes + Auditoria
+// ───────────────────────────────────────────────────────────────────────
+
+// Estado local da aba (sub-tabs)
+state.configSub = state.configSub || 'usuarios';
+state.configCache = state.configCache || { users: [], catalogo: null, equipe: [], auditoria: [] };
+
+async function renderConfiguracoes() {
+  const v = document.getElementById('view-config');
+  v.innerHTML = `
+    <div class="card">
+      <p class="section-title">⚙️ Configurações</p>
+      <div style="display:flex; gap:6px; margin-bottom:14px; border-bottom:1px solid var(--border);">
+        <button class="cfg-tab" data-sub="usuarios"  style="padding:8px 14px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--text-muted); cursor:pointer;">👥 Usuários</button>
+        <button class="cfg-tab" data-sub="auditoria" style="padding:8px 14px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--text-muted); cursor:pointer;">📋 Auditoria</button>
+      </div>
+      <div id="cfg-body">Carregando…</div>
+    </div>
+  `;
+  v.querySelectorAll('.cfg-tab').forEach(b => {
+    const ativo = b.dataset.sub === state.configSub;
+    b.style.borderBottomColor = ativo ? 'var(--neon)' : 'transparent';
+    b.style.color = ativo ? 'var(--text)' : 'var(--text-muted)';
+    b.style.fontWeight = ativo ? '600' : '400';
+    b.onclick = () => { state.configSub = b.dataset.sub; renderConfiguracoes(); };
+  });
+  try {
+    if (state.configSub === 'usuarios') await renderCfgUsuarios();
+    else if (state.configSub === 'auditoria') await renderCfgAuditoria();
+  } catch (e) {
+    document.getElementById('cfg-body').innerHTML = `<div class="card empty">Erro: ${escape(e.message)}</div>`;
+  }
+}
+
+async function renderCfgUsuarios() {
+  // Carrega users + catalogo de permissoes em paralelo
+  const [{ items: users }, catalogo] = await Promise.all([
+    api('/api/admin/users-config'),
+    state.configCache.catalogo
+      ? Promise.resolve(state.configCache.catalogo)
+      : api('/api/admin/permissions-catalog'),
+  ]);
+  state.configCache.users = users;
+  state.configCache.catalogo = catalogo;
+
+  const corRole = { admin: '#ef4444', owner: '#ef4444', gestor: '#fbbf24', colaborador: '#60a5fa' };
+  const linhas = users.map(u => `
+    <tr style="border-bottom:1px solid var(--border);">
+      <td style="padding:8px;">
+        <div style="font-weight:600;">${escape(u.name)}</div>
+        <div style="font-size:11px; color:var(--text-muted);">${escape(u.email)}</div>
+      </td>
+      <td style="padding:8px;">
+        <span style="background:${corRole[u.role]||'#666'}22; color:${corRole[u.role]||'#666'}; padding:2px 8px; border-radius:10px; font-size:11px; font-weight:600;">
+          ${escape(u.role.toUpperCase())}
+        </span>
+        ${u.equipe_nome ? `<div style="font-size:10px; color:var(--text-muted); margin-top:2px;">→ ${escape(u.equipe_nome)}</div>` : ''}
+      </td>
+      <td style="padding:8px; font-size:11px; color:var(--text-muted);">
+        ${u.permissions === null ? `<em>default do role</em>` : `${u.permissions.length} permissões custom`}
+      </td>
+      <td style="padding:8px; font-size:11px; color:var(--text-muted);">
+        ${u.last_login_at ? new Date(u.last_login_at).toLocaleString('pt-BR') : '<em>nunca</em>'}
+      </td>
+      <td style="padding:8px;">
+        <span style="display:inline-block; width:8px; height:8px; border-radius:50%; background:${u.active?'var(--neon)':'#666'};"></span>
+        ${u.active ? 'Ativo' : 'Desativado'}
+      </td>
+      <td style="padding:8px; text-align:right;">
+        <button class="btn-secondary cfg-edit" data-id="${u.id}" style="padding:4px 10px; font-size:11px;">✏ Editar</button>
+        <button class="btn-secondary cfg-reset" data-id="${u.id}" style="padding:4px 10px; font-size:11px;">🔄 Resetar</button>
+        <button class="btn-danger cfg-del" data-id="${u.id}" style="padding:4px 10px; font-size:11px;">🗑</button>
+      </td>
+    </tr>
+  `).join('');
+
+  document.getElementById('cfg-body').innerHTML = `
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+      <p style="margin:0; font-weight:600; color:var(--text-muted);">${users.length} usuário(s) cadastrado(s)</p>
+      <button class="btn-primary" id="cfgNovoUser">➕ Novo Usuário</button>
+    </div>
+    <table style="width:100%; border-collapse:collapse; font-size:13px;">
+      <thead>
+        <tr style="background:var(--bg-elev); text-align:left;">
+          <th style="padding:8px;">Nome / Email</th>
+          <th style="padding:8px;">Role</th>
+          <th style="padding:8px;">Permissões</th>
+          <th style="padding:8px;">Último login</th>
+          <th style="padding:8px;">Status</th>
+          <th style="padding:8px; text-align:right;">Ações</th>
+        </tr>
+      </thead>
+      <tbody>${linhas}</tbody>
+    </table>
+  `;
+  document.getElementById('cfgNovoUser').onclick = () => abrirModalCfgUser(null, catalogo);
+  document.querySelectorAll('.cfg-edit').forEach(b => b.onclick = () => {
+    const u = state.configCache.users.find(x => x.id === Number(b.dataset.id));
+    if (u) abrirModalCfgUser(u, state.configCache.catalogo);
+  });
+  document.querySelectorAll('.cfg-reset').forEach(b => b.onclick = async () => {
+    const u = state.configCache.users.find(x => x.id === Number(b.dataset.id));
+    if (!u) return;
+    if (!confirm(`Resetar senha de ${u.name}? Uma nova senha temporária será gerada.`)) return;
+    try {
+      const r = await api(`/api/admin/users-config/${u.id}/reset-senha`, { method:'POST', body:'{}' });
+      alert(`✅ Nova senha gerada pra ${u.name}:\n\n${r.senha_temporaria}\n\nAnote e envie pro usuário. Esta senha não será mostrada novamente.`);
+    } catch (e) { alert('Erro: ' + e.message); }
+  });
+  document.querySelectorAll('.cfg-del').forEach(b => b.onclick = async () => {
+    const u = state.configCache.users.find(x => x.id === Number(b.dataset.id));
+    if (!u) return;
+    if (!confirm(`Desativar usuário "${u.name}" (${u.email})?\n\nO acesso será bloqueado. Dados são preservados.`)) return;
+    try {
+      await api(`/api/admin/users-config/${u.id}`, { method:'DELETE' });
+      state.configCache.users = [];
+      await renderCfgUsuarios();
+    } catch (e) { alert('Erro: ' + e.message); }
+  });
+}
+
+function abrirModalCfgUser(user, catalogo) {
+  const isEdit = !!user;
+  const roleAtual = user?.role || 'colaborador';
+  const permsAtuais = user?.permissions; // null = default do role
+  const usaCustom = permsAtuais !== null && permsAtuais !== undefined;
+
+  const overlay = document.createElement('div');
+  overlay.style.cssText = 'position:fixed; inset:0; background:rgba(0,0,0,0.75); z-index:9999; display:flex; align-items:center; justify-content:center; padding:20px; overflow-y:auto;';
+  const modal = document.createElement('div');
+  modal.className = 'card';
+  modal.style.cssText = 'max-width:840px; width:100%; max-height:92vh; overflow-y:auto;';
+
+  const categoriasHtml = catalogo.categorias.map(cat => `
+    <fieldset style="border:1px solid var(--border); border-radius:6px; padding:8px 10px; margin-bottom:6px;">
+      <legend style="padding:0 6px; font-size:12px; color:var(--neon); font-weight:600;">${cat.icone} ${escape(cat.label)}</legend>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:4px;">
+        ${cat.itens.map(it => `
+          <label style="display:flex; align-items:flex-start; gap:6px; font-size:12px; cursor:pointer; padding:3px;">
+            <input type="checkbox" class="cfg-perm" data-key="${it.key}" style="margin-top:2px;">
+            <div>
+              <div>${escape(it.label)}</div>
+              ${it.descricao ? `<div style="font-size:10px; color:var(--text-muted);">${escape(it.descricao)}</div>` : ''}
+            </div>
+          </label>
+        `).join('')}
+      </div>
+    </fieldset>
+  `).join('');
+
+  modal.innerHTML = `
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:14px;">
+      <p class="section-title" style="margin:0;">${isEdit ? '✏ Editar usuário' : '➕ Novo usuário'}</p>
+      <button data-cfg-fechar style="background:transparent;">✕</button>
+    </div>
+    <div class="form-grid">
+      <label>Nome completo *
+        <input id="cfg_nome" value="${escape(user?.name || '')}" style="width:100%;">
+      </label>
+      <label>Email (login) *
+        <input id="cfg_email" type="email" value="${escape(user?.email || '')}" ${isEdit?'disabled':''} style="width:100%; ${isEdit?'opacity:0.6;':''}">
+      </label>
+      <label>Telefone (WhatsApp)
+        <input id="cfg_phone" value="${escape(user?.phone || '')}" placeholder="(99) 99999-9999" style="width:100%;">
+      </label>
+      <label>Vincular a colaborador (opcional)
+        <select id="cfg_equipe" style="width:100%;">
+          <option value="">— Nenhum —</option>
+          ${(state.equipe||[]).map(e => `<option value="${e.id}" ${user?.equipe_id==e.id?'selected':''}>${escape(e.nome)}</option>`).join('')}
+        </select>
+      </label>
+    </div>
+    <div style="margin-top:14px;">
+      <label style="font-weight:600;">Perfil base</label>
+      <div style="display:flex; gap:8px; margin-top:6px; flex-wrap:wrap;">
+        ${['admin','gestor','colaborador'].map(r => `
+          <label style="flex:1; min-width:120px; padding:8px 12px; border:2px solid var(--border); border-radius:6px; cursor:pointer; text-align:center;" data-role-wrap="${r}">
+            <input type="radio" name="cfg_role" value="${r}" ${roleAtual===r?'checked':''} style="margin-right:6px;">
+            ${r.toUpperCase()}
+          </label>
+        `).join('')}
+      </div>
+    </div>
+    <div style="margin-top:14px; padding:10px; background:var(--bg-elev); border-radius:6px;">
+      <label style="display:flex; gap:8px; align-items:center; cursor:pointer;">
+        <input type="checkbox" id="cfg_custom" ${usaCustom?'checked':''}>
+        <strong>Customizar permissões (em vez de usar defaults do role)</strong>
+      </label>
+      <p style="margin:6px 0 0; font-size:11px; color:var(--text-muted);">
+        Sem marcar: usa o conjunto padrão do role (admin=tudo, gestor=quase tudo, colaborador=sem /obras).<br>
+        Marcado: você escolhe permissão por permissão abaixo.
+      </p>
+    </div>
+    <div id="cfg_perms_grid" style="margin-top:14px; display:none;">
+      ${categoriasHtml}
+    </div>
+    ${isEdit ? `
+      <div style="margin-top:14px;">
+        <label style="display:flex; gap:8px; align-items:center;">
+          <input type="checkbox" id="cfg_active" ${user.active?'checked':''}>
+          <strong>Usuário ativo (pode fazer login)</strong>
+        </label>
+      </div>
+    ` : `
+      <div style="margin-top:14px; padding:10px; background:rgba(212,184,0,0.10); border-left:3px solid var(--gold); border-radius:4px;">
+        <p style="margin:0; font-size:12px; color:var(--gold); font-weight:600;">🔑 Senha temporária será gerada automaticamente</p>
+        <p style="margin:4px 0 0; font-size:11px; color:var(--text-muted);">A senha aparece no alert após criar. Anote e envie pro usuário.</p>
+      </div>
+    `}
+    <div style="display:flex; gap:8px; margin-top:16px; justify-content:flex-end;">
+      <button data-cfg-cancelar style="background:transparent;">Cancelar</button>
+      <button class="btn-primary" id="cfg_salvar">${isEdit?'💾 Salvar alterações':'💾 Criar usuário'}</button>
+    </div>
+  `;
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+
+  const cleanup = () => { try { document.body.removeChild(overlay); } catch {} };
+  modal.querySelector('[data-cfg-fechar]').onclick = cleanup;
+  modal.querySelector('[data-cfg-cancelar]').onclick = cleanup;
+  overlay.onclick = (e) => { if (e.target === overlay) cleanup(); };
+
+  // Highlight visual do role escolhido
+  function refletirRole() {
+    const val = modal.querySelector('input[name="cfg_role"]:checked').value;
+    modal.querySelectorAll('[data-role-wrap]').forEach(w => {
+      w.style.borderColor = w.dataset.roleWrap === val ? 'var(--neon)' : 'var(--border)';
+      w.style.background = w.dataset.roleWrap === val ? 'rgba(0,255,136,0.10)' : 'transparent';
+    });
+  }
+  modal.querySelectorAll('input[name="cfg_role"]').forEach(r => r.onchange = refletirRole);
+  refletirRole();
+
+  // Toggle grid de permissões custom
+  const chkCustom = modal.querySelector('#cfg_custom');
+  const grid = modal.querySelector('#cfg_perms_grid');
+  function refletirCustom() {
+    grid.style.display = chkCustom.checked ? 'block' : 'none';
+    if (chkCustom.checked) {
+      // Pre-marca permissoes (custom ou defaults do role)
+      const role = modal.querySelector('input[name="cfg_role"]:checked').value;
+      const perms = usaCustom ? permsAtuais : (catalogo.defaults_por_role[role] || []);
+      modal.querySelectorAll('.cfg-perm').forEach(c => c.checked = perms.includes(c.dataset.key));
+    }
+  }
+  chkCustom.onchange = refletirCustom;
+  modal.querySelectorAll('input[name="cfg_role"]').forEach(r => r.onchange = () => { refletirRole(); refletirCustom(); });
+  refletirCustom();
+
+  // Salvar
+  modal.querySelector('#cfg_salvar').onclick = async () => {
+    const nome = modal.querySelector('#cfg_nome').value.trim();
+    const email = modal.querySelector('#cfg_email').value.trim().toLowerCase();
+    const phone = modal.querySelector('#cfg_phone').value.trim() || null;
+    const role = modal.querySelector('input[name="cfg_role"]:checked').value;
+    const equipeRaw = modal.querySelector('#cfg_equipe').value;
+    const equipe_id = equipeRaw ? Number(equipeRaw) : null;
+    const customOn = chkCustom.checked;
+    const permissions = customOn
+      ? Array.from(modal.querySelectorAll('.cfg-perm:checked')).map(c => c.dataset.key)
+      : null;
+    if (!nome) return alert('Nome obrigatório');
+    if (!isEdit && (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))) return alert('Email inválido');
+
+    try {
+      if (isEdit) {
+        const active = modal.querySelector('#cfg_active').checked;
+        await api(`/api/admin/users-config/${user.id}`, {
+          method:'PUT', body: JSON.stringify({ name:nome, phone, role, equipe_id, permissions, active }),
+        });
+        alert('✅ Usuário atualizado.');
+      } else {
+        const r = await api('/api/admin/users-config', {
+          method:'POST', body: JSON.stringify({ email, name:nome, phone, role, equipe_id, permissions }),
+        });
+        alert(`✅ Usuário "${nome}" criado!\n\n🔑 Senha temporária: ${r.senha_temporaria}\n\nAnote e envie pro usuário. Esta senha não será mostrada novamente.`);
+      }
+      cleanup();
+      state.configCache.users = [];
+      await renderCfgUsuarios();
+    } catch (e) { alert('Erro: ' + e.message); }
+  };
+}
+
+async function renderCfgAuditoria() {
+  const { items } = await api('/api/admin/auditoria?limite=100');
+  state.configCache.auditoria = items;
+  const linhas = items.map(l => `
+    <tr style="border-bottom:1px solid var(--border);">
+      <td style="padding:6px; font-size:11px; color:var(--text-muted); white-space:nowrap;">
+        ${new Date(l.created_at).toLocaleString('pt-BR')}
+      </td>
+      <td style="padding:6px;">
+        <div>${escape(l.user_name || l.login_attempt || '—')}</div>
+        ${l.user_email ? `<div style="font-size:10px; color:var(--text-muted);">${escape(l.user_email)}</div>` : ''}
+      </td>
+      <td style="padding:6px; font-size:11px; color:var(--text-muted);">${escape(l.ip || '—')}</td>
+      <td style="padding:6px;">
+        ${l.sucesso
+          ? '<span style="background:rgba(0,255,136,0.15); color:var(--neon); padding:2px 8px; border-radius:10px; font-size:11px;">✓ Sucesso</span>'
+          : `<span style="background:rgba(239,68,68,0.15); color:#ef4444; padding:2px 8px; border-radius:10px; font-size:11px;">✗ ${escape(l.motivo_falha || 'Falha')}</span>`
+        }
+      </td>
+    </tr>
+  `).join('');
+  document.getElementById('cfg-body').innerHTML = `
+    <p style="margin:0 0 10px; font-weight:600; color:var(--text-muted);">📋 Últimos ${items.length} eventos de login</p>
+    <table style="width:100%; border-collapse:collapse; font-size:12px;">
+      <thead>
+        <tr style="background:var(--bg-elev); text-align:left;">
+          <th style="padding:8px;">Quando</th>
+          <th style="padding:8px;">Quem (ou tentativa)</th>
+          <th style="padding:8px;">IP</th>
+          <th style="padding:8px;">Resultado</th>
+        </tr>
+      </thead>
+      <tbody>${linhas || '<tr><td colspan="4" style="padding:14px; text-align:center; color:var(--text-muted);">Nenhum log ainda.</td></tr>'}</tbody>
+    </table>
+  `;
 }
 </script>
 <!-- v3.10.0: Fechamento de Folha (modal + painel saldo) -->

--- a/src/routes/adminUsers.ts
+++ b/src/routes/adminUsers.ts
@@ -1,0 +1,123 @@
+// v3.25.0: Rotas da aba Configuracoes > Usuarios.
+// Todas exigem JWT admin/owner (requireRole).
+//
+// Endpoints:
+//   GET    /api/admin/users-config                  → lista todos os users
+//   POST   /api/admin/users-config                  → cria user com role + permissoes
+//   PUT    /api/admin/users-config/:id              → atualiza dados/role/permissoes/active
+//   DELETE /api/admin/users-config/:id              → soft-delete
+//   POST   /api/admin/users-config/:id/reset-senha  → reseta senha + retorna temporaria
+//   GET    /api/admin/permissions-catalog           → catalogo de permissoes do sistema
+//   GET    /api/admin/auditoria                     → ultimos 100 auth_logs
+
+import { Router, type Request, type Response } from 'express';
+import { requireAuth, requireRole } from '../middleware/auth';
+import {
+  listarUsuariosAdmin,
+  criarUsuarioAdmin,
+  atualizarUsuarioAdmin,
+  excluirUsuarioAdmin,
+  resetarSenhaUsuario,
+  listarAuditoriaRecente,
+} from '../integrations/adminUsers';
+import {
+  CATEGORIAS_PERMISSOES,
+  DEFAULT_PERMISSIONS_BY_ROLE,
+  type RoleNome,
+} from '../constants/permissoesSistema';
+
+const router = Router();
+router.use(requireAuth, requireRole('admin', 'owner'));
+
+router.get('/permissions-catalog', (_req: Request, res: Response) => {
+  res.json({
+    categorias: CATEGORIAS_PERMISSOES,
+    defaults_por_role: DEFAULT_PERMISSIONS_BY_ROLE,
+  });
+});
+
+router.get('/users-config', async (_req: Request, res: Response) => {
+  try {
+    const users = await listarUsuariosAdmin();
+    res.json({ total: users.length, items: users });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+router.post('/users-config', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as {
+      email?: string; name?: string; phone?: string;
+      role?: RoleNome; equipe_id?: number | null;
+      permissions?: string[] | null; senha?: string;
+    };
+    const createdBy = (req as { user?: { sub?: number } }).user?.sub;
+    const r = await criarUsuarioAdmin({
+      email: String(body.email || ''),
+      name: String(body.name || ''),
+      phone: body.phone,
+      role: (body.role || 'colaborador') as RoleNome,
+      equipe_id: body.equipe_id ?? null,
+      permissions: body.permissions ?? null,
+      senha: body.senha,
+      created_by: createdBy,
+    });
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+router.put('/users-config/:id', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as {
+      name?: string; phone?: string;
+      role?: RoleNome; equipe_id?: number | null;
+      permissions?: string[] | null; active?: boolean;
+    };
+    const r = await atualizarUsuarioAdmin({
+      id: Number(req.params.id),
+      name: body.name,
+      phone: body.phone,
+      role: body.role,
+      equipe_id: body.equipe_id,
+      permissions: body.permissions,
+      active: body.active,
+    });
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+router.delete('/users-config/:id', async (req: Request, res: Response) => {
+  try {
+    const r = await excluirUsuarioAdmin(Number(req.params.id));
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+router.post('/users-config/:id/reset-senha', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as { senha?: string };
+    const r = await resetarSenhaUsuario(Number(req.params.id), body.senha);
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+router.get('/auditoria', async (req: Request, res: Response) => {
+  try {
+    const limite = Number(req.query.limite) || 100;
+    const items = await listarAuditoriaRecente(limite);
+    res.json({ total: items.length, items });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -106,6 +106,10 @@ app.use('/api/minha-quinzena', minhaQuinzenaRoutes);
 import adminAcessosRoutes from './routes/adminAcessos';
 app.use('/api/admin', adminAcessosRoutes);
 
+// v3.25.0: rotas /api/admin/* — gestao de usuarios + permissoes (Configuracoes)
+import adminUsersRoutes from './routes/adminUsers';
+app.use('/api/admin', adminUsersRoutes);
+
 // v3.24.0: tela /login (HTML mobile-first dark theme). Cache no-store pra
 // nao servir versao antiga apos deploy. /login.html tambem funciona via static.
 app.get('/login', (_req: Request, res: Response) => {

--- a/src/test/permissoes-sistema.test.ts
+++ b/src/test/permissoes-sistema.test.ts
@@ -1,0 +1,144 @@
+// v3.25.0: tests do catalogo de permissoes + resolverPermissoesEfetivas.
+
+import { describe, it, expect } from 'vitest';
+import {
+  CATEGORIAS_PERMISSOES,
+  PERMISSIONS_VALIDAS,
+  DEFAULT_PERMISSIONS_BY_ROLE,
+  resolverPermissoesEfetivas,
+  temPermissao,
+} from '../constants/permissoesSistema';
+
+describe('Catalogo de Permissoes', () => {
+  it('tem 14 categorias com pelo menos 50 keys totais', () => {
+    expect(CATEGORIAS_PERMISSOES.length).toBeGreaterThanOrEqual(14);
+    expect(PERMISSIONS_VALIDAS.size).toBeGreaterThanOrEqual(50);
+  });
+
+  it('todas as keys seguem padrao modulo:acao', () => {
+    for (const k of PERMISSIONS_VALIDAS) {
+      expect(k).toMatch(/^[a-z_]+:[a-z_]+$/);
+    }
+  });
+
+  it('todas as keys do catalogo sao unicas', () => {
+    const todas = CATEGORIAS_PERMISSOES.flatMap(c => c.itens.map(i => i.key));
+    expect(new Set(todas).size).toBe(todas.length);
+  });
+
+  it('cada categoria tem icone + label nao vazio', () => {
+    for (const c of CATEGORIAS_PERMISSOES) {
+      expect(c.icone.length).toBeGreaterThan(0);
+      expect(c.label.length).toBeGreaterThan(2);
+      expect(c.itens.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('DEFAULT_PERMISSIONS_BY_ROLE', () => {
+  it('admin tem TODAS as permissoes', () => {
+    expect(DEFAULT_PERMISSIONS_BY_ROLE.admin.length).toBe(PERMISSIONS_VALIDAS.size);
+  });
+
+  it('owner = admin (mesmo conjunto)', () => {
+    expect(DEFAULT_PERMISSIONS_BY_ROLE.owner).toEqual(DEFAULT_PERMISSIONS_BY_ROLE.admin);
+  });
+
+  it('gestor NAO tem config:* nem :excluir nem reverter folha', () => {
+    const g = DEFAULT_PERMISSIONS_BY_ROLE.gestor;
+    expect(g.some(p => p.startsWith('config:'))).toBe(false);
+    expect(g.some(p => p.endsWith(':excluir'))).toBe(false);
+    expect(g).not.toContain('folha:reverter');
+    expect(g).not.toContain('financeiro:excluir');
+    // Mas tem operacoes basicas
+    expect(g).toContain('proposta:criar');
+    expect(g).toContain('equipe:editar');
+  });
+
+  it('colaborador NAO tem nada por default (so /minha-quinzena fora desse sistema)', () => {
+    expect(DEFAULT_PERMISSIONS_BY_ROLE.colaborador).toEqual([]);
+  });
+});
+
+describe('resolverPermissoesEfetivas', () => {
+  it('null custom -> usa defaults do role', () => {
+    expect(resolverPermissoesEfetivas('admin', null)).toEqual(DEFAULT_PERMISSIONS_BY_ROLE.admin);
+    expect(resolverPermissoesEfetivas('gestor', undefined)).toEqual(DEFAULT_PERMISSIONS_BY_ROLE.gestor);
+  });
+
+  it('array vazio explicito -> usuario sem permissoes', () => {
+    expect(resolverPermissoesEfetivas('admin', [])).toEqual([]);
+  });
+
+  it('array com keys validas -> retorna so as validas', () => {
+    expect(resolverPermissoesEfetivas('colaborador', ['proposta:ver','equipe:ver']))
+      .toEqual(['proposta:ver','equipe:ver']);
+  });
+
+  it('filtra keys invalidas silenciosamente', () => {
+    expect(resolverPermissoesEfetivas('admin', ['proposta:ver','xxx:invalido','equipe:ver']))
+      .toEqual(['proposta:ver','equipe:ver']);
+  });
+});
+
+describe('temPermissao helper', () => {
+  it('admin sem custom -> tem qualquer key valida', () => {
+    expect(temPermissao('admin', null, 'proposta:assinar')).toBe(true);
+    expect(temPermissao('admin', null, 'config:usuarios')).toBe(true);
+    expect(temPermissao('admin', null, 'financeiro:excluir')).toBe(true);
+  });
+
+  it('gestor sem custom -> NAO tem :excluir nem config:*', () => {
+    expect(temPermissao('gestor', null, 'proposta:criar')).toBe(true);
+    expect(temPermissao('gestor', null, 'proposta:excluir')).toBe(false);
+    expect(temPermissao('gestor', null, 'config:usuarios')).toBe(false);
+  });
+
+  it('colaborador sem custom -> nenhuma', () => {
+    expect(temPermissao('colaborador', null, 'proposta:ver')).toBe(false);
+  });
+
+  it('user com custom = [] -> nada', () => {
+    expect(temPermissao('admin', [], 'proposta:ver')).toBe(false);
+  });
+
+  it('user com custom = [...] -> exatamente isso', () => {
+    expect(temPermissao('colaborador', ['proposta:ver'], 'proposta:ver')).toBe(true);
+    expect(temPermissao('colaborador', ['proposta:ver'], 'proposta:criar')).toBe(false);
+  });
+});
+
+describe('Smoke — endpoints adminUsers', () => {
+  it('routes/adminUsers.ts registra 7 endpoints', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'routes', 'adminUsers.ts'), 'utf8');
+    expect(src).toContain("'/permissions-catalog'");
+    expect(src).toContain("'/users-config'");
+    expect(src).toContain("/reset-senha");
+    expect(src).toContain("'/auditoria'");
+    expect(src).toMatch(/router\.use\(requireAuth, requireRole/);
+  });
+
+  it('server.ts monta adminUsersRoutes em /api/admin', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'server.ts'), 'utf8');
+    expect(src).toContain('adminUsersRoutes');
+    expect(src).toContain("app.use('/api/admin', adminUsersRoutes)");
+  });
+
+  it('obras.html renderiza aba Configuracoes', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'obras.html'), 'utf8');
+    expect(src).toMatch(/data-tab="config"/);
+    expect(src).toMatch(/renderConfiguracoes/);
+    expect(src).toMatch(/renderCfgUsuarios/);
+    expect(src).toMatch(/abrirModalCfgUser/);
+    expect(src).toMatch(/renderCfgAuditoria/);
+  });
+});


### PR DESCRIPTION
…ranulares

CEO pediu aba Configuracoes pra cadastrar novos usuarios com matriz checkbox de TODAS as atividades/funcoes do sistema. v3.24.x ja tinha auth/JWT/roles basicos mas faltava UX pra criar e gerenciar.

MIGRATION (idempotente, migrations-auth.ts):
- ALTER users ADD permissions JSON NULL (array de keys granulares; NULL = usa defaults do role)
- ALTER users ADD active TINYINT(1) DEFAULT 1 (soft-disable de login)
- ALTER users ADD created_by INT NULL (auditoria de quem criou)

CONSTANTS (src/constants/permissoesSistema.ts) — 56 permissoes em 15 categorias:
- Propostas (8): ver/criar/editar/excluir/assinar/enviar/anexos/revisar
- Clientes (4): ver/criar/editar/excluir
- Equipe (7): ver/criar/editar/excluir/foto/pix/acesso
- Recibos (7): ver/criar/emitir/assinar/enviar/editar/cancelar
- Folha (5): ver/fechar/reverter/exportar/ajuste
- Marcar Dias (4): ver/marcar/desmarcar/editar_passado
- Materiais (4), Despesas (5), Financeiro (5)
- Laudos (6), Loteamentos (4), Vistorias (5), Galeria (4)
- Calculos (2), Configuracoes (4)

Defaults por role:
- admin/owner = TODAS as 56 permissoes
- gestor = tudo MENOS config:*, *:excluir, folha:reverter, financeiro:excluir
- colaborador = [] (so /minha-quinzena fora desse escopo)

BACKEND (integrations/adminUsers.ts + routes/adminUsers.ts):
- listarUsuariosAdmin: SELECT users + JOIN tenant_users + equipe
- criarUsuarioAdmin: gera senha temp (12 chars sem ambiguidade), INSERT com fallback gracioso pra schema legacy (sem permissions/active), vincula em tenant_users com ON DUPLICATE KEY UPDATE
- atualizarUsuarioAdmin: PATCH parcial com validacao de keys de permissoes (filtra invalidas), atualiza tenant_users tambem
- excluirUsuarioAdmin: soft-delete (deleted_at + active=0)
- resetarSenhaUsuario: gera nova senha temp + retorna 1x
- listarAuditoriaRecente: GET ultimos 100 auth_logs

Rotas (todas requireAuth + requireRole admin/owner):
  GET    /api/admin/permissions-catalog
  GET    /api/admin/users-config
  POST   /api/admin/users-config
  PUT    /api/admin/users-config/:id
  DELETE /api/admin/users-config/:id
  POST   /api/admin/users-config/:id/reset-senha
  GET    /api/admin/auditoria

FRONTEND (obras.html):
- Nova aba "⚙️ Configuracoes" no header
- 2 sub-tabs: Usuarios | Auditoria
- Lista de usuarios com: nome/email/role/permissoes/ultimo_login/status
- Botoes por linha: Editar / Resetar senha / Excluir
- Modal "Novo/Editar Usuario":
  * Nome, email (locked em edit), telefone, vincular colaborador
  * Radio Perfil base (admin/gestor/colaborador) com highlight visual
  * Checkbox "Customizar permissoes" → revela matriz granular
  * Grid 15 fieldsets agrupados por modulo com 56 checkboxes
  * Pre-marca defaults do role escolhido ao abrir custom
  * Em edit: toggle "Usuario ativo" pra soft-disable login
  * Em new: aviso "Senha temporaria sera gerada"
- Sub-tab Auditoria: tabela com 100 ultimos auth_logs (data, user, IP, sucesso/falha com motivo)

ENFORCEMENT (NAO incluido nesta PR — fica pra v3.25.x): Por ora as permissoes sao apenas persistidas + exibidas. Nao ha middleware requirePermission ainda nas 79 rotas. Quem definir "proposta:excluir" como false ainda consegue chamar DELETE direto via API (mas o botao Excluir pode ser escondido na UI futura).

20 testes novos em src/test/permissoes-sistema.test.ts:
- Catalogo (4): 14+ categorias, 50+ keys, padrao modulo:acao, unicas
- Defaults (4): admin=tudo, owner=admin, gestor sem destrutivas, colaborador=[]
- resolverPermissoesEfetivas (4): null=default, []=nada, valid=mantem, invalid=filtra
- temPermissao (5): admin true, gestor bloqueado, colaborador false, custom=[] vazio, custom=[...] exato
- Smoke (3): routes registrados, server.ts monta, obras.html renderiza

Total: 642 passing / 1 skipped / 0 failures (era 622 -> +20).

Bump v3.24.19 -> v3.25.0 (minor — feature nova significativa).