### PR TITLE
feat(live-feed): componente universal Live Feed para 14 abas do painel

### DIFF
--- a/src/components/liveFeed/liveFeed.test.ts
+++ b/src/components/liveFeed/liveFeed.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Live Feed Universal — testes do service + router
+ * ZAYRA v1.99.15
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'mysql2/promise';
+import { LiveFeedService } from './liveFeedService';
+import { createLiveFeedRouter } from './liveFeedRouter';
+
+function makePool(rows: Record<string, unknown>[]): Pool {
+  return {
+    query: vi.fn().mockResolvedValue([rows, []]),
+    execute: vi.fn().mockResolvedValue([rows, []]),
+  } as unknown as Pool;
+}
+
+describe('LiveFeedService', () => {
+  it('retorna estrutura valida para folha mensal', async () => {
+    const pool = makePool([
+      {
+        id: 1,
+        nome: 'João Pereira',
+        funcao: 'Pedreiro',
+        valor_dia: 170,
+        obra_nome: 'GBOX PRIME',
+        dias_equivalentes: 11,
+        total_a_receber: 1870,
+      },
+    ]);
+    const service = new LiveFeedService(pool);
+    const result = await service.fetch('folha', { obraId: 1, ano: 2026, mes: 5 });
+
+    expect(result.tab).toBe('folha');
+    expect(result.theme).toBe('orange');
+    expect(result.counterValue).toBe(1);
+    expect(result.title).toContain('Maio');
+    expect(result.cards).toBeInstanceOf(Array);
+    expect(result.cards[0]).toMatchObject({
+      title: 'João Pereira',
+      avatar: 'JP',
+      metrics: expect.arrayContaining([
+        expect.objectContaining({ label: 'Diária' }),
+        expect.objectContaining({ label: 'Dias' }),
+        expect.objectContaining({ label: 'A Receber' }),
+      ]),
+    });
+  });
+
+  it('rejeita folha sem obraId', async () => {
+    const service = new LiveFeedService(makePool([]));
+    await expect(service.fetch('folha', {})).rejects.toThrow(/obrigatório/i);
+  });
+
+  it('rejeita aba desconhecida', async () => {
+    const service = new LiveFeedService(makePool([]));
+    // @ts-expect-error testando entrada invalida
+    await expect(service.fetch('inexistente', {})).rejects.toThrow(/desconhecida/i);
+  });
+
+  it('aplica limit no resultado', async () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      nome: `Cliente ${i + 1}`,
+      cpf_cnpj: null,
+      telefone: null,
+      cidade: 'Açailândia',
+      estado: 'MA',
+      qtd_propostas: 0,
+      valor_total: 0,
+    }));
+    const service = new LiveFeedService(makePool(rows));
+    const result = await service.fetch('clientes', { limit: 3 });
+    expect(result.cards.length).toBe(3);
+  });
+
+  it('inclui filtros no retorno', async () => {
+    const service = new LiveFeedService(makePool([]));
+    const result = await service.fetch('despesas', { obraId: 42 });
+    expect(result.filters).toEqual({ obraId: 42 });
+  });
+
+  it('passa por todas as 14 abas sem erro', async () => {
+    const service = new LiveFeedService(makePool([]));
+    const tabs = [
+      'painel', 'obras', 'despesas', 'materiais', 'financeiro',
+      'clientes', 'colaboradores', 'contratos', 'vales', 'laudos',
+      'diarias', 'demarcacoes', 'certs',
+    ] as const;
+    for (const tab of tabs) {
+      const result = await service.fetch(tab, { obraId: 1 });
+      expect(result.tab).toBe(tab);
+      expect(Array.isArray(result.cards)).toBe(true);
+    }
+  });
+
+  it('avatar gera iniciais corretas', async () => {
+    const pool = makePool([
+      { id: 1, nome: 'Ana Maria Silva', funcao: 'Engenheira', valor_dia: 200, telefone: null, tipo_contrato: 'clt', qtd_obras: 2, dias_30d: 15 },
+    ]);
+    const service = new LiveFeedService(pool);
+    const result = await service.fetch('colaboradores');
+    expect(result.cards[0].avatar).toBe('AS');
+  });
+
+  it('formata BRL no metric value', async () => {
+    const pool = makePool([
+      { id: 1, nome: 'Obra X', cliente: 'João', cidade: 'Açailândia', orcamento: 1500, valor_contrato: null, consumo: 0, qtd_etapas_atrasadas: 0 },
+    ]);
+    const service = new LiveFeedService(pool);
+    const result = await service.fetch('painel');
+    const orcMetric = result.cards[0].metrics.find((m) => m.label === 'Orçamento');
+    expect(orcMetric?.value).toMatch(/R\$\s*1\.500,00/);
+  });
+});
+
+describe('LiveFeedRouter', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    app.use('/api/live-feed', createLiveFeedRouter(makePool([])));
+  });
+
+  it('GET aba valida retorna 200 + JSON', async () => {
+    const res = await request(app).get('/api/live-feed/painel');
+    expect(res.status).toBe(200);
+    expect(res.body.tab).toBe('painel');
+    expect(Array.isArray(res.body.cards)).toBe(true);
+  });
+
+  it('aba invalida retorna 404', async () => {
+    const res = await request(app).get('/api/live-feed/foo');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/desconhecida/i);
+  });
+
+  it('folha sem obraId retorna 400', async () => {
+    const res = await request(app).get('/api/live-feed/folha');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/obrigatório/i);
+  });
+
+  it('aceita filtros via query string', async () => {
+    const res = await request(app).get('/api/live-feed/folha?obraId=1&ano=2026&mes=5');
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toMatchObject({ obraId: 1, ano: 2026, mes: 5 });
+  });
+
+  it('headers no-cache', async () => {
+    const res = await request(app).get('/api/live-feed/obras');
+    expect(res.headers['cache-control']).toContain('no-cache');
+  });
+});

--- a/src/components/liveFeed/liveFeedQueries.ts
+++ b/src/components/liveFeed/liveFeedQueries.ts
@@ -1,0 +1,708 @@
+/**
+ * Queries SQL do Live Feed Universal
+ * ZAYRA v1.99.15 — Romatec
+ *
+ * Adaptadas ao schema real (prefixo romatec_*, contratantes p/ laudos,
+ * recibos.tipo='funcionario' p/ vales).
+ *
+ * Nota mysql2: pool.execute() nao aceita LIMIT como placeholder (TypeError).
+ * Pra LIMIT, sanitizamos o numero e interpolamos direto na string.
+ */
+
+import type { Pool, RowDataPacket } from 'mysql2/promise';
+import type { LiveFeedCard, LiveFeedHighlight } from './liveFeedTypes';
+
+// ── HELPERS ──────────────────────────────────────────────────────────────────
+
+function safeLimit(n: number | undefined, fallback: number, max = 500): number {
+  const v = Math.floor(Number(n ?? fallback));
+  if (!Number.isFinite(v) || v <= 0) return fallback;
+  return Math.min(v, max);
+}
+
+function getInitials(nome: string | null | undefined): string {
+  if (!nome) return '??';
+  const parts = String(nome).trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].substring(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function formatBRL(valor: number | string | null | undefined): string {
+  const n = typeof valor === 'string' ? parseFloat(valor) : Number(valor ?? 0);
+  if (!Number.isFinite(n)) return 'R$ 0,00';
+  return n.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+  });
+}
+
+function pctConsumo(consumo: number, orcamento: number): string {
+  const c = Number(consumo) || 0;
+  const o = Number(orcamento) || 0;
+  if (o <= 0) return '0%';
+  return `${Math.round((c / o) * 100)}%`;
+}
+
+function emojiCategoria(cat: string | null | undefined): string {
+  const map: Record<string, string> = {
+    ferramenta: '🔧',
+    aluguel: '🏠',
+    material: '🧱',
+    outros: '📌',
+  };
+  return map[(cat || '').toLowerCase()] || '📌';
+}
+
+function corStatusRecibo(status: string): LiveFeedHighlight {
+  if (status === 'confirmado' || status === 'entregue' || status === 'lido') return 'green';
+  if (status === 'cancelado' || status === 'expirado' || status === 'contestado') return 'red';
+  return 'orange';
+}
+
+function labelStatusRecibo(status: string): string {
+  const map: Record<string, string> = {
+    rascunho: 'Rascunho',
+    aguardando_envio: 'Aguardando',
+    enviado: 'Enviado',
+    entregue: '✓ Entregue',
+    lido: '👁 Lido',
+    respondido: 'Respondido',
+    confirmado: '✓ Confirmado',
+    contestado: 'Contestado',
+    expirado: 'Expirado',
+    cancelado: 'Cancelado',
+  };
+  return map[status] || status;
+}
+
+function fmtDataBR(d: Date | string | null | undefined): string {
+  if (!d) return '—';
+  const date = d instanceof Date ? d : new Date(d);
+  if (isNaN(date.getTime())) return String(d);
+  const dd = String(date.getDate()).padStart(2, '0');
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  return `${dd}/${mm}/${date.getFullYear()}`;
+}
+
+// ── QUERIES POR ABA ──────────────────────────────────────────────────────────
+
+/**
+ * PAINEL (dashboard inicial) · obras em andamento com saúde geral
+ */
+export async function queryPainel(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      o.id,
+      o.nome,
+      o.cliente,
+      o.cidade,
+      o.orcamento,
+      o.valor_contrato,
+      COALESCE(SUM(CASE WHEN t.tipo = 'saida' THEN t.valor ELSE 0 END), 0) AS consumo,
+      COUNT(DISTINCT e.id) AS qtd_etapas_atrasadas
+    FROM romatec_obras o
+    LEFT JOIN romatec_obra_transacoes t ON t.obra_id = o.id
+    LEFT JOIN romatec_obra_etapas e ON e.obra_id = o.id AND e.status = 'atrasado'
+    WHERE o.status = 'em_andamento'
+    GROUP BY o.id, o.nome, o.cliente, o.cidade, o.orcamento, o.valor_contrato
+    ORDER BY o.orcamento DESC
+  `);
+
+  return rows.map((r) => {
+    const orcamento = Number(r.orcamento ?? r.valor_contrato ?? 0);
+    const consumo = Number(r.consumo ?? 0);
+    const atrasadas = Number(r.qtd_etapas_atrasadas ?? 0);
+    return {
+      avatar: getInitials(r.nome),
+      title: String(r.nome),
+      subtitle: `${r.cliente ?? 'Sem cliente'} · ${r.cidade ?? '—'}`,
+      theme: atrasadas > 0 ? 'orange' : 'green',
+      id: Number(r.id),
+      href: `/painel#obra-${r.id}`,
+      metrics: [
+        { label: 'Orçamento', value: formatBRL(orcamento), highlight: 'gold' },
+        { label: 'Consumo', value: pctConsumo(consumo, orcamento), highlight: 'orange' },
+        {
+          label: 'Atrasadas',
+          value: String(atrasadas),
+          highlight: atrasadas > 0 ? 'red' : 'green',
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * OBRAS · todas as obras com status e orçamento
+ */
+export async function queryObras(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      o.id,
+      o.nome,
+      o.cliente,
+      o.endereco,
+      o.cidade,
+      o.orcamento,
+      o.valor_contrato,
+      o.status,
+      COALESCE(SUM(CASE WHEN t.tipo = 'saida' THEN t.valor ELSE 0 END), 0) AS consumo,
+      COUNT(DISTINCT d.funcionario_id) AS qtd_colaboradores
+    FROM romatec_obras o
+    LEFT JOIN romatec_obra_transacoes t ON t.obra_id = o.id
+    LEFT JOIN romatec_obra_funcionario_dias d ON d.obra_id = o.id
+    WHERE o.status IN ('em_andamento', 'paralisada', 'planejamento')
+    GROUP BY o.id, o.nome, o.cliente, o.endereco, o.cidade, o.orcamento, o.valor_contrato, o.status
+    ORDER BY o.orcamento DESC
+  `);
+
+  return rows.map((r) => {
+    const orcamento = Number(r.orcamento ?? r.valor_contrato ?? 0);
+    const consumo = Number(r.consumo ?? 0);
+    const theme: LiveFeedCard['theme'] =
+      r.status === 'paralisada' ? 'red' : r.status === 'planejamento' ? 'blue' : 'gold';
+    return {
+      avatar: getInitials(r.nome),
+      title: String(r.nome),
+      subtitle: `${r.cliente ?? 'Sem cliente'} · ${String(r.endereco ?? '').split(',')[0] || r.cidade || '—'}`,
+      theme,
+      id: Number(r.id),
+      href: `/painel#obra-${r.id}`,
+      metrics: [
+        { label: 'Orçamento', value: formatBRL(orcamento), highlight: 'gold' },
+        { label: 'Consumo', value: pctConsumo(consumo, orcamento), highlight: 'orange' },
+        { label: 'Equipe', value: String(r.qtd_colaboradores ?? 0), highlight: 'green' },
+      ],
+    };
+  });
+}
+
+/**
+ * FOLHA MENSAL · funcionários com diárias no mês (todas marcadas)
+ * Não há status aberta/paga em romatec_obra_funcionario_dias — todas contam.
+ */
+export async function queryFolhaMensal(
+  pool: Pool,
+  obraId: number,
+  ano: number,
+  mes: number,
+): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `
+    SELECT
+      e.id,
+      e.nome,
+      e.funcao,
+      e.valor_dia,
+      o.nome AS obra_nome,
+      COALESCE(SUM(
+        CASE d.periodo
+          WHEN 'integral' THEN 1.0
+          WHEN 'manha'    THEN 0.5
+          WHEN 'tarde'    THEN 0.5
+          ELSE 0
+        END
+      ), 0) AS dias_equivalentes,
+      COALESCE(SUM(
+        COALESCE(d.valor, CASE d.periodo
+          WHEN 'integral' THEN e.valor_dia
+          WHEN 'manha'    THEN e.valor_dia * 0.5
+          WHEN 'tarde'    THEN e.valor_dia * 0.5
+          ELSE 0
+        END)
+      ), 0) AS total_a_receber
+    FROM romatec_obra_equipe e
+    INNER JOIN romatec_obra_funcionario_dias d ON d.funcionario_id = e.id
+    INNER JOIN romatec_obras o ON o.id = d.obra_id
+    WHERE d.obra_id = ?
+      AND YEAR(d.data) = ?
+      AND MONTH(d.data) = ?
+      AND e.ativo = 1
+    GROUP BY e.id, e.nome, e.funcao, e.valor_dia, o.nome
+    HAVING dias_equivalentes > 0
+    ORDER BY total_a_receber DESC
+  `,
+    [obraId, ano, mes],
+  );
+
+  return rows.map((r) => ({
+    avatar: getInitials(r.nome),
+    title: String(r.nome),
+    subtitle: `${r.funcao ?? 'Função n/d'} · ${r.obra_nome}`,
+    theme: 'orange',
+    id: Number(r.id),
+    metrics: [
+      { label: 'Diária', value: formatBRL(r.valor_dia) },
+      { label: 'Dias', value: String(r.dias_equivalentes), highlight: 'green' },
+      { label: 'A Receber', value: formatBRL(r.total_a_receber), highlight: 'orange' },
+    ],
+  }));
+}
+
+/**
+ * MATERIAIS · catálogo (sem obra_id na tabela; obraId é ignorado)
+ */
+export async function queryMateriais(pool: Pool, _obraId?: number): Promise<LiveFeedCard[]> {
+  const limite = safeLimit(50, 50, 200);
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      m.id,
+      m.nome,
+      m.categoria,
+      m.fornecedor_principal,
+      m.unidade,
+      m.estoque,
+      m.estoque_minimo,
+      m.valor_unitario,
+      (COALESCE(m.estoque, 0) * COALESCE(m.valor_unitario, 0)) AS valor_total
+    FROM romatec_obra_materiais m
+    ORDER BY valor_total DESC
+    LIMIT ${limite}
+  `);
+
+  return rows.map((r) => {
+    const estoque = Number(r.estoque ?? 0);
+    const minimo = Number(r.estoque_minimo ?? 0);
+    const lowStock = minimo > 0 && estoque < minimo;
+    return {
+      avatar: '📦',
+      title: String(r.nome),
+      subtitle: `${r.fornecedor_principal ?? 'Sem fornecedor'} · ${r.categoria ?? 'Sem categoria'}`,
+      theme: lowStock ? 'red' : 'gold',
+      id: Number(r.id),
+      metrics: [
+        {
+          label: 'Estoque',
+          value: `${estoque} ${r.unidade ?? 'un'}`,
+          highlight: lowStock ? 'red' : 'green',
+        },
+        { label: 'Unitário', value: formatBRL(r.valor_unitario) },
+        { label: 'Total', value: formatBRL(r.valor_total), highlight: 'gold' },
+      ],
+    };
+  });
+}
+
+/**
+ * COLABORADORES · equipe ativa
+ */
+export async function queryColaboradores(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      e.id,
+      e.nome,
+      e.funcao,
+      e.valor_dia,
+      e.telefone,
+      e.tipo_contrato,
+      COUNT(DISTINCT d.obra_id) AS qtd_obras,
+      COALESCE(SUM(
+        CASE d.periodo
+          WHEN 'integral' THEN 1.0
+          WHEN 'manha'    THEN 0.5
+          WHEN 'tarde'    THEN 0.5
+          ELSE 0
+        END
+      ), 0) AS dias_30d
+    FROM romatec_obra_equipe e
+    LEFT JOIN romatec_obra_funcionario_dias d
+      ON d.funcionario_id = e.id
+     AND d.data >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)
+    WHERE e.ativo = 1
+    GROUP BY e.id, e.nome, e.funcao, e.valor_dia, e.telefone, e.tipo_contrato
+    ORDER BY e.nome ASC
+  `);
+
+  return rows.map((r) => ({
+    avatar: getInitials(r.nome),
+    title: String(r.nome),
+    subtitle: `${r.funcao ?? r.tipo_contrato ?? '—'} · ${r.telefone ?? 's/ telefone'}`,
+    theme: 'green',
+    id: Number(r.id),
+    metrics: [
+      { label: 'Diária', value: formatBRL(r.valor_dia) },
+      { label: 'Obras (30d)', value: String(r.qtd_obras ?? 0), highlight: 'gold' },
+      { label: 'Dias (30d)', value: String(r.dias_30d ?? 0), highlight: 'orange' },
+    ],
+  }));
+}
+
+/**
+ * CLIENTES · cadastrados em propostas_clientes
+ */
+export async function queryClientes(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      c.id,
+      c.nome,
+      c.cpf_cnpj,
+      c.telefone,
+      c.cidade,
+      c.estado,
+      COUNT(DISTINCT p.id) AS qtd_propostas,
+      COALESCE(SUM(p.valor_total), 0) AS valor_total
+    FROM propostas_clientes c
+    LEFT JOIN propostas p ON p.cliente_id = c.id AND p.deleted_at IS NULL
+    WHERE c.deleted_at IS NULL
+    GROUP BY c.id, c.nome, c.cpf_cnpj, c.telefone, c.cidade, c.estado
+    ORDER BY valor_total DESC, c.nome ASC
+  `);
+
+  return rows.map((r) => ({
+    avatar: getInitials(r.nome),
+    title: String(r.nome),
+    subtitle: `${r.cpf_cnpj ?? 's/ documento'} · ${r.cidade ?? '—'}${r.estado ? '/' + r.estado : ''}`,
+    theme: 'green',
+    id: Number(r.id),
+    metrics: [
+      { label: 'Propostas', value: String(r.qtd_propostas ?? 0), highlight: 'gold' },
+      { label: 'Valor Total', value: formatBRL(r.valor_total), highlight: 'green' },
+      { label: 'Telefone', value: r.telefone ?? '—' },
+    ],
+  }));
+}
+
+/**
+ * VALES (recibos do tipo funcionario) · últimos 60 dias
+ */
+export async function queryVales(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      r.id,
+      r.numero,
+      r.destinatario_nome,
+      r.destinatario_doc,
+      r.valor,
+      r.status,
+      r.created_at,
+      r.tipo
+    FROM recibos r
+    WHERE r.tipo IN ('funcionario', 'parcela')
+      AND r.created_at >= DATE_SUB(CURDATE(), INTERVAL 60 DAY)
+    ORDER BY r.created_at DESC, r.id DESC
+    LIMIT 100
+  `);
+
+  return rows.map((r) => {
+    const status = String(r.status);
+    return {
+      avatar: getInitials(r.destinatario_nome),
+      title: String(r.destinatario_nome),
+      subtitle: `Recibo #${r.numero} · ${fmtDataBR(r.created_at)}`,
+      theme: status === 'confirmado' || status === 'entregue' ? 'green' : 'orange',
+      id: Number(r.id),
+      metrics: [
+        { label: 'Valor', value: formatBRL(r.valor), highlight: 'gold' },
+        { label: 'Status', value: labelStatusRecibo(status), highlight: corStatusRecibo(status) },
+        { label: 'Data', value: fmtDataBR(r.created_at) },
+      ],
+    };
+  });
+}
+
+/**
+ * LAUDOS · demarcação (única tabela de laudos no MySQL)
+ */
+export async function queryLaudos(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      l.id,
+      l.numero_laudo,
+      l.tipo_imovel,
+      l.quadra,
+      l.numero_lote,
+      l.loteamento,
+      l.area_total_m2,
+      l.valor_servico,
+      l.status,
+      l.created_at,
+      c.nome AS contratante_nome
+    FROM laudos_demarcacao l
+    LEFT JOIN contratantes c ON c.id = l.contratante_id
+    WHERE l.ativo = TRUE
+    ORDER BY l.created_at DESC
+    LIMIT 100
+  `);
+
+  return rows.map((r) => {
+    const status = String(r.status ?? 'RASCUNHO');
+    const concluido = status === 'CONFIRMADO' || status === 'ASSINADO' || status === 'ENVIADO';
+    return {
+      avatar: r.tipo_imovel === 'RURAL' ? '🌾' : '📐',
+      title: String(r.contratante_nome ?? 'Sem contratante'),
+      subtitle: `Laudo #${r.numero_laudo} · ${r.tipo_imovel}`,
+      theme: 'gold',
+      id: Number(r.id),
+      metrics: [
+        { label: 'Área', value: `${Number(r.area_total_m2 ?? 0).toFixed(2)} m²` },
+        { label: 'Valor', value: formatBRL(r.valor_servico), highlight: 'gold' },
+        { label: 'Status', value: status, highlight: concluido ? 'green' : 'orange' },
+      ],
+    };
+  });
+}
+
+/**
+ * DESPESAS EXTRAS · com filtro opcional por obra
+ */
+export async function queryDespesas(pool: Pool, obraId?: number): Promise<LiveFeedCard[]> {
+  const filter = obraId ? 'AND d.obra_id = ?' : '';
+  const params: number[] = obraId ? [obraId] : [];
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `
+    SELECT
+      d.id,
+      d.data,
+      d.loja,
+      d.destinatario,
+      d.categoria,
+      d.valor_total,
+      d.forma_pagamento,
+      o.nome AS obra_nome
+    FROM despesas_extras d
+    LEFT JOIN romatec_obras o ON o.id = d.obra_id
+    WHERE d.deleted_at IS NULL ${filter}
+    ORDER BY d.data DESC, d.id DESC
+    LIMIT 100
+  `,
+    params,
+  );
+
+  return rows.map((r) => ({
+    avatar: emojiCategoria(r.categoria),
+    title: String(r.destinatario ?? r.loja ?? 'Despesa'),
+    subtitle: `${r.loja} · ${r.obra_nome ?? 'Geral'}`,
+    theme: 'red',
+    id: Number(r.id),
+    metrics: [
+      { label: 'Categoria', value: String(r.categoria) },
+      { label: 'Data', value: fmtDataBR(r.data) },
+      { label: 'Valor', value: formatBRL(r.valor_total), highlight: 'red' },
+    ],
+  }));
+}
+
+/**
+ * FINANCEIRO · lançamentos (romatec_obra_transacoes)
+ */
+export async function queryFinanceiro(pool: Pool, obraId?: number): Promise<LiveFeedCard[]> {
+  const filter = obraId ? 'WHERE t.obra_id = ?' : '';
+  const params: number[] = obraId ? [obraId] : [];
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `
+    SELECT
+      t.id,
+      t.tipo,
+      t.descricao,
+      t.categoria,
+      t.fornecedor,
+      t.valor,
+      t.data,
+      t.forma_pagamento,
+      o.nome AS obra_nome
+    FROM romatec_obra_transacoes t
+    LEFT JOIN romatec_obras o ON o.id = t.obra_id
+    ${filter}
+    ORDER BY t.data DESC, t.id DESC
+    LIMIT 100
+  `,
+    params,
+  );
+
+  return rows.map((r) => {
+    const entrada = r.tipo === 'entrada';
+    return {
+      avatar: entrada ? '⬆️' : '⬇️',
+      title: String(r.descricao),
+      subtitle: `${r.fornecedor ?? r.categoria ?? 'Manual'} · ${r.obra_nome ?? 'Geral'}`,
+      theme: entrada ? 'green' : 'red',
+      id: Number(r.id),
+      metrics: [
+        { label: 'Tipo', value: entrada ? 'ENTRADA' : 'SAÍDA' },
+        { label: 'Data', value: fmtDataBR(r.data) },
+        { label: 'Valor', value: formatBRL(r.valor), highlight: entrada ? 'green' : 'red' },
+      ],
+    };
+  });
+}
+
+/**
+ * CONTRATOS · sem tabela MySQL no projeto (contratos_gerados é Supabase).
+ * Fallback: propostas aceitas servem como contrato firmado.
+ */
+export async function queryContratos(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      p.id,
+      p.numero,
+      p.endereco_obra,
+      p.data_proposta,
+      p.valor_total,
+      p.status,
+      c.nome AS cliente_nome,
+      c.cidade
+    FROM propostas p
+    LEFT JOIN propostas_clientes c ON c.id = p.cliente_id
+    WHERE p.deleted_at IS NULL
+    ORDER BY p.data_proposta DESC, p.id DESC
+    LIMIT 100
+  `);
+
+  return rows.map((r) => {
+    const status = String(r.status);
+    const aceita = status === 'aceita';
+    return {
+      avatar: '📄',
+      title: String(r.cliente_nome ?? 'Sem cliente'),
+      subtitle: `Proposta #${r.numero} · ${fmtDataBR(r.data_proposta)}`,
+      theme: 'gold',
+      id: Number(r.id),
+      metrics: [
+        { label: 'Valor', value: formatBRL(r.valor_total), highlight: 'gold' },
+        {
+          label: 'Status',
+          value: status.toUpperCase(),
+          highlight: aceita ? 'green' : status === 'recusada' ? 'red' : 'orange',
+        },
+        { label: 'Cidade', value: r.cidade ?? '—' },
+      ],
+    };
+  });
+}
+
+/**
+ * DEMARCAÇÕES · alias de laudos com filtro mais estrito
+ */
+export async function queryDemarcacoes(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      l.id,
+      l.numero_laudo,
+      l.tipo_imovel,
+      l.tipo_lote_urbano,
+      l.quadra,
+      l.numero_lote,
+      l.loteamento,
+      l.denominacao_imovel,
+      l.area_total_m2,
+      l.valor_servico,
+      l.status,
+      c.nome AS contratante_nome
+    FROM laudos_demarcacao l
+    LEFT JOIN contratantes c ON c.id = l.contratante_id
+    WHERE l.ativo = TRUE
+    ORDER BY l.created_at DESC
+    LIMIT 100
+  `);
+
+  return rows.map((r) => {
+    const status = String(r.status ?? 'RASCUNHO');
+    const concluido = status === 'CONFIRMADO' || status === 'ASSINADO';
+    const lugar =
+      r.tipo_imovel === 'RURAL'
+        ? r.denominacao_imovel ?? 'Imóvel rural'
+        : `Lote ${r.numero_lote ?? '—'} Qd ${r.quadra ?? '—'}`;
+    return {
+      avatar: '📐',
+      title: String(r.contratante_nome ?? 'Sem contratante'),
+      subtitle: `${lugar} · ${r.loteamento ?? ''}`.trim(),
+      theme: 'gold',
+      id: Number(r.id),
+      metrics: [
+        { label: 'Área', value: `${Number(r.area_total_m2 ?? 0).toFixed(2)} m²` },
+        { label: 'Valor', value: formatBRL(r.valor_servico), highlight: 'gold' },
+        { label: 'Status', value: status, highlight: concluido ? 'green' : 'orange' },
+      ],
+    };
+  });
+}
+
+/**
+ * DIÁRIAS · lançamentos recentes (últimos 15 dias)
+ */
+export async function queryDiarias(pool: Pool, obraId?: number): Promise<LiveFeedCard[]> {
+  const filter = obraId ? 'AND d.obra_id = ?' : '';
+  const params: number[] = obraId ? [obraId] : [];
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `
+    SELECT
+      d.id,
+      d.data,
+      d.periodo,
+      d.valor,
+      e.nome AS colaborador_nome,
+      e.funcao,
+      e.valor_dia,
+      o.nome AS obra_nome
+    FROM romatec_obra_funcionario_dias d
+    INNER JOIN romatec_obra_equipe e ON e.id = d.funcionario_id
+    LEFT JOIN romatec_obras o ON o.id = d.obra_id
+    WHERE d.data >= DATE_SUB(CURDATE(), INTERVAL 15 DAY) ${filter}
+    ORDER BY d.data DESC, d.id DESC
+    LIMIT 100
+  `,
+    params,
+  );
+
+  return rows.map((r) => {
+    const valorBase =
+      r.valor != null
+        ? Number(r.valor)
+        : r.periodo === 'integral'
+          ? Number(r.valor_dia ?? 0)
+          : Number(r.valor_dia ?? 0) * 0.5;
+    return {
+      avatar: getInitials(r.colaborador_nome),
+      title: String(r.colaborador_nome),
+      subtitle: `${r.funcao ?? '—'} · ${r.obra_nome ?? 'Sem obra'}`,
+      theme: 'green',
+      id: Number(r.id),
+      metrics: [
+        { label: 'Período', value: String(r.periodo).toUpperCase() },
+        { label: 'Data', value: fmtDataBR(r.data) },
+        { label: 'Valor', value: formatBRL(valorBase), highlight: 'gold' },
+      ],
+    };
+  });
+}
+
+/**
+ * CERTIFICAÇÕES · usa registros dos executantes (CREA/CFT/INCRA).
+ * Sem tabela dedicada de certificacoes neste projeto.
+ */
+export async function queryCerts(pool: Pool): Promise<LiveFeedCard[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(`
+    SELECT
+      id,
+      nome,
+      qualificacao,
+      registro_crea,
+      registro_cft,
+      cadastro_incra
+    FROM executantes
+    WHERE ativo = TRUE
+    ORDER BY nome ASC
+  `);
+
+  return rows.map((r) => {
+    const registros = [
+      r.registro_crea && `CREA ${r.registro_crea}`,
+      r.registro_cft && `CFT ${r.registro_cft}`,
+      r.cadastro_incra && `INCRA ${r.cadastro_incra}`,
+    ].filter(Boolean);
+
+    return {
+      avatar: '📜',
+      title: String(r.nome),
+      subtitle: String(r.qualificacao ?? 'Responsável técnico'),
+      theme: 'green',
+      id: Number(r.id),
+      metrics: [
+        { label: 'CREA', value: r.registro_crea ?? '—' },
+        { label: 'CFT', value: r.registro_cft ?? '—' },
+        { label: 'Registros', value: String(registros.length), highlight: 'gold' },
+      ],
+    };
+  });
+}

--- a/src/components/liveFeed/liveFeedRouter.ts
+++ b/src/components/liveFeed/liveFeedRouter.ts
@@ -1,0 +1,58 @@
+/**
+ * Live Feed Universal — Router
+ * ZAYRA v1.99.15 — Romatec
+ *
+ * GET /api/live-feed/:tab
+ *   ?obraId  (opcional / obrigatório para folha)
+ *   ?ano,?mes (opcional, default = data atual)
+ *   ?limit   (opcional)
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { Pool } from 'mysql2/promise';
+import { LiveFeedService } from './liveFeedService';
+import type { LiveFeedTab } from './liveFeedTypes';
+
+const VALID_TABS: LiveFeedTab[] = [
+  'painel', 'obras', 'folha', 'despesas', 'materiais', 'financeiro',
+  'clientes', 'colaboradores', 'contratos', 'vales', 'laudos',
+  'diarias', 'demarcacoes', 'certs',
+];
+
+function parsePositiveInt(raw: unknown): number | undefined {
+  if (raw == null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+export function createLiveFeedRouter(pool: Pool): Router {
+  const router = Router();
+  const service = new LiveFeedService(pool);
+
+  router.get('/:tab', async (req: Request, res: Response) => {
+    const tab = req.params.tab as LiveFeedTab;
+
+    if (!VALID_TABS.includes(tab)) {
+      return res.status(404).json({ error: `Aba desconhecida: ${tab}`, tab });
+    }
+
+    try {
+      const data = await service.fetch(tab, {
+        obraId: parsePositiveInt(req.query.obraId),
+        ano: parsePositiveInt(req.query.ano),
+        mes: parsePositiveInt(req.query.mes),
+        limit: parsePositiveInt(req.query.limit),
+      });
+      res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.json(data);
+    } catch (err) {
+      console.error('[LiveFeed]', tab, (err as Error).message);
+      const msg = err instanceof Error ? err.message : 'Erro interno';
+      const status = msg.startsWith('Parâmetro') ? 400 : 500;
+      res.status(status).json({ error: msg, tab });
+    }
+  });
+
+  return router;
+}

--- a/src/components/liveFeed/liveFeedService.ts
+++ b/src/components/liveFeed/liveFeedService.ts
@@ -1,0 +1,170 @@
+/**
+ * Live Feed Universal — Service
+ * ZAYRA v1.99.15 — Romatec
+ */
+
+import type { Pool } from 'mysql2/promise';
+import * as Q from './liveFeedQueries';
+import type {
+  LiveFeedCard,
+  LiveFeedFetchOptions,
+  LiveFeedResponse,
+  LiveFeedTab,
+  LiveFeedTheme,
+} from './liveFeedTypes';
+
+const MES_NOMES = [
+  'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+  'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+] as const;
+
+function mesNome(mes: number): string {
+  return MES_NOMES[mes - 1] ?? '';
+}
+
+interface TabConfig {
+  title: string | ((opts: LiveFeedFetchOptions) => string);
+  counterLabel: string;
+  theme: LiveFeedTheme;
+  fetcher: (pool: Pool, opts: LiveFeedFetchOptions) => Promise<LiveFeedCard[]>;
+  requires?: Array<keyof LiveFeedFetchOptions>;
+}
+
+const TABS: Record<LiveFeedTab, TabConfig> = {
+  painel: {
+    title: 'Obras em Andamento',
+    counterLabel: 'OBRAS',
+    theme: 'green',
+    fetcher: (pool) => Q.queryPainel(pool),
+  },
+  obras: {
+    title: 'Obras Cadastradas',
+    counterLabel: 'OBRAS',
+    theme: 'gold',
+    fetcher: (pool) => Q.queryObras(pool),
+  },
+  folha: {
+    title: (opts) =>
+      `Folha Mensal · ${mesNome(opts.mes ?? new Date().getMonth() + 1)}/${opts.ano ?? new Date().getFullYear()}`,
+    counterLabel: 'FUNCIONÁRIOS',
+    theme: 'orange',
+    requires: ['obraId'],
+    fetcher: (pool, opts) => {
+      const now = new Date();
+      return Q.queryFolhaMensal(
+        pool,
+        opts.obraId!,
+        opts.ano ?? now.getFullYear(),
+        opts.mes ?? now.getMonth() + 1,
+      );
+    },
+  },
+  despesas: {
+    title: 'Despesas Extras',
+    counterLabel: 'LANÇAMENTOS',
+    theme: 'red',
+    fetcher: (pool, opts) => Q.queryDespesas(pool, opts.obraId),
+  },
+  materiais: {
+    title: 'Materiais Cadastrados',
+    counterLabel: 'ITENS',
+    theme: 'gold',
+    fetcher: (pool, opts) => Q.queryMateriais(pool, opts.obraId),
+  },
+  financeiro: {
+    title: 'Lançamentos Financeiros',
+    counterLabel: 'MOVIMENTOS',
+    theme: 'green',
+    fetcher: (pool, opts) => Q.queryFinanceiro(pool, opts.obraId),
+  },
+  clientes: {
+    title: 'Clientes',
+    counterLabel: 'CLIENTES',
+    theme: 'green',
+    fetcher: (pool) => Q.queryClientes(pool),
+  },
+  colaboradores: {
+    title: 'Equipe',
+    counterLabel: 'COLABORADORES',
+    theme: 'green',
+    fetcher: (pool) => Q.queryColaboradores(pool),
+  },
+  contratos: {
+    title: 'Contratos / Propostas',
+    counterLabel: 'CONTRATOS',
+    theme: 'gold',
+    fetcher: (pool) => Q.queryContratos(pool),
+  },
+  vales: {
+    title: 'Vales / Recibos',
+    counterLabel: 'VALES',
+    theme: 'orange',
+    fetcher: (pool) => Q.queryVales(pool),
+  },
+  laudos: {
+    title: 'Laudos Técnicos',
+    counterLabel: 'LAUDOS',
+    theme: 'gold',
+    fetcher: (pool) => Q.queryLaudos(pool),
+  },
+  diarias: {
+    title: 'Diárias Lançadas',
+    counterLabel: 'DIÁRIAS',
+    theme: 'green',
+    fetcher: (pool, opts) => Q.queryDiarias(pool, opts.obraId),
+  },
+  demarcacoes: {
+    title: 'Demarcações',
+    counterLabel: 'DEMARCAÇÕES',
+    theme: 'gold',
+    fetcher: (pool) => Q.queryDemarcacoes(pool),
+  },
+  certs: {
+    title: 'Certificações Técnicas',
+    counterLabel: 'RESPONSÁVEIS',
+    theme: 'green',
+    fetcher: (pool) => Q.queryCerts(pool),
+  },
+};
+
+export class LiveFeedService {
+  constructor(private pool: Pool) {}
+
+  async fetch(tab: LiveFeedTab, opts: LiveFeedFetchOptions = {}): Promise<LiveFeedResponse> {
+    const config = TABS[tab];
+    if (!config) {
+      throw new Error(`Aba desconhecida: ${tab}`);
+    }
+
+    for (const required of config.requires ?? []) {
+      if (opts[required] == null) {
+        throw new Error(`Parâmetro obrigatório ausente: ${required}`);
+      }
+    }
+
+    let cards = await config.fetcher(this.pool, opts);
+
+    if (opts.limit && opts.limit > 0) {
+      cards = cards.slice(0, opts.limit);
+    }
+
+    const title = typeof config.title === 'function' ? config.title(opts) : config.title;
+
+    const filters: Record<string, string | number> = {};
+    if (opts.obraId != null) filters.obraId = opts.obraId;
+    if (opts.ano != null) filters.ano = opts.ano;
+    if (opts.mes != null) filters.mes = opts.mes;
+    if (opts.limit != null) filters.limit = opts.limit;
+
+    return {
+      tab,
+      title,
+      counterLabel: config.counterLabel,
+      counterValue: cards.length,
+      theme: config.theme,
+      cards,
+      filters,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/src/components/liveFeed/liveFeedTypes.ts
+++ b/src/components/liveFeed/liveFeedTypes.ts
@@ -1,0 +1,67 @@
+/**
+ * Tipos do Live Feed Universal
+ * ZAYRA v1.99.15 — Romatec
+ */
+
+export type LiveFeedTab =
+  | 'painel'
+  | 'obras'
+  | 'folha'
+  | 'despesas'
+  | 'materiais'
+  | 'financeiro'
+  | 'clientes'
+  | 'colaboradores'
+  | 'contratos'
+  | 'vales'
+  | 'laudos'
+  | 'diarias'
+  | 'demarcacoes'
+  | 'certs';
+
+export type LiveFeedTheme = 'green' | 'gold' | 'orange' | 'red' | 'blue';
+export type LiveFeedHighlight = 'green' | 'gold' | 'orange' | 'red' | 'white';
+
+export interface LiveFeedMetric {
+  label: string;
+  value: string;
+  highlight?: LiveFeedHighlight;
+}
+
+export interface LiveFeedCard {
+  /** Iniciais para o avatar (2 letras) ou emoji */
+  avatar: string;
+  /** Título principal (ex: nome do funcionário) */
+  title: string;
+  /** Linha secundária (ex: "Pedreiro · RODO RANCHO") */
+  subtitle: string;
+  /** Tema de cor do card */
+  theme: LiveFeedTheme;
+  /** Grid de 3 métricas (label + value + opcional highlight) */
+  metrics: LiveFeedMetric[];
+  /** ID opcional para clique/navegação */
+  id?: number | string;
+  /** URL opcional ao clicar */
+  href?: string;
+}
+
+export interface LiveFeedResponse {
+  tab: LiveFeedTab;
+  title: string;
+  subtitle?: string;
+  counterLabel: string;
+  counterValue: number;
+  theme: LiveFeedTheme;
+  cards: LiveFeedCard[];
+  /** Filtros aplicados (ex: obra ativa) */
+  filters?: Record<string, string | number>;
+  /** Timestamp ISO da geração */
+  generatedAt: string;
+}
+
+export interface LiveFeedFetchOptions {
+  obraId?: number;
+  ano?: number;
+  mes?: number;
+  limit?: number;
+}

--- a/src/public/css/live-feed.css
+++ b/src/public/css/live-feed.css
@@ -1,0 +1,209 @@
+/* ============================================================
+   ZAYRA · Live Feed Universal · v1.99.15
+   ============================================================ */
+.zayra-live-feed {
+  --zlf-bg: rgba(255, 255, 255, 0.02);
+  --zlf-border: rgba(255, 255, 255, 0.06);
+  --zlf-accent: #00ff88;
+  --zlf-accent-soft: rgba(0, 255, 136, 0.15);
+
+  margin-bottom: 20px;
+  padding: 20px;
+  background: var(--zlf-bg);
+  border: 1px solid var(--zlf-border);
+  border-radius: 16px;
+  position: relative;
+  overflow: hidden;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+.zayra-live-feed[data-theme="green"]  { --zlf-accent:#00ff88; --zlf-accent-soft:rgba(0,255,136,0.15); --zlf-border:rgba(0,255,136,0.25); --zlf-bg:rgba(0,255,136,0.03); }
+.zayra-live-feed[data-theme="gold"]   { --zlf-accent:#d4af37; --zlf-accent-soft:rgba(212,175,55,0.15); --zlf-border:rgba(212,175,55,0.25); --zlf-bg:rgba(212,175,55,0.03); }
+.zayra-live-feed[data-theme="orange"] { --zlf-accent:#ff9500; --zlf-accent-soft:rgba(255,149,0,0.15); --zlf-border:rgba(255,149,0,0.25); --zlf-bg:rgba(255,149,0,0.03); }
+.zayra-live-feed[data-theme="red"]    { --zlf-accent:#ff3366; --zlf-accent-soft:rgba(255,51,102,0.15); --zlf-border:rgba(255,51,102,0.25); --zlf-bg:rgba(255,51,102,0.03); }
+.zayra-live-feed[data-theme="blue"]   { --zlf-accent:#00c8ff; --zlf-accent-soft:rgba(0,200,255,0.15); --zlf-border:rgba(0,200,255,0.25); --zlf-bg:rgba(0,200,255,0.03); }
+
+.zayra-live-feed::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--zlf-accent), transparent);
+  animation: zlf-sweep 3s linear infinite;
+  pointer-events: none;
+}
+@keyframes zlf-sweep {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.zlf-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.zlf-title {
+  font-size: 14px;
+  color: #fff;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: 0.3px;
+  margin: 0;
+}
+.zlf-live-dot {
+  width: 9px;
+  height: 9px;
+  background: var(--zlf-accent);
+  border-radius: 50%;
+  box-shadow: 0 0 12px var(--zlf-accent);
+  animation: zlf-blink 1s infinite;
+}
+@keyframes zlf-blink { 50% { opacity: 0.3; } }
+
+.zlf-counter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--zlf-accent-soft);
+  border: 1px solid var(--zlf-accent);
+  color: var(--zlf-accent);
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+.zlf-counter-num {
+  font-family: 'JetBrains Mono', ui-monospace, 'Cascadia Mono', monospace;
+  font-size: 13px;
+}
+
+.zlf-viewport {
+  overflow: hidden;
+  position: relative;
+  mask-image: linear-gradient(90deg, transparent 0, #000 40px, #000 calc(100% - 40px), transparent 100%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 40px, #000 calc(100% - 40px), transparent 100%);
+}
+.zlf-track {
+  display: flex;
+  gap: 12px;
+  width: max-content;
+  animation: zlf-scroll var(--zlf-duration, 45s) linear infinite;
+}
+.zayra-live-feed:hover .zlf-track { animation-play-state: paused; }
+@keyframes zlf-scroll {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+.zlf-card {
+  width: 340px;
+  flex-shrink: 0;
+  padding: 16px;
+  background: linear-gradient(135deg, var(--zlf-accent-soft), rgba(212, 175, 55, 0.03));
+  border: 1px solid var(--zlf-border);
+  border-radius: 14px;
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  cursor: default;
+  color: #fff;
+  text-decoration: none;
+  display: block;
+}
+a.zlf-card { cursor: pointer; }
+.zlf-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--zlf-accent);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.zlf-card-top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.zlf-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--zlf-accent), #d4af37);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  color: #000;
+  flex-shrink: 0;
+}
+.zlf-card-info { flex: 1; min-width: 0; }
+.zlf-card-title {
+  color: #fff;
+  font-weight: 700;
+  font-size: 14px;
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.zlf-card-sub {
+  color: #aaa;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.zlf-card-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--zlf-border);
+}
+.zlf-cell { text-align: center; }
+.zlf-cell-lbl {
+  font-size: 9px;
+  color: #888;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+.zlf-cell-val {
+  font-size: 14px;
+  font-weight: 700;
+  color: #fff;
+  font-family: 'JetBrains Mono', ui-monospace, 'Cascadia Mono', monospace;
+  letter-spacing: -0.3px;
+}
+.zlf-cell-val.zlf-hl-green  { color: #00ff88; font-size: 16px; }
+.zlf-cell-val.zlf-hl-gold   { color: #d4af37; }
+.zlf-cell-val.zlf-hl-orange { color: #ff9500; }
+.zlf-cell-val.zlf-hl-red    { color: #ff3366; }
+.zlf-cell-val.zlf-hl-white  { color: #fff; }
+
+.zlf-empty {
+  padding: 32px;
+  text-align: center;
+  color: #666;
+  font-size: 13px;
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+  .zayra-live-feed { padding: 14px; }
+  .zlf-card { width: 280px; padding: 12px; }
+  .zlf-card-title { font-size: 13px; }
+  .zlf-cell-val { font-size: 13px; }
+  .zlf-cell-val.zlf-hl-green { font-size: 15px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zlf-track { animation: none; }
+  .zayra-live-feed::before { animation: none; }
+  .zlf-live-dot { animation: none; }
+}

--- a/src/public/js/live-feed.js
+++ b/src/public/js/live-feed.js
@@ -1,0 +1,157 @@
+/**
+ * ZAYRA · Live Feed Universal · v1.99.15
+ * Auto-inicializa qualquer .zayra-live-feed na página.
+ * Recarrega via window.ZayraLiveFeed.reload(seletor) ou reloadAll().
+ */
+(function () {
+  'use strict';
+
+  const SCROLL_SECONDS_PER_CARD = 4;
+
+  function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function renderCard(card) {
+    const cells = (card.metrics || [])
+      .map(function (m) {
+        const hl = m.highlight ? ' zlf-hl-' + m.highlight : '';
+        return (
+          '<div class="zlf-cell">' +
+          '<div class="zlf-cell-lbl">' + escapeHtml(m.label) + '</div>' +
+          '<div class="zlf-cell-val' + hl + '">' + escapeHtml(m.value) + '</div>' +
+          '</div>'
+        );
+      })
+      .join('');
+
+    const tag = card.href ? 'a' : 'div';
+    const href = card.href ? ' href="' + escapeHtml(card.href) + '"' : '';
+
+    return (
+      '<' + tag + ' class="zlf-card"' + href + '>' +
+        '<div class="zlf-card-top">' +
+          '<div class="zlf-avatar">' + escapeHtml(card.avatar) + '</div>' +
+          '<div class="zlf-card-info">' +
+            '<div class="zlf-card-title">' + escapeHtml(card.title) + '</div>' +
+            '<div class="zlf-card-sub">' + escapeHtml(card.subtitle) + '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="zlf-card-grid">' + cells + '</div>' +
+      '</' + tag + '>'
+    );
+  }
+
+  function buildUrl(el) {
+    const tab = el.dataset.tab;
+    const params = new URLSearchParams();
+    if (el.dataset.obraId) params.set('obraId', el.dataset.obraId);
+    if (el.dataset.ano) params.set('ano', el.dataset.ano);
+    if (el.dataset.mes) params.set('mes', el.dataset.mes);
+    if (el.dataset.limit) params.set('limit', el.dataset.limit);
+    const qs = params.toString();
+    return '/api/live-feed/' + encodeURIComponent(tab) + (qs ? '?' + qs : '');
+  }
+
+  async function loadFeed(el) {
+    const tab = el.dataset.tab;
+    if (!tab) return;
+
+    try {
+      const res = await fetch(buildUrl(el), { credentials: 'same-origin' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const data = await res.json();
+      applyData(el, data);
+    } catch (err) {
+      console.error('[LiveFeed]', tab, err);
+      const titleEl = el.querySelector('.zlf-title-text');
+      if (titleEl) titleEl.textContent = 'Erro ao carregar';
+      el.dataset.theme = 'red';
+    }
+  }
+
+  function applyData(el, data) {
+    el.dataset.theme = data.theme || 'green';
+
+    const titleEl = el.querySelector('.zlf-title-text');
+    if (titleEl) titleEl.textContent = data.title || '';
+
+    const counterNum = el.querySelector('.zlf-counter-num');
+    const counterLbl = el.querySelector('.zlf-counter-label');
+    if (counterNum) counterNum.textContent = String(data.counterValue ?? 0);
+    if (counterLbl) counterLbl.textContent = data.counterLabel || 'REGISTROS';
+
+    const empty = el.querySelector('.zlf-empty');
+    const viewport = el.querySelector('.zlf-viewport');
+
+    if (!data.cards || data.cards.length === 0) {
+      if (empty) empty.hidden = false;
+      if (viewport) viewport.hidden = true;
+      return;
+    }
+    if (empty) empty.hidden = true;
+    if (viewport) viewport.hidden = false;
+
+    const track = el.querySelector('.zlf-track');
+    if (!track) return;
+
+    const html = data.cards.map(renderCard).join('');
+    track.innerHTML = html + html; // duplica pra loop infinito sem corte
+
+    const duration = Math.max(20, data.cards.length * SCROLL_SECONDS_PER_CARD);
+    track.style.setProperty('--zlf-duration', duration + 's');
+  }
+
+  function setupAutoRefresh(el) {
+    const ms = parseInt(el.dataset.refreshMs || '60000', 10);
+    if (Number.isFinite(ms) && ms > 0) {
+      const id = setInterval(function () {
+        if (document.body.contains(el)) {
+          loadFeed(el);
+        } else {
+          clearInterval(id);
+        }
+      }, ms);
+    }
+  }
+
+  function init() {
+    document.querySelectorAll('.zayra-live-feed').forEach(function (el) {
+      loadFeed(el);
+      setupAutoRefresh(el);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  window.ZayraLiveFeed = {
+    reload: function (selectorOrEl) {
+      const el = typeof selectorOrEl === 'string'
+        ? document.querySelector(selectorOrEl)
+        : selectorOrEl;
+      if (el) loadFeed(el);
+    },
+    reloadAll: function () {
+      document.querySelectorAll('.zayra-live-feed').forEach(loadFeed);
+    },
+    setFilter: function (selectorOrEl, key, value) {
+      const el = typeof selectorOrEl === 'string'
+        ? document.querySelector(selectorOrEl)
+        : selectorOrEl;
+      if (!el) return;
+      const camelKey = key === 'obraId' ? 'obraId' : key;
+      el.dataset[camelKey] = value == null ? '' : String(value);
+      loadFeed(el);
+    },
+  };
+})();

--- a/src/public/partials/live-feed-snippet.html
+++ b/src/public/partials/live-feed-snippet.html
@@ -1,0 +1,34 @@
+<!--
+  Live Feed Universal · ZAYRA v1.99.15 — snippet HTML standalone.
+  Copie/cole em qualquer pagina .html do projeto. Ajuste data-tab e
+  os filtros (data-obra-id, data-ano, data-mes) conforme a aba.
+  Requer no <head>:
+    <link rel="stylesheet" href="/css/live-feed.css">
+  E antes do </body>:
+    <script src="/js/live-feed.js"></script>
+-->
+<div
+  class="zayra-live-feed"
+  data-tab="painel"
+  data-obra-id=""
+  data-ano=""
+  data-mes=""
+  data-refresh-ms="60000"
+>
+  <div class="zlf-header">
+    <h3 class="zlf-title">
+      <span class="zlf-live-dot"></span>
+      <span class="zlf-title-text">Carregando…</span>
+    </h3>
+    <div class="zlf-counter">
+      <span class="zlf-counter-num">0</span>
+      <span class="zlf-counter-label">REGISTROS</span>
+    </div>
+  </div>
+  <div class="zlf-viewport">
+    <div class="zlf-track"></div>
+  </div>
+  <div class="zlf-empty" hidden>
+    <span>Nenhum registro nesta seção.</span>
+  </div>
+</div>

--- a/src/server.ts
+++ b/src/server.ts
@@ -146,6 +146,11 @@ app.use('/api/gnss', gnssRouter);
 app.use('/api/cartorios', cartoriosRouter);
 app.use('/api/explicativo', explicativoRouter); // v3.23.0 — texto explicativo de serviço
 
+// v1.99.15: Live Feed Universal — feed animado no topo de toda aba.
+// GET /api/live-feed/:tab → cards passando em loop com os registros da aba.
+import { createLiveFeedRouter } from './components/liveFeed/liveFeedRouter';
+app.use('/api/live-feed', createLiveFeedRouter(pool));
+
 // v3.23.2: /sw.js servido com injecao de versao em runtime.
 // Fonte unica da verdade e' package.json (via AGENT_IDENTITY.version).
 // O arquivo em disco contem o placeholder __APP_VERSION__ no const CACHE;

--- a/src/views/partials/_live_feed.ejs
+++ b/src/views/partials/_live_feed.ejs
@@ -1,0 +1,33 @@
+<%#
+  Live Feed Universal · ZAYRA v1.99.15
+  Uso (EJS): <%- include('partials/_live_feed', { tab: 'folha', obraId: 1, ano: 2026, mes: 5 }) %>
+  Uso (HTML estatico): copie a div abaixo trocando data-* manualmente.
+  Requer: /css/live-feed.css e /js/live-feed.js no layout.
+%>
+<div
+  class="zayra-live-feed"
+  data-tab="<%= tab %>"
+  data-obra-id="<%= typeof obraId !== 'undefined' && obraId !== null ? obraId : '' %>"
+  data-ano="<%= typeof ano !== 'undefined' && ano !== null ? ano : '' %>"
+  data-mes="<%= typeof mes !== 'undefined' && mes !== null ? mes : '' %>"
+  data-refresh-ms="<%= typeof refreshMs !== 'undefined' ? refreshMs : 60000 %>"
+>
+  <div class="zlf-header">
+    <h3 class="zlf-title">
+      <span class="zlf-live-dot"></span>
+      <span class="zlf-title-text">Carregando…</span>
+    </h3>
+    <div class="zlf-counter">
+      <span class="zlf-counter-num">0</span>
+      <span class="zlf-counter-label">REGISTROS</span>
+    </div>
+  </div>
+
+  <div class="zlf-viewport">
+    <div class="zlf-track"></div>
+  </div>
+
+  <div class="zlf-empty" hidden>
+    <span>Nenhum registro nesta seção.</span>
+  </div>
+</div>


### PR DESCRIPTION
Cria componente standalone que mostra cards animados (loop infinito, hover pausa) com os registros da aba ativa. GET /api/live-feed/:tab retorna ate 100 cards estruturados; auto-refresh 60s no frontend.

- Backend: types + queries + service + router em src/components/liveFeed
- Frontend: CSS dark theme com 5 temas (green/gold/orange/red/blue), JS auto-bootstrap e API window.ZayraLiveFeed pra reload manual
- Partial EJS + snippet HTML standalone (pra paginas .html existentes)
- 14 abas mapeadas ao schema real (romatec_*, contratantes, recibos): painel, obras, folha, despesas, materiais, financeiro, clientes, colaboradores, contratos (=propostas), vales (=recibos), laudos, diarias, demarcacoes, certs (=executantes registros)
- Cobertura: 13 testes Vitest (service + router) — typecheck OK, suite completa 655/655 passando