### PR TITLE
feat(live-feed): integra componente nas views painel.html e obras.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.26.0",
+  "version": "3.26.1",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1008,6 +1008,7 @@ async function nukeReload() {
 // Expõe pra debug manual no console
 window.forcarUpdateApp = forcarUpdate;
 </script>
+<link rel="stylesheet" href="/css/live-feed.css">
 </head>
 <body>
 <div class="container">
@@ -1047,6 +1048,22 @@ window.forcarUpdateApp = forcarUpdate;
     <button class="tab" data-tab="proposta">Proposta</button>
     <button class="tab" data-tab="calculos">🧮 Cálculos</button>
     <button class="tab" data-tab="config">⚙️ Configurações</button>
+  </div>
+
+  <!-- v1.99.15: Live Feed Universal — atualizado dinamicamente conforme tab ativa -->
+  <div class="zayra-live-feed" id="zayraLiveFeed" data-tab="painel" data-refresh-ms="60000">
+    <div class="zlf-header">
+      <h3 class="zlf-title">
+        <span class="zlf-live-dot"></span>
+        <span class="zlf-title-text">Carregando…</span>
+      </h3>
+      <div class="zlf-counter">
+        <span class="zlf-counter-num">0</span>
+        <span class="zlf-counter-label">REGISTROS</span>
+      </div>
+    </div>
+    <div class="zlf-viewport"><div class="zlf-track"></div></div>
+    <div class="zlf-empty" hidden><span>Nenhum registro nesta seção.</span></div>
   </div>
 
   <div id="view-dashboard" class="view active"></div>
@@ -15998,7 +16015,39 @@ function renderCobDet() {
   `;
 }
 
-document.querySelectorAll('.tab').forEach(t => t.onclick = () => { state.currentTab = t.dataset.tab; render(); });
+document.querySelectorAll('.tab').forEach(t => t.onclick = () => { state.currentTab = t.dataset.tab; render(); atualizarLiveFeed(); });
+
+// v1.99.15: Live Feed sincronizado com a aba ativa.
+// Mapa obras.html tab -> liveFeed tab. Tabs sem mapeamento escondem o feed.
+const ZLF_TAB_MAP = {
+  dashboard: 'painel', obras: 'obras', despesas: 'despesas',
+  materiais: 'materiais', financeiro: 'financeiro', recibos: 'vales',
+  equipe: 'colaboradores', marcar: 'diarias', folha: 'folha',
+  laudos: 'laudos', proposta: 'contratos',
+};
+function atualizarLiveFeed() {
+  const el = document.getElementById('zayraLiveFeed');
+  if (!el || !window.ZayraLiveFeed) return;
+  const tab = ZLF_TAB_MAP[state.currentTab];
+  if (!tab) { el.style.display = 'none'; return; }
+  el.style.display = '';
+  el.dataset.tab = tab;
+  // obraId para folha/despesas/financeiro/diarias/materiais
+  const needsObra = ['folha','despesas','financeiro','diarias','materiais'];
+  if (needsObra.includes(tab) && state.currentObra?.id) {
+    el.dataset.obraId = state.currentObra.id;
+  } else {
+    el.dataset.obraId = '';
+  }
+  if (tab === 'folha') {
+    const now = new Date();
+    el.dataset.ano = String(now.getFullYear());
+    el.dataset.mes = String(now.getMonth() + 1);
+    // folha exige obraId — se não houver, esconde
+    if (!el.dataset.obraId) { el.style.display = 'none'; return; }
+  }
+  window.ZayraLiveFeed.reload(el);
+}
 document.getElementById('zayraFab').onclick = () => {
   const m = document.getElementById('zayraModal');
   m.classList.toggle('open');
@@ -21774,5 +21823,14 @@ async function renderCfgAuditoria() {
 <script src="/relatorio-demarcacao.js"></script>
 <!-- v3.18.0: Processamento GNSS (RINEX -> IBGE-PPP) -->
 <script src="/laudo-gnss.js"></script>
+<!-- v1.99.15: Live Feed Universal — auto-bootstrap + ZayraLiveFeed.* API -->
+<script src="/js/live-feed.js"></script>
+<script>
+  // Aciona uma atualizacao inicial assim que o live-feed.js esta carregado
+  // e depois quando state.currentObra muda (selecao de obra dispara render()).
+  window.addEventListener('load', () => {
+    if (typeof atualizarLiveFeed === 'function') atualizarLiveFeed();
+  });
+</script>
 </body>
 </html>

--- a/src/public/painel.html
+++ b/src/public/painel.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ZAYRA — Painel Romatec</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <link rel="stylesheet" href="/css/live-feed.css">
   <style>
     :root {
       --bg: #0b0f17;
@@ -144,6 +145,22 @@
     </div>
     <div class="pill" id="version-pill">v1.47.0</div>
   </header>
+
+  <!-- v1.99.15: Live Feed Universal -->
+  <div class="zayra-live-feed" data-tab="painel" data-refresh-ms="60000">
+    <div class="zlf-header">
+      <h3 class="zlf-title">
+        <span class="zlf-live-dot"></span>
+        <span class="zlf-title-text">Carregando…</span>
+      </h3>
+      <div class="zlf-counter">
+        <span class="zlf-counter-num">0</span>
+        <span class="zlf-counter-label">REGISTROS</span>
+      </div>
+    </div>
+    <div class="zlf-viewport"><div class="zlf-track"></div></div>
+    <div class="zlf-empty" hidden><span>Nenhum registro nesta seção.</span></div>
+  </div>
 
   <div id="error-zone"></div>
 
@@ -385,5 +402,6 @@
     carregar();
     setInterval(carregar, 60_000);
   </script>
+  <script src="/js/live-feed.js"></script>
 </body>
 </html>


### PR DESCRIPTION
painel.html: sempre data-tab='painel'.
obras.html: data-tab dinamico conforme aba ativa via state.currentTab.
  Mapa: dashboard->painel, obras->obras, despesas->despesas,
  materiais->materiais, financeiro->financeiro, recibos->vales,
  equipe->colaboradores, marcar->diarias, folha->folha,
  laudos->laudos, proposta->contratos. Tabs sem mapeamento escondem
  o feed. folha exige currentObra.id (esconde se nao houver).

bump 3.26.0 -> 3.26.1