### PR TITLE
fix(auditoria): mysql2.execute() nao aceita LIMIT como placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.25.1",
+  "version": "3.25.2",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/adminUsers.ts
+++ b/src/integrations/adminUsers.ts
@@ -288,8 +288,12 @@ export async function resetarSenhaUsuario(id: number, novaSenha?: string) {
   };
 }
 
-// Lista os 100 logs mais recentes pra aba Auditoria
+// Lista os 100 logs mais recentes pra aba Auditoria.
+// v3.25.2 FIX: mysql2.execute() (prepared statement) NAO aceita LIMIT como
+// placeholder — retorna "Incorrect arguments to mysqld_stmt_execute". Solucao:
+// interpolar Number(limite) direto no SQL (seguro porque Number() garante int).
 export async function listarAuditoriaRecente(limite = 100) {
+  const lim = Math.max(1, Math.min(1000, Number(limite) || 100));
   const [rows] = await pool.execute<RowDataPacket[]>(`
     SELECT al.id, al.user_id, al.login_attempt, al.ip,
            al.sucesso, al.motivo_falha, al.created_at,
@@ -297,7 +301,7 @@ export async function listarAuditoriaRecente(limite = 100) {
       FROM auth_logs al
       LEFT JOIN users u ON u.id = al.user_id
      ORDER BY al.created_at DESC
-     LIMIT ?
-  `, [Number(limite)]);
+     LIMIT ${lim}
+  `);
   return rows;
 }


### PR DESCRIPTION
CEO testou aba Auditoria apos v3.25.1 e recebeu:
  "Erro: Incorrect arguments to mysqld_stmt_execute"

Causa conhecida do driver mysql2: pool.execute() (que usa prepared statements via mysqld_stmt_prepare) NAO aceita LIMIT como placeholder `?` em algumas versoes do MySQL server / driver. Retorna erro generico "Incorrect arguments". Funciona com pool.query() (nao-prepared) mas ja temos pool.execute() pre-padronizado no projeto.

Fix: interpolar Number(limite) direto no SQL. Seguro porque:
  - Number(x) ou retorna number, NaN ou Infinity
  - Math.max(1, Math.min(1000, n || 100)) clampa pra [1, 1000]
  - Nao ha como injetar SQL via int
  - Pattern usado em varios outros lugares do projeto (folha, recibos)

Total: 642 passing / 1 skipped / 0 failures.