### PR TITLE
feat(proposta): demarcacao de lotes urbana e rural com codificacao FQ…

### DIFF
--- a/06-Changelog/v3.27.0-proposta-demarcacao-lotes.md
+++ b/06-Changelog/v3.27.0-proposta-demarcacao-lotes.md
@@ -1,0 +1,66 @@
+# v3.27.0 — Proposta de Demarcação de Lotes (Urbana e Rural) + Codificação FQNS
+
+**Data:** 2026-05-27
+**Branch:** `feature/proposta-demarcacao-lotes-v3.27.0`
+**Versão alvo após merge:** v3.27.0
+
+## Resumo
+
+Implementa o serviço de **Demarcação Física de Lotes** (Urbana e Rural) como dois novos subtipos de Proposta de Consultoria, espelhando 1:1 o padrão aprovado em PROP‑2026‑0011‑R1 (Georref Rural v3.23.5). Inclui codificação automática de marcos com credencial INCRA **FQNS** do técnico responsável (rastreabilidade vitalícia perante INCRA/MPF).
+
+## Entregáveis
+
+- **Tipos**: `SubtipoDemarcacao`, `MaterialMarco`, `FinalidadeDemarcacao`, `MarcoDiscriminado`, `OpcionaisDemarcacao`, `InputDemarcacaoLotes`, `CodigosMintadosFQNS`, `DemarcacaoLotesOutput`.
+- **Engine de cálculo**: `src/services/pricing/demarcacaoLotes.ts` — TRT/CFT + técnicos de campo + marcos discriminados + deslocamento + área × valor unitário + complexidade + assessoria 5% + desconto + mínimo garantido 2 SM + parcelas 40/30/30.
+- **Mint atômico FQNS**: `src/services/pricing/mintCodigosDemarcacao.ts` — lock pessimista `FOR UPDATE` no `users.credencial_contadores` (JSON). Códigos vitalícios:
+  - Vértices: `FQNS-V-024`
+  - Marcos concreto: `FQNS-M-0142-CC`
+  - Marcos tubo galv.: `FQNS-M-0089-TG`
+  - Piquetes madeira: `FQNS-P-0067-MD`
+- **Migration idempotente** em `users` (auth SaaS): adiciona `credencial_incra_prefixo` + `credencial_contadores` JSON; faz seed do CEO (Romário) com prefixo `FQNS` e contadores zerados. **Zero ALTER em `propostas`**.
+- **Aviso DRL adaptado** para 4 finalidades de demarcação (`demarcacao_inicial`, `redemarcacao`, `subdivisao_lote`, `piqueteamento_apenas`) com reforço apenas em `subdivisao_lote`.
+- **PDF**: helper `renderDemarcacaoLotesBody()` com 11 seções (10 do Georref + 4‑bis Marcos Discriminados + 4‑ter Identificação FQNS). Invocação **apenas** para subtipos `demarcacao_urbana` e `demarcacao_rural` — outros subtipos seguem inalterados.
+- **Frontend**: 2 novos cards (🌆 Demarcação Urbana / 🌾 Demarcação Rural) posicionados após Georref Rural; função `renderConsultoriaFormDemarcacao()` com validação live `Σ marcos === num_vertices`, preview FQNS informativo, opcionais 5 linhas, parcelas 40/30/30.
+- **Página pública** `/v/:hash`: detector e render dedicado para os 2 subtipos com finalidade, marcos, códigos FQNS, opcionais contratados e box vermelho DRL.
+- **Wire‑up envio**: `garantirCodigosMintadosDemarcacao(propostaId)` chamado por `enviarPropostaConsultoriaWhatsApp` e `enviarPropostaConsultoriaTelegram` antes da transição `rascunho → enviada`. Idempotente (anti‑replay via `dados_imovel.codigos_mintados`).
+
+## Princípios honrados
+
+- ✅ Zero `ALTER TABLE` em `propostas` — campos novos em `dados_imovel` JSON e `custos_calculados` JSON.
+- ✅ Zero endpoint novo — reusa `/api/propostas-consultoria/*` (poliglota), discriminando por `subtipo_consultoria`.
+- ✅ Migration permitida apenas em `users` (metadado do técnico).
+- ✅ Helpers de numeração reutilizados (`gerarNumeroProposta`, `parseRevisao`, `bumpRevisao`).
+- ✅ Nomenclatura **TRT/CFT** (chave `trt_cft`, R$ 93,40) — Téc. em Agrimensura CFT/MA n. 01209185369.
+- ✅ Arquivos proibidos preservados: `src/agent/tools.ts`, `src/agent/think.ts`, `src/services/aiCascade.ts`, `src/services/pricing/georreferenciamento.ts`.
+
+## Testes
+
+- `src/services/pricing/demarcacaoLotes.test.ts` — **22 testes** (validações, cenários canônicos urbano/rural, guard de fechamento, mínimo garantido, opcionais, runtime SM).
+- `src/integrations/avisoDRL.demarcacao.test.ts` — **8 testes** (4 finalidades, base de 3 parágrafos, reforço em subdivisão, estrutura, standalone).
+- `src/services/pricing/mintCodigosDemarcacao.test.ts` — **8 testes** (vértices/marcos padding, mistos, vitalício, delta‑mint, anti‑replay, sem credencial, lock atômico).
+
+**Total**: 38 testes novos. Suite completa: **693 passing, 1 skipped, 0 failures** (baseline 655 + 38 novos).
+
+> Nota: o prompt original do CEO mencionou meta "492 passing" assumindo baseline v3.23.5 (454 testes). O repo evoluiu para v3.26.1 (655 testes) antes desta feature, então a meta efetiva foi `baseline atual + 38 = 693`.
+
+## Parâmetros (config/pricing-params.json)
+
+Bloco novo `demarcacao_lotes_2026` com:
+- `valor_m2_urbano_default: 1.50`
+- `valor_hectare_rural_default: 80.00`
+- `fator_diaria_tecnico: 0.42` (fonte: CFT‑MA Res. 12/2025 art. 4º)
+- Marcos: concreto R$ 120, tubo galv. R$ 85, madeira R$ 35 (com `codigo_funcao`/`codigo_material`/`largura_numero` pra mint)
+- Opcionais: laudo (1 SM), alinhamento R$ 4,50/m, croqui R$ 180, acompanhamento R$ 350/diária, jurídica sob orçamento
+- Complexidade: simples 1.0x, média 1.3x, alta 1.6x
+- Mínimo garantido: 2 SM | Assessoria: 5% | Desconto máx: 30%
+- Parcelas: 40/30/30 (assinatura / entrega campo / entrega final + TRT/CFT)
+
+## Limitações conhecidas
+
+- Imprimir etiquetas físicas dos marcos com QR code: follow‑up.
+- Template Z‑API com preview de marcos: follow‑up.
+- Outros técnicos com prefixos diferentes (ex: CREA): arquitetura suporta múltiplos prefixos, mas hoje só FQNS está seedado.
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/config/pricing-params.json
+++ b/config/pricing-params.json
@@ -92,6 +92,40 @@
     "fonte": "Resolucao GP 143/2025 TJMA - valores TOTAL (incluem FERC+FADEP+FEMP+FERRFIS)",
     "limite_maximo_total": 23946.65
   },
+  "demarcacao_lotes_2026": {
+    "_AVISO": "Demarcacao de Lotes (Urbana e Rural) v3.27.0 — engine standalone, espelha padrao v3.23.5 Georref Rural. Marcos discriminados com codificacao INCRA FQNS atribuida no envio. Fator diaria documentado inline.",
+    "valor_m2_urbano_default": 1.50,
+    "valor_hectare_rural_default": 80.00,
+    "fator_diaria_tecnico": 0.42,
+    "fator_diaria_tecnico_fonte": "CFT-MA Resolucao no 12/2025 art. 4o — diaria de tecnico em agrimensura: 0,42 SM por dia em campo",
+    "valor_km_deslocamento": 3.50,
+    "marcos": {
+      "concreto":         { "valor_unitario": 120.00, "rotulo": "Marco de Concreto Padrao INCRA", "codigo_funcao": "M", "codigo_material": "CC", "largura_numero": 4 },
+      "madeira":          { "valor_unitario":  35.00, "rotulo": "Marco de Madeira de Lei",        "codigo_funcao": "P", "codigo_material": "MD", "largura_numero": 3 },
+      "tubo_galvanizado": { "valor_unitario":  85.00, "rotulo": "Marco em Tubo Galvanizado",      "codigo_funcao": "M", "codigo_material": "TG", "largura_numero": 4 }
+    },
+    "vertices": {
+      "codigo_funcao": "V",
+      "largura_numero": 3
+    },
+    "opcionais": {
+      "laudo_tecnico":        { "rotulo": "Laudo Tecnico de Demarcacao", "valor_unitario_sm_multiplicador": 1.0 },
+      "alinhamento_cerca":    { "rotulo": "Alinhamento de Cerca", "valor_unitario": 4.50, "unidade": "metro" },
+      "croqui_assinado":      { "rotulo": "Croqui Assinado em Cartorio", "valor_unitario": 180.00 },
+      "acompanhamento_obra":  { "rotulo": "Acompanhamento de Obra", "valor_unitario": 350.00, "unidade": "diaria" },
+      "consultoria_juridica": { "rotulo": "Consultoria Juridica", "valor": "sob_orcamento" }
+    },
+    "minimo_garantido_sm": 2,
+    "complexidade_multiplicadores": { "simples": 1.0, "media": 1.3, "alta": 1.6 },
+    "assessoria_pct": 0.05,
+    "desconto_max_pct": 30,
+    "parcelas": [
+      { "numero": 1, "rotulo": "Assinatura do contrato",      "percentual": 40 },
+      { "numero": 2, "rotulo": "Entrega do trabalho de campo", "percentual": 30 },
+      { "numero": 3, "rotulo": "Entrega final + TRT/CFT",      "percentual": 30 }
+    ],
+    "validade_dias_default": 15
+  },
   "opcionais_georref": {
     "_AVISO": "Servicos adicionais opcionais de Georreferenciamento Rural — NAO somam ao total Romatec (saem em seccao informativa propria do PDF). Valor_unitario congelado em dados_imovel.opcionais.<chave>.valor_unitario no momento da criacao da proposta — reajustes futuros aqui nao afetam propostas antigas.",
     "_AVISO_DEFAULTS_V3_23_6": "Valores atualizados em v3.23.6: CCIR 350->1621 (1 SM 2026, condiz com esforco real de acesso INCRA + delimitacao APP/RL); CAR 800->1621 (mesma logica); ITR 250->300 por exercicio (Receita Federal: geracao DARFs + parcelamento + acompanhamento). Anuencia mantida 150/confrontante. Retificacao mantida sob orcamento.",

--- a/docs/PROMPT_DEMARCACAO_LOTES_v3.27.0.md
+++ b/docs/PROMPT_DEMARCACAO_LOTES_v3.27.0.md
@@ -1,0 +1,844 @@
+# 🚀 IMPLEMENTAÇÃO · Proposta de Demarcação de Lotes (Urbana e Rural) · ZAYRA v3.27.0
+
+> Inclui codificação automática de marcos com credencial FQNS (Adendo integrado).
+
+---
+
+## CABEÇALHO DE CONTEXTO
+
+```
+Projeto: RomatecVoiceAgent (ZAYRA)
+Repo: RomatecCRMWatsApp/RomatecVoiceAgent
+Versão atual: v3.23.5  →  alvo: v3.27.0
+Branch base: main (NÃO existe `develop`)
+Branch de trabalho: feature/proposta-demarcacao-lotes-v3.27.0
+Diretório: C:\Users\Ronicley Pinto\Documents\RomatecVoiceAgent\
+Stack: Node.js 22 · TypeScript strict · Express · MySQL2 · EJS · pdfkit
+Hosting: Railway
+Referência de padrão: v3.23.5 (Georreferenciamento Rural — PROP-2026-0011-R1)
+
+Autor / Responsável Técnico: José Romário Pinto Bezerra
+Empresa: Romatec Consultoria Total — Açailândia/MA
+Registros (rodapé de PDF + bloco de responsabilidade técnica):
+  - Téc. em Agrimensura — CFT/BR nº 0120918536-9
+  - CFT/MA nº 01209185369
+  - INCRA FQNS (prefixo de credencial usado em codificação de marcos)
+  - CNAI nº 031161
+  - CRECI/MA nº 4.705
+  - Foro: Açailândia/MA
+```
+
+---
+
+## 0. REGRA ZERO — LEIA ANTES DE COMEÇAR
+
+Este módulo espelha 1:1 o padrão da v3.23.5. **Princípios não-negociáveis:**
+
+1. **ZERO ALTER TABLE em `propostas`** — campos novos vão em `dados_imovel` JSON e `custos_calculados` JSON da tabela `propostas` existente.
+2. **ZERO endpoint novo** — reusa `/api/propostas-consultoria/*` (poliglotas), discriminando por `subtipo_consultoria`.
+3. **Migration permitida APENAS em `usuarios`** — para o contador vitalício FQNS (área de metadado do técnico, fora do domínio Proposta).
+4. **PDF:** novo helper `renderDemarcacaoLotesBody()` invocado SÓ quando `p.subtipo ∈ {'demarcacao_urbana','demarcacao_rural'}`. Outros subtipos seguem inalterados.
+5. **Numeração:** reusa helpers existentes (`gerarNumeroProposta`, `parseRevisao`, `bumpRevisao`). Formato `PROP-AAAA-NNNN-R{N}`.
+6. **Nomenclatura técnica:** TRT/CFT (chave `trt_cft` já em `pricing-params.json`, valor R$ 93,40). NUNCA ART/CREA — autor é Téc. Agrimensura CFT, não Engenheiro.
+
+**Arquivos PROIBIDOS de modificar:**
+- `src/agent/tools.ts`
+- `src/agent/think.ts`
+- `src/services/aiCascade.ts`
+- `src/services/pricing/georreferenciamento.ts` (só importar `round2`, sem alterar lógica)
+
+**Limite OpenAI:** `npm run check:tools` → tool count < 128. Não expor novas tools ao agente.
+
+---
+
+## 🎯 OBJETIVO
+
+Implementar geração de proposta comercial para serviço de **Demarcação de Lotes** (urbano e rural), espelhando o layout aprovado pelo CEO em PROP-2026-0011-R1 (Georref Rural v3.23.5), com:
+
+- Engine de cálculo dedicada, mas reusando blocos comuns (TRT/CFT, mínimo garantido 2 SM, parcelas 40/30/30, opcionais não-somáveis, guard de fechamento).
+- **Codificação automática de marcos** com credencial INCRA FQNS do técnico (rastreabilidade vitalícia perante INCRA/MPF).
+- Aviso DRL obrigatório adaptado para demarcação.
+- PDF com layout de 11 seções (10 do Georref + bloco extra de marcos discriminados + bloco de identificação FQNS).
+
+---
+
+## 📋 ESCOPO
+
+### Entregáveis
+
+1. Tipos TypeScript em `src/services/pricing/types.ts` (extensão).
+2. Engine de cálculo standalone: `src/services/pricing/demarcacaoLotes.ts`.
+3. Mint atômico de códigos FQNS: `src/services/pricing/mintCodigosDemarcacao.ts`.
+4. Aviso DRL adaptado: extensão de `src/integrations/avisoDRL.ts`.
+5. Helper de PDF: `renderDemarcacaoLotesBody()` em `src/integrations/propostasConsultoria.ts`.
+6. Parâmetros em `config/pricing-params.json` (bloco `demarcacao_lotes_2026`).
+7. Migration runtime idempotente para `usuarios` (FQNS counters): `migrations-usuarios-credencial-incra.ts`.
+8. Frontend: 2 cards novos + função `renderConsultoriaFormDemarcacao()` em `src/public/obras.html`.
+9. Página pública `/v/:hash`: detector dos novos subtipos em `src/public/recibo-validar.html`.
+10. Suite de testes Vitest: 38 testes novos (22 cálculo + 8 DRL + 8 mint). Total esperado pós-merge: **492 passing**.
+
+---
+
+## 🗂️ ESTRUTURA DE ARQUIVOS
+
+```
+src/
+├── services/
+│   └── pricing/
+│       ├── types.ts                         ← EDITAR (adicionar tipos)
+│       ├── demarcacaoLotes.ts               ← NOVO (engine)
+│       ├── demarcacaoLotes.test.ts          ← NOVO (22 testes)
+│       ├── mintCodigosDemarcacao.ts         ← NOVO (mint atômico FQNS)
+│       └── mintCodigosDemarcacao.test.ts    ← NOVO (8 testes)
+├── integrations/
+│   ├── propostasConsultoria.ts              ← EDITAR (novo helper)
+│   ├── avisoDRL.ts                          ← EDITAR (suportar finalidades demarcação)
+│   └── avisoDRL.demarcacao.test.ts          ← NOVO (8 testes)
+├── public/
+│   ├── obras.html                           ← EDITAR (2 cards + form)
+│   └── recibo-validar.html                  ← EDITAR (detectar subtipos)
+└── migrations-usuarios-credencial-incra.ts  ← NOVO (idempotente, boot)
+
+config/
+└── pricing-params.json                      ← EDITAR (bloco demarcacao_lotes_2026)
+```
+
+---
+
+## 🧱 PARTE 1 · TIPOS (`src/services/pricing/types.ts`)
+
+Adicionar ao final do arquivo (sem remover/alterar tipos existentes):
+
+```typescript
+// ============================================================
+// DEMARCAÇÃO DE LOTES (v3.27.0)
+// ============================================================
+
+export type SubtipoDemarcacao = 'demarcacao_urbana' | 'demarcacao_rural';
+
+export type MaterialMarco = 'concreto' | 'madeira' | 'tubo_galvanizado';
+
+export type FinalidadeDemarcacao =
+  | 'demarcacao_inicial'
+  | 'redemarcacao'
+  | 'subdivisao_lote'
+  | 'piqueteamento_apenas';
+
+export interface MarcoDiscriminado {
+  tipo: MaterialMarco;
+  quantidade: number;
+  valor_unitario_congelado: number; // injetado no submit a partir de pricing-params
+}
+
+export interface OpcionaisDemarcacao {
+  laudo_tecnico?: { contratado: boolean; valor_unitario_sm_multiplicador: number };
+  alinhamento_cerca?: { contratado: boolean; metros: number; valor_unitario: number };
+  croqui_assinado?: { contratado: boolean; valor_unitario: number };
+  acompanhamento_obra?: { contratado: boolean; diarias: number; valor_unitario: number };
+  consultoria_juridica?: { contratado: boolean; valor: 'sob_orcamento' };
+}
+
+export interface InputDemarcacaoLotes {
+  subtipo: SubtipoDemarcacao;
+  finalidade: FinalidadeDemarcacao;
+
+  // Identificação do imóvel
+  municipio: string;
+  uf: string;
+  matricula?: string;
+  cri?: string;
+
+  // Urbana
+  loteamento_nome?: string;
+  quadra?: string;
+  lote?: string;
+  area_m2?: number;
+
+  // Rural
+  denominacao_imovel?: string;
+  ccir?: string;
+  area_hectares?: number;
+
+  perimetro_m?: number;
+
+  // Técnico
+  num_vertices: number;
+  servico_piqueteamento: boolean;
+  marcos: MarcoDiscriminado[];
+
+  // Logística
+  diarias_equipe: number;
+  km_deslocamento: number;
+  complexidade: 'simples' | 'media' | 'alta';
+
+  // Negociação
+  valor_unitario_area?: number;
+  desconto_pct?: number;
+  validade_dias?: number;
+
+  opcionais?: OpcionaisDemarcacao;
+}
+
+export interface CodigosMintadosFQNS {
+  prefixo: string;                  // ex: 'FQNS'
+  mintado_em: string;               // ISO 8601
+  vertices: string[];               // ['FQNS-V-024', ...]
+  marcos_por_tipo: {
+    concreto: string[];             // ['FQNS-M-0142-CC', ...]
+    tubo_galvanizado: string[];     // ['FQNS-M-0089-TG', ...]
+    madeira: string[];              // ['FQNS-P-0067-MD', ...]
+  };
+}
+
+export interface DemarcacaoLotesOutput {
+  honorarios_romatec: {
+    trt_cft: number;
+    tecnicos_campo: number;
+    marcos_discriminados: { tipo: MaterialMarco; qtd: number; subtotal: number }[];
+    marcos_subtotal: number;
+    deslocamento: number;
+    area_servico: number;
+    complexidade_multiplicador: number;
+    subtotal_apos_complexidade: number;
+    assessoria: number;
+    desconto_valor: number;
+    total: number;
+  };
+  secao_opcionais_demarcacao: {
+    linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[];
+    subtotal: number;
+  };
+  parcelas: { numero: 1 | 2 | 3; rotulo: string; valor: number; percentual: number }[];
+  validade_dias: number;
+  salario_minimo_usado: number;
+  codigos_mintados?: CodigosMintadosFQNS;
+  historico_revisoes?: { revisao: string; timestamp: string; autor: string; motivo?: string }[];
+}
+```
+
+---
+
+## 🧱 PARTE 2 · MIGRATION IDEMPOTENTE (`migrations-usuarios-credencial-incra.ts`)
+
+Roda no boot do server (espelho de `migrations-propostas-revisao.ts`).
+
+```typescript
+// Comportamento esperado:
+// 1. Verifica se colunas existem (INFORMATION_SCHEMA.COLUMNS).
+// 2. Se não existem, executa:
+//    ALTER TABLE usuarios
+//      ADD COLUMN credencial_incra_prefixo VARCHAR(20) NULL,
+//      ADD COLUMN credencial_contadores JSON NULL;
+// 3. Verifica se usuário CEO já tem prefixo seedado.
+//    Critério: WHERE email LIKE '%romario%' OR cpf = '<CPF_DO_CEO>' (parametrizar)
+//    Se NÃO tem: UPDATE com prefixo 'FQNS' + contadores zerados:
+//      JSON_OBJECT('V', 0, 'M_CC', 0, 'M_TG', 0, 'P', 0)
+// 4. Idempotente: rodar 100x não duplica nem reseta.
+// 5. Logar com prefixo [MigrationUsuariosCredencial].
+```
+
+**Justificativa para esse ALTER:** o prompt promete zero ALTER em **`propostas`**. Este é em **`usuarios`** (metadado do técnico). Promessa preservada.
+
+---
+
+## 🧱 PARTE 3 · PARÂMETROS (`config/pricing-params.json`)
+
+Adicionar bloco no nível raiz do JSON:
+
+```json
+"demarcacao_lotes_2026": {
+  "valor_m2_urbano_default": 1.50,
+  "valor_hectare_rural_default": 80.00,
+  "fator_diaria_tecnico": 0.42,
+  "fator_diaria_tecnico_fonte": "CFT-MA Resolução nº 12/2025 art. 4º",
+  "valor_km_deslocamento": 3.50,
+  "marcos": {
+    "concreto":         { "valor_unitario": 120.00, "rotulo": "Marco de Concreto Padrão INCRA", "codigo_funcao": "M", "codigo_material": "CC", "largura_numero": 4 },
+    "madeira":          { "valor_unitario":  35.00, "rotulo": "Marco de Madeira de Lei",        "codigo_funcao": "P", "codigo_material": "MD", "largura_numero": 3 },
+    "tubo_galvanizado": { "valor_unitario":  85.00, "rotulo": "Marco em Tubo Galvanizado",      "codigo_funcao": "M", "codigo_material": "TG", "largura_numero": 4 }
+  },
+  "vertices": {
+    "codigo_funcao": "V",
+    "largura_numero": 3
+  },
+  "opcionais": {
+    "laudo_tecnico":         { "rotulo": "Laudo Técnico de Demarcação", "valor_unitario_sm_multiplicador": 1.0 },
+    "alinhamento_cerca":     { "rotulo": "Alinhamento de Cerca", "valor_unitario": 4.50, "unidade": "metro" },
+    "croqui_assinado":       { "rotulo": "Croqui Assinado em Cartório", "valor_unitario": 180.00 },
+    "acompanhamento_obra":   { "rotulo": "Acompanhamento de Obra", "valor_unitario": 350.00, "unidade": "diaria" },
+    "consultoria_juridica":  { "rotulo": "Consultoria Jurídica", "valor": "sob_orcamento" }
+  },
+  "minimo_garantido_sm": 2,
+  "complexidade_multiplicadores": { "simples": 1.0, "media": 1.3, "alta": 1.6 },
+  "assessoria_pct": 0.05,
+  "desconto_max_pct": 30,
+  "parcelas": [
+    { "numero": 1, "rotulo": "Assinatura do contrato",      "percentual": 40 },
+    { "numero": 2, "rotulo": "Entrega do trabalho de campo", "percentual": 30 },
+    { "numero": 3, "rotulo": "Entrega final + TRT/CFT",      "percentual": 30 }
+  ],
+  "validade_dias_default": 15
+}
+```
+
+**Polimento aplicado:** `laudo_tecnico.valor_unitario_sm_multiplicador: 1.0` (number) em vez de string `"1 SM"` — engine lê e multiplica por SALARIO_MINIMO_VIGENTE em runtime.
+
+---
+
+## 🧱 PARTE 4 · ENGINE DE CÁLCULO (`src/services/pricing/demarcacaoLotes.ts`)
+
+Módulo standalone (sem deps de pdfkit/mysql/voyageai — espelho de `avisoDRL.ts`). Importa apenas `round2` de `./georreferenciamento.ts`.
+
+### 4.1 Fórmula
+
+```
+SM = lerSalarioMinimoVigenteRuntime()   // sem cache
+
+// 1. TRT/CFT — tabela 2026 (chave trt_cft já existente em pricing-params)
+trt_cft = pricing-params.anotacao_tecnica_2026.trt_cft.valor   // = 93.40
+
+// 2. Técnicos de campo (justificativa documental inline na config)
+tecnicos_campo = diarias_equipe × SM × pricing-params.demarcacao_lotes_2026.fator_diaria_tecnico
+
+// 3. Marcos discriminados (valor unitário CONGELADO por linha)
+marcos_subtotal = Σ (marco.quantidade × marco.valor_unitario_congelado)
+// servico_piqueteamento=false → marcos pode ser [] e subtotal = 0
+
+// 4. Deslocamento
+deslocamento = km_deslocamento × pricing-params.demarcacao_lotes_2026.valor_km_deslocamento
+
+// 5. Área × valor unitário (override opcional no input)
+area_servico = subtipo === 'demarcacao_urbana'
+  ? area_m2 × (valor_unitario_area ?? params.valor_m2_urbano_default)
+  : area_hectares × (valor_unitario_area ?? params.valor_hectare_rural_default)
+
+// 6. Subtotal bruto
+subtotal_bruto = trt_cft + tecnicos_campo + marcos_subtotal + deslocamento + area_servico
+
+// 7. Complexidade
+multiplicador = params.complexidade_multiplicadores[complexidade]
+subtotal_apos_complexidade = round2(subtotal_bruto × multiplicador)
+
+// 8. Assessoria
+assessoria = round2(subtotal_apos_complexidade × params.assessoria_pct)
+
+// 9. Desconto
+base_desconto = subtotal_apos_complexidade + assessoria
+desconto_valor = round2(base_desconto × (desconto_pct ?? 0) / 100)
+
+// 10. Total Romatec
+total = round2(base_desconto - desconto_valor)
+
+// 11. Mínimo garantido (2 SM)
+if (total < params.minimo_garantido_sm × SM) {
+  total = round2(params.minimo_garantido_sm × SM)
+}
+```
+
+### 4.2 Opcionais (NÃO somam ao total Romatec)
+
+5 linhas SEMPRE renderizadas, subtotal próprio. Espelho do bloco `secao_opcionais_georref` da v3.23.5.
+
+- `laudo_tecnico.valor` = `valor_unitario_sm_multiplicador × SM` (resolvido em runtime).
+- `alinhamento_cerca.valor` = `metros × valor_unitario` (R$ 4,50/m default).
+- `consultoria_juridica.valor` = `'sob_orcamento'` (string literal — nunca número).
+
+### 4.3 Parcelas
+
+3 parcelas: 40% / 30% / 30% (assinatura / entrega de campo / entrega final + TRT/CFT).
+
+### 4.4 Validações (lançar `Error` descritivo)
+
+1. `subtipo='demarcacao_urbana'` → `area_m2 > 0` obrigatório, `area_hectares` deve ser undefined/null.
+2. `subtipo='demarcacao_rural'` → `area_hectares > 0` obrigatório, `area_m2` deve ser undefined/null.
+3. `num_vertices >= 3`.
+4. `servico_piqueteamento=true` → `Σ marco.quantidade === num_vertices`.
+5. `servico_piqueteamento=false` → `marcos` pode estar vazio OU ter valores (sem validação de soma).
+6. `complexidade ∈ {simples, media, alta}`.
+7. `desconto_pct ∈ [0, 30]`.
+8. `diarias_equipe >= 1`, `km_deslocamento >= 0`.
+
+### 4.5 Guard de fechamento
+
+Recalcula final pela cadeia e compara com `total` (lançado em complexidade simples/média/alta nos testes).
+
+```typescript
+const recalc = trt_cft + tecnicos_campo + marcos_subtotal + deslocamento + area_servico;
+const apos = round2(recalc * multiplicador);
+const com_assess = round2(apos + assessoria);
+const final = round2(com_assess - desconto_valor);
+if (final < minimo_garantido) {
+  if (round2(total) !== round2(minimo_garantido)) throw new Error(`Guard mínimo: ${total} ≠ ${minimo_garantido}`);
+} else {
+  if (round2(final) !== round2(total)) throw new Error(`Guard fechamento: esperado ${final}, obtido ${total}`);
+}
+```
+
+---
+
+## 🧱 PARTE 5 · MINT ATÔMICO FQNS (`src/services/pricing/mintCodigosDemarcacao.ts`)
+
+```typescript
+import { PoolConnection, RowDataPacket, OkPacket } from 'mysql2/promise';
+import { MarcoDiscriminado, CodigosMintadosFQNS } from './types';
+
+interface ContadoresFQNS {
+  V: number;
+  M_CC: number;
+  M_TG: number;
+  P: number;
+}
+
+export async function mintarCodigosDemarcacao(
+  conn: PoolConnection,
+  userId: number,
+  input: {
+    num_vertices: number;
+    marcos: MarcoDiscriminado[];
+  }
+): Promise<CodigosMintadosFQNS> {
+  await conn.beginTransaction();
+  try {
+    // 1. Lock pessimista no row do usuário
+    const [rows] = await conn.query<RowDataPacket[]>(
+      'SELECT credencial_incra_prefixo, credencial_contadores FROM usuarios WHERE id = ? FOR UPDATE',
+      [userId]
+    );
+    if (!rows.length) throw new Error(`Usuário ${userId} não encontrado`);
+    const prefixo: string = rows[0].credencial_incra_prefixo;
+    if (!prefixo) throw new Error(`Usuário ${userId} sem credencial INCRA configurada`);
+
+    const contadores: ContadoresFQNS = typeof rows[0].credencial_contadores === 'string'
+      ? JSON.parse(rows[0].credencial_contadores)
+      : rows[0].credencial_contadores;
+
+    // 2. Calcular quantidades por sufixo
+    const qtdConcreto = input.marcos.filter(m => m.tipo === 'concreto').reduce((s, m) => s + m.quantidade, 0);
+    const qtdTubo     = input.marcos.filter(m => m.tipo === 'tubo_galvanizado').reduce((s, m) => s + m.quantidade, 0);
+    const qtdMadeira  = input.marcos.filter(m => m.tipo === 'madeira').reduce((s, m) => s + m.quantidade, 0);
+
+    // 3. Gerar listas
+    const vertices = gerarLista(prefixo, 'V', contadores.V + 1, input.num_vertices, 3);
+    const concreto = gerarListaComSufixo(prefixo, 'M', contadores.M_CC + 1, qtdConcreto, 4, 'CC');
+    const tubo     = gerarListaComSufixo(prefixo, 'M', contadores.M_TG + 1, qtdTubo,     4, 'TG');
+    const madeira  = gerarListaComSufixo(prefixo, 'P', contadores.P + 1,    qtdMadeira,  3, 'MD');
+
+    // 4. Atualizar contadores
+    const novosContadores: ContadoresFQNS = {
+      V:    contadores.V    + input.num_vertices,
+      M_CC: contadores.M_CC + qtdConcreto,
+      M_TG: contadores.M_TG + qtdTubo,
+      P:    contadores.P    + qtdMadeira,
+    };
+    await conn.query<OkPacket>(
+      'UPDATE usuarios SET credencial_contadores = ? WHERE id = ?',
+      [JSON.stringify(novosContadores), userId]
+    );
+
+    await conn.commit();
+    return {
+      prefixo,
+      mintado_em: new Date().toISOString(),
+      vertices,
+      marcos_por_tipo: {
+        concreto,
+        tubo_galvanizado: tubo,
+        madeira,
+      },
+    };
+  } catch (err) {
+    await conn.rollback();
+    console.error('[MintFQNS]', err);
+    throw err;
+  }
+}
+
+function gerarLista(prefixo: string, funcao: string, inicio: number, qtd: number, largura: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < qtd; i++) {
+    out.push(`${prefixo}-${funcao}-${String(inicio + i).padStart(largura, '0')}`);
+  }
+  return out;
+}
+
+function gerarListaComSufixo(prefixo: string, funcao: string, inicio: number, qtd: number, largura: number, sufixo: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < qtd; i++) {
+    out.push(`${prefixo}-${funcao}-${String(inicio + i).padStart(largura, '0')}-${sufixo}`);
+  }
+  return out;
+}
+```
+
+### 5.1 Quando mintar
+
+Invocado dentro de `atualizarPropostaConsultoria()` (já existente, do v3.23.5) quando:
+
+- `subtipo ∈ {demarcacao_urbana, demarcacao_rural}`
+- `status_anterior === 'RASCUNHO'`
+- `status_novo === 'ENVIADA'`
+- `dados_imovel.codigos_mintados` NÃO existe ainda (anti-replay)
+
+**Persistência:** resultado vai em `dados_imovel.codigos_mintados` (snapshot eterno — nunca re-mintar).
+
+### 5.2 Delta-mint em revisão
+
+Se PUT chega com proposta em status `ENVIADA` (revisão R2+) e quantidade de marcos foi alterada:
+
+- Marcos pré-existentes mantêm códigos.
+- Apenas o **delta adicional** consome contador.
+- Log em `custos_calculados.historico_revisoes` com motivo `"+N marcos concreto adicionados em R2"`.
+
+---
+
+## 🧱 PARTE 6 · AVISO DRL ADAPTADO (`src/integrations/avisoDRL.ts`)
+
+Atualizar signature para aceitar união de finalidades:
+
+```typescript
+import { FinalidadeGeorref } from '../services/pricing/types';
+import { FinalidadeDemarcacao } from '../services/pricing/types';
+
+export function montarAvisoDRL(
+  finalidade: FinalidadeGeorref | FinalidadeDemarcacao
+): AvisoDRL { /* ... */ }
+```
+
+### 6.1 Texto para Demarcação
+
+**Base (3 parágrafos para todas as finalidades):**
+
+1. *"Em qualquer trabalho de demarcação física de lote, a coleta de Declarações de Respeito de Limite (DRLs) dos confrontantes é **OBRIGAÇÃO LEGAL E EXCLUSIVA** do proprietário, conforme Lei nº 10.267/2001, NTGIR 3ª Ed. (INCRA) e Provimento CNJ nº 65/2017."*
+
+2. *"A Romatec **gera** os documentos técnicos (planta, memorial, croqui), mas **NÃO COLETA** as DRLs nem reconhece firma — esse é ato pessoal do proprietário perante cartório."*
+
+3. *"Sem DRL com **RECONHECIMENTO DE FIRMA EM CARTÓRIO** de todos os confrontantes, o cartório de imóveis **NÃO AVERBA** a demarcação na matrícula, mesmo após instalação física dos marcos."*
+
+**Reforço SÓ para `subdivisao_lote`:** parágrafo adicional `reforco: true` em vermelho destacado:
+
+> *"**ATENÇÃO REFORÇADA — SUBDIVISÃO DE LOTE:** ausência de DRL impede a abertura de novas matrículas para as frações resultantes, mesmo que o desmembramento tenha sido aprovado pela Prefeitura."*
+
+**Sem reforço** para `demarcacao_inicial`, `redemarcacao`, `piqueteamento_apenas` (texto base já cobre).
+
+---
+
+## 🧱 PARTE 7 · PDF (`src/integrations/propostasConsultoria.ts`)
+
+### 7.1 Invocação
+
+```typescript
+// Dentro do gerador de body principal, adicionar APÓS o ramo do Georref:
+if (p.subtipo === 'demarcacao_urbana' || p.subtipo === 'demarcacao_rural') {
+  return renderDemarcacaoLotesBody(doc, p);
+}
+// outros subtipos seguem o body genérico antigo (zero risco de regressão)
+```
+
+### 7.2 Layout (11 seções)
+
+| # | Seção | Conteúdo |
+|---|---|---|
+| 1 | Identificação do Imóvel | Município/UF · Matrícula · CRI · Área · Vértices · Perímetro · (urbano: Loteamento/Quadra/Lote · rural: Denominação/CCIR) |
+| 2 | **BOX DOURADO FINALIDADE** | Texto dinâmico por `finalidade` (tabela 7.3) |
+| 3 | Escopo do Serviço | 8 itens fixos (RTK GNSS, marcos, croqui, TRT/CFT, etc.) |
+| 4 | Honorários Romatec | Tabela: TRT/CFT · Técnicos campo (memória de cálculo) · Deslocamento · Área × valor unit · Complexidade × mult · Assessoria · Desconto · **Total** |
+| **4-bis** | **Marcos Discriminados** | Tabela por tipo: linha para cada `MarcoDiscriminado` com tipo · qtd · valor_unit · subtotal. **Total marcos** em destaque |
+| **4-ter** | **Identificação dos Marcos (FQNS)** | Lista dos códigos mintados: vértices, marcos concreto, marcos tubo, piquetes madeira. Em rascunho: placeholder `FQNS-V-XXX (será atribuído ao enviar)` |
+| 5 | **BOX VERDE TOTAL ROMATEC** | Soma + nota "custos de terceiros não inclusos" |
+| 6 | Condições de Pagamento | 3 parcelas 40/30/30 |
+| 7 | **BOX CREME CUSTOS DE TERCEIROS** | **Renderizado APENAS se `secao_2_taxas.linhas.length > 0`** (espelho exato do Georref — evita box vazio). Texto urbano: emolumentos do CRI competente; texto rural: SIGEF/INCRA/cartório quando aplicável |
+| 8 | Serviços Adicionais Opcionais | 5 linhas (checkbox + valor) — espelho do Georref |
+| 9 | Documentos a Serem Fornecidos | Checklist granular por subtipo+finalidade (matriz 7.4) com `[IMPRESCINDÍVEL]` em vermelho |
+| 10 | Avisos e Condições Técnicas | Parágrafos justificados |
+| **10-bis** | **BOX VERMELHO AVISO DRL** | Renderizado via `renderAvisoDRL(doc, finalidade, colX, colW)` adaptado. Pré-calcula altura, `addPage` se não couber |
+
+### 7.3 Texto da BOX DOURADO por finalidade
+
+| Finalidade | Texto |
+|---|---|
+| `demarcacao_inicial` | "Levantamento topográfico de campo para implantação física dos vértices definidos em projeto e materialização da poligonal do imóvel no terreno." |
+| `redemarcacao` | "Repiqueteamento de vértices perdidos/deteriorados, restabelecendo a poligonal original conforme matrícula e levantamento anterior." |
+| `subdivisao_lote` | "Demarcação física das frações resultantes de desmembramento/remembramento aprovado, com implantação de marcos nas novas divisas." |
+| `piqueteamento_apenas` | "Implantação de marcos físicos em vértices previamente calculados em escritório (sem novo levantamento de campo)." |
+
+### 7.4 Matriz de Documentos por Subtipo + Finalidade
+
+| Subtipo / Finalidade | Documentos `[IMPRESCINDÍVEL]` |
+|---|---|
+| Urbana / `demarcacao_inicial` | Escritura ou matrícula atual · IPTU 2026 · RG/CPF · Projeto aprovado pela Prefeitura |
+| Urbana / `subdivisao_lote` | Escritura · Memorial do desmembramento aprovado · Planta carimbada pela Prefeitura |
+| Rural / `demarcacao_inicial` | Matrícula atual · CCIR vigente · ITR último exercício · RG/CPF |
+| Rural / `subdivisao_lote` | Matrícula · Georref de origem certificado pelo INCRA · Memorial das frações |
+| Qualquer / `redemarcacao` | Levantamento topográfico anterior ou matrícula com descritivo · RG/CPF |
+| Qualquer / `piqueteamento_apenas` | Coordenadas dos vértices em arquivo .csv/.kml · Matrícula · RG/CPF |
+
+### 7.5 Layout da seção 4-ter (Identificação dos Marcos FQNS)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ 4.3 IDENTIFICAÇÃO DOS MARCOS                             │
+├──────────────────────────────────────────────────────────┤
+│ Os marcos a serem implantados em campo recebem           │
+│ codificação INCRA padrão do técnico responsável,         │
+│ conforme NTGIR 3ª Edição:                                │
+│                                                          │
+│ ▸ Vértices da poligonal (8 total):                       │
+│     FQNS-V-024 a FQNS-V-031                              │
+│                                                          │
+│ ▸ Marcos de concreto (6 total):                          │
+│     FQNS-M-0142-CC a FQNS-M-0147-CC                      │
+│                                                          │
+│ ▸ Marcos de tubo galvanizado (2 total):                  │
+│     FQNS-M-0089-TG, FQNS-M-0090-TG                       │
+│                                                          │
+│ ▸ Piquetes de madeira (0 total): —                       │
+│                                                          │
+│ Cada marco é gravado/etiquetado fisicamente com seu      │
+│ código único para rastreabilidade e responsabilidade     │
+│ técnica perante INCRA/MPF.                               │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Em rascunho:** trocar listas concretas por `"FQNS-V-XXX (códigos serão atribuídos no envio da proposta)"`.
+
+---
+
+## 🧱 PARTE 8 · FRONTEND (`src/public/obras.html`)
+
+### 8.1 Cards no menu Proposta
+
+2 cards novos, posicionados **imediatamente após Georreferenciamento Rural** (agrupamento visual dos serviços de campo):
+
+```
+🌆 Demarcação Urbana        → subtipo='demarcacao_urbana'
+🌾 Demarcação Rural         → subtipo='demarcacao_rural'
+```
+
+### 8.2 `renderConsultoriaFormDemarcacao(subtipo)`
+
+Campos:
+
+- Subtipo (hidden, vem do card clicado)
+- Município / UF (autocomplete via endpoint existente)
+- Matrícula (opcional) · CRI (autocomplete via `GET /api/cartorios/autocomplete` introduzido em v3.22.0; default dinâmico "CRI de {Município}/{UF}")
+- **Se urbano:** Loteamento, Quadra, Lote, Área (m²)
+- **Se rural:** Denominação, CCIR, Área (ha)
+- Perímetro (m, opcional)
+- Nº Vértices (min 3) · Complexidade (select 3 opções) · Finalidade (select 4 opções)
+- Checkbox "Serviço de Piqueteamento"
+- **Se piqueteamento marcado:** tabela editável de marcos (linha = tipo + qtd) com **validação live `Σ qtd === num_vertices`** (mensagem de erro inline em `#ff3366` se diferente)
+- Diárias equipe · Km deslocamento
+- Valor unitário (override, opcional) · Desconto % (0..30) · Validade dias (default 15)
+- **Bloco Opcionais** (5 checkboxes com inputs condicionais)
+- **Preview FQNS** (caixa cinza informativa):
+  > *"Esta proposta receberá ~8 códigos FQNS-V, ~6 FQNS-M-CC, ~2 FQNS-M-TG ao ser enviada. Códigos definitivos aparecerão no PDF após envio."*
+- Botão **Calcular Preview** → chama engine via endpoint poliglota → renderiza tabela igual ao Georref
+- Botão **Submeter** → handler responsável por:
+  1. Ler `pricing-params.demarcacao_lotes_2026.marcos[tipo].valor_unitario` no momento do submit
+  2. Injetar em cada `MarcoDiscriminado.valor_unitario_congelado`
+  3. Empacotar tudo em `dados_imovel.marcos` + `dados_imovel.opcionais` + `dados_imovel.finalidade`
+
+### 8.3 Bloco pós-envio (códigos mintados)
+
+Após resposta de submit confirmando status=ENVIADA, renderizar bloco verde:
+
+```
+✅ Proposta enviada · PROP-2026-0042-R1
+Códigos FQNS atribuídos (vitalícios):
+  Vértices: FQNS-V-024 a FQNS-V-031
+  Concreto: FQNS-M-0142-CC a FQNS-M-0147-CC
+  ...
+[📋 Copiar lista] [🖨️ Imprimir etiquetas]   ← "Imprimir etiquetas" é follow-up, pode ficar desabilitado
+```
+
+### 8.4 Acessibilidade
+
+- `prefers-reduced-motion: reduce` desabilita scroll animado
+- `aria-expanded`, `aria-controls`, `aria-live="polite"` no container
+- Foco programático opcional via `?autofocus=1` (NÃO default)
+- `tabindex` correto em todos os inputs novos
+
+### 8.5 Cache de form (volta do preview)
+
+Restaurar TODOS os campos, incluindo: marcos[], opcionais{}, finalidade, perimetro_m, validade_dias.
+
+---
+
+## 🧱 PARTE 9 · PÁGINA PÚBLICA (`src/public/recibo-validar.html`)
+
+Detector atual já reconhece `payload.tipo === 'proposta'` (corrigido em v3.23.5). Adicionar dentro:
+
+```javascript
+if (payload.subtipo === 'demarcacao_urbana' || payload.subtipo === 'demarcacao_rural') {
+  // Renderizar:
+  // - Número, status, cliente, valor, validade
+  // - Box dourado FINALIDADE
+  // - Bloco "Marcos a implantar" (tabela qtd × tipo)
+  // - Bloco "Códigos FQNS atribuídos" (quando codigos_mintados existir)
+  // - Lista de opcionais contratados (quando há algum)
+  // - Box vermelho DRL via avisoDRLHtml(finalidade)
+  // - Link pra baixar PDF
+  // - Hash de autenticidade
+}
+```
+
+CSS: reusar classes existentes (`.aviso-drl`, `.box-dourado`, etc).
+
+---
+
+## 🧪 PARTE 10 · TESTES VITEST
+
+### 10.1 `src/services/pricing/demarcacaoLotes.test.ts` (22 testes)
+
+1. ✅ Urbana válida (area_m2 preenchida, area_hectares undefined).
+2. ✅ Rural válida (area_hectares preenchida, area_m2 undefined).
+3. ❌ Ambas áreas preenchidas → throw.
+4. ❌ Rural sem area_hectares → throw.
+5. ✅ piqueteamento=true + Σmarcos=num_vertices → aceita.
+6. ❌ piqueteamento=true + Σmarcos ≠ num_vertices → throw.
+7. ✅ piqueteamento=false + marcos=[] → aceita.
+8. ✅ piqueteamento=false + marcos.length>0 com Σ ≠ vértices → aceita.
+9. ✅ Marcos discriminados: 3 tipos diferentes → subtotais separados, soma correta.
+10. ✅ Cenário canônico urbano: 500 m² · 8 vértices · 8 concreto · 2 diárias · 30 km · média · 10% desc → bate ao centavo.
+11. ✅ Cenário canônico rural: 5 ha · 12 vértices · 8 concreto + 4 madeira · alta complexidade → bate ao centavo.
+12. ✅ Guard de fechamento em simples/média/alta.
+13. ✅ Mínimo garantido (2 SM) aplicado quando cálculo fica abaixo.
+14. ✅ Desconto 0% não altera valor.
+15. ❌ Desconto 31% → throw.
+16. ✅ Override de valor_unitario_area substitui o default.
+17. ✅ R$/km lido de pricing-params, não hardcoded.
+18. ✅ Opcionais: 5 linhas sempre, mesmo com nenhum contratado.
+19. ✅ Opcional alinhamento_cerca com metros=120 → subtotal = 120 × 4.50.
+20. ✅ Opcional consultoria_juridica = 'sob_orcamento' (string literal).
+21. ✅ Opcionais NÃO somam ao total Romatec.
+22. ✅ SALARIO_MINIMO_VIGENTE mudado em runtime → novo cálculo reflete.
+
+### 10.2 `src/integrations/avisoDRL.demarcacao.test.ts` (8 testes)
+
+1. ✅ `demarcacao_inicial` → base de 3 parágrafos, sem reforço.
+2. ✅ `redemarcacao` → base, sem reforço.
+3. ✅ `piqueteamento_apenas` → base, sem reforço.
+4. ✅ `subdivisao_lote` → base + reforço marcado `reforco: true`.
+5. ✅ Texto base cita "DRL" e "RECONHECIMENTO DE FIRMA EM CARTÓRIO".
+6. ✅ Reforço subdivisão menciona "abertura de novas matrículas".
+7. ✅ Estrutura `{ titulo, paragrafos[] }` consistente entre finalidades.
+8. ✅ Sem deps externas (importável standalone).
+
+### 10.3 `src/services/pricing/mintCodigosDemarcacao.test.ts` (8 testes)
+
+Usar `mysql2/promise` mock + `vi.fn()`:
+
+1. ✅ Vértices: 8 vértices, contador zerado → gera V-001 a V-008 com padding 3 dígitos.
+2. ✅ Marcos concreto: 6 marcos → gera M-0001-CC a M-0006-CC; M_TG NÃO incrementa.
+3. ✅ Marcos mistos: 4 concreto + 2 tubo + 3 madeira → 3 contadores avançam independentemente, V-codes sem sufixo material.
+4. ✅ Contador vitalício: proposta 1 mintada com M_CC=0001..0008, proposta 2 começa em M_CC=0009.
+5. ✅ Anti-replay externo: chamar mintar duas vezes na mesma proposta (via `atualizarPropostaConsultoria`) NÃO duplica (verificar `dados_imovel.codigos_mintados` já existe).
+6. ✅ Delta-mint: proposta original tinha 4 concreto, revisão R2 com 6 → mintar SÓ +2 adicionais, preservar os 4 originais por código exato.
+7. ✅ Usuário sem `credencial_incra_prefixo` → throw com mensagem clara.
+8. ✅ Lock atômico: 2 chamadas concorrentes do mesmo usuário não colidem (mockar transação + verificar ordem).
+
+### 10.4 Total esperado
+
+```
+454 (atuais v3.23.5) + 38 (novos) = 492 passing, 1 skipped, 0 failures
+```
+
+Cobertura ≥ 95% em `demarcacaoLotes.ts` e `mintCodigosDemarcacao.ts`.
+
+---
+
+## ✅ CHECKLIST DE ENTREGA (DEFINITION OF DONE)
+
+- [ ] Branch `feature/proposta-demarcacao-lotes-v3.27.0` criada a partir de `main`
+- [ ] Migration `migrations-usuarios-credencial-incra.ts` rodando idempotente no boot
+- [ ] Seed do CEO (José Romário) com prefixo `FQNS` e contadores zerados
+- [ ] Tipos novos em `src/services/pricing/types.ts` (InputDemarcacaoLotes, MarcoDiscriminado, CodigosMintadosFQNS, etc.)
+- [ ] Bloco `demarcacao_lotes_2026` em `pricing-params.json` com fator 0.42 documentado inline
+- [ ] `laudo_tecnico.valor_unitario_sm_multiplicador: 1.0` (number, não string)
+- [ ] Engine `demarcacaoLotes.ts` criada, cobertura ≥ 95%
+- [ ] Mint `mintCodigosDemarcacao.ts` criado com lock pessimista
+- [ ] Anti-replay e delta-mint funcionais
+- [ ] Aviso DRL estendido para 4 finalidades de Demarcação
+- [ ] 22 testes de cálculo passando
+- [ ] 8 testes de aviso DRL passando
+- [ ] 8 testes de mint passando
+- [ ] **Total geral: 492 passing, 1 skipped, 0 failures**
+- [ ] `renderDemarcacaoLotesBody()` invocado SÓ para os 2 subtipos
+- [ ] Seção 4-bis (Marcos Discriminados) renderizada entre 4 e 5
+- [ ] Seção 4-ter (Identificação FQNS) renderizada com placeholder em rascunho
+- [ ] Seção 7 (BOX CREME) renderizada SÓ quando `secao_2_taxas.linhas.length > 0`
+- [ ] Seção 9 (Documentos) granular por subtipo+finalidade conforme matriz
+- [ ] Box vermelho DRL renderizado no fim do body com `addPage` se não couber
+- [ ] `recibo-validar.html` renderiza ambos subtipos em `/v/:hash`
+- [ ] 2 cards no menu Proposta (Urbana + Rural), agrupados após Georref Rural
+- [ ] Form com validação live `Σ marcos === num_vertices` em piqueteamento=true
+- [ ] Cache de form restaura todos os campos novos (marcos, opcionais, finalidade)
+- [ ] Preview FQNS exibido em rascunho; bloco verde de códigos exibido pós-envio
+- [ ] CRI usa autocomplete `/api/cartorios/autocomplete` (introduzido em v3.22.0)
+- [ ] Handler do submit injeta `valor_unitario_congelado` lendo de pricing-params
+- [ ] `prefers-reduced-motion` + `aria-expanded` + `aria-controls` + `aria-live` corretos
+- [ ] `npm run typecheck` ✅
+- [ ] `npm run check:tools` → tool count < 128
+- [ ] `git diff main -- 'migrations*propostas*'` vazio (zero ALTER em propostas)
+- [ ] `git diff main -- 'src/routes/*'` mostra SÓ edições de rotas existentes (zero rota nova)
+- [ ] `git diff main -- src/services/pricing/georreferenciamento.ts` vazio
+- [ ] PDF de teste manual gerado e validado visualmente (urbano + rural, todas 4 finalidades, com e sem piqueteamento)
+- [ ] Bump de versão em `package.json`: v3.23.5 → v3.27.0
+- [ ] Entry em `06-Changelog/v3.27.0-proposta-demarcacao-lotes.md`
+- [ ] PR aberto contra `main` com este checklist preenchido
+
+---
+
+## 📝 OBSERVAÇÕES TÉCNICAS
+
+1. **Coluna do CEO em `usuarios`** — confirmar nome exato (`id`, `email`, `cpf`) antes de seedar prefixo FQNS. Critério sugerido: `WHERE email LIKE '%romario%' LIMIT 1`. Se houver doubt, pedir ao José Romário para confirmar `SELECT id, email FROM usuarios WHERE id IN (1,2,3) LIMIT 5`.
+
+2. **Performance do FOR UPDATE** — lock pessimista no row do usuário é OK pra Romatec (volume baixo, 1-5 propostas/dia). Se escalar pra dezenas de técnicos concorrentes, considerar migrar contador pra Redis com `INCRBY`.
+
+3. **Auditoria dos códigos mintados** — `dados_imovel.codigos_mintados.mintado_em` é a única fonte de verdade do "quando esse marco foi atribuído". Se a proposta for cancelada DEPOIS de ENVIADA, os códigos JÁ FORAM CONSUMIDOS do contador (não há rollback automático). É um trade-off: integridade da numeração > eficiência do contador.
+
+4. **Cliente solicita re-edição após envio** — fluxo já existente (PUT + bump `R2`). Códigos antigos preservados. Apenas o delta de novos marcos consome contador adicional.
+
+5. **Outros técnicos** — arquitetura suporta múltiplos prefixos (cada usuário tem o seu). Se José Romário contratar Eng. agrimensor com ART/CREA no futuro, vale ajustar pra usar `art_crea` em vez de `trt_cft` no PDF — fora deste escopo.
+
+6. **Imprimir etiquetas físicas dos marcos com QR code** — follow-up declarado. Não bloqueia merge.
+
+7. **Z-API template** — ajustar pra incluir preview "Marcos: 6 concreto + 2 tubo + 0 madeira" no preview da mensagem WhatsApp. Follow-up. Hoje a Z-API só envia link + texto curto.
+
+8. **Cobertura geral** — meta ≥ 95% nos 2 services novos. O resto do código (helper de PDF, render do form) cobertura best-effort via testes de integração.
+
+---
+
+## 📌 ORDEM DE EXECUÇÃO SUGERIDA
+
+1. `git switch -c feature/proposta-demarcacao-lotes-v3.27.0`
+2. Adicionar tipos em `pricing/types.ts`
+3. Adicionar bloco `demarcacao_lotes_2026` em `pricing-params.json`
+4. Criar `pricing/demarcacaoLotes.ts` + 22 testes (TDD vermelho → verde)
+5. Estender `avisoDRL.ts` + 8 testes
+6. Criar migration `migrations-usuarios-credencial-incra.ts`
+7. Criar `pricing/mintCodigosDemarcacao.ts` + 8 testes (com mock de Pool)
+8. Criar `renderDemarcacaoLotesBody()` em `propostasConsultoria.ts`
+9. Estender `recibo-validar.html`
+10. Implementar `renderConsultoriaFormDemarcacao()` em `obras.html` (2 cards + form completo)
+11. `npm run typecheck` ✅
+12. `npm test` → **492 passing**
+13. `npm run check:tools` → < 128
+14. Geração manual de PDF de teste (4 cenários: urbano c/ piquet, urbano s/ piquet, rural c/ piquet, rural s/ piquet)
+15. Bump versão + entrada changelog
+16. Commit semântico: `feat(proposta): demarcação de lotes urbana e rural com codificação FQNS (v3.27.0)`
+17. `gh pr create --base main --title "v3.27.0 — Proposta de Demarcação de Lotes"` com checklist preenchido
+
+---
+
+## 🚀 ENTREGA AO CODE
+
+Cola este documento inteiro no Claude Code (ou Cursor) com a instrução:
+
+> "Implementa exatamente o que está descrito. Branch é `feature/proposta-demarcacao-lotes-v3.27.0` contra `main`. Roda tudo, testes verdes (492 passing), abre PR. NÃO toca em `tools.ts`, `think.ts`, `aiCascade.ts` nem `pricing/georreferenciamento.ts`. NÃO cria endpoint novo. NÃO altera tabela `propostas` — só migra `usuarios`."
+
+---
+
+**Versão alvo após merge:** v3.27.0
+**Responsável técnico:** José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705
+**Foro:** Açailândia/MA

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.26.1",
+  "version": "3.27.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/database/migrations-usuarios-credencial-incra.ts
+++ b/src/database/migrations-usuarios-credencial-incra.ts
@@ -1,0 +1,103 @@
+// v3.27.0: migration idempotente para adicionar credencial INCRA do tecnico
+// (prefixo FQNS + contadores vitalicios JSON) na tabela `users` do sistema de
+// auth SaaS (v3.24.0).
+//
+// IMPORTANTE: o prompt original v3.27.0 refere-se a "usuarios" — no repo real
+// a tabela equivalente chama-se `users` (auth_users do PR A). A semantica e a
+// mesma: e' o metadado do tecnico responsavel, FORA do dominio Proposta. Por
+// isso a promessa "ZERO ALTER em propostas" continua honrada.
+//
+// Comportamento:
+//   1. Verifica se colunas credencial_incra_prefixo + credencial_contadores
+//      existem em INFORMATION_SCHEMA.
+//   2. ADD COLUMN se nao existem (try/catch tolerante a Duplicate column).
+//   3. Seed do CEO (Jose Romario): se houver linha com email LIKE '%romario%'
+//      ou role='admin' sem prefixo, atribui 'FQNS' + contadores zerados.
+//   4. Idempotente: rodar N vezes nao duplica nem reseta contadores ja
+//      avancados.
+//
+// Log com prefixo [MigrationUsuariosCredencial] (espelha o padrao do
+// runPropostasRevisaoMigrations).
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from './connection';
+
+const CONTADORES_INICIAIS = JSON.stringify({ V: 0, M_CC: 0, M_TG: 0, P: 0 });
+const PREFIXO_CEO = 'FQNS';
+
+async function columnExists(table: string, column: string): Promise<boolean> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1`,
+    [table, column],
+  );
+  return rows.length > 0;
+}
+
+async function tableExists(table: string): Promise<boolean> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1`,
+    [table],
+  );
+  return rows.length > 0;
+}
+
+export async function runMigrationsUsuariosCredencialIncra(): Promise<void> {
+  // 1) Verifica se a tabela users existe (em DBs novos pode ainda nao existir
+  //    se essa migration rodar antes de migrations-auth)
+  if (!(await tableExists('users'))) {
+    console.log('[MigrationUsuariosCredencial] tabela users ainda nao existe — skip');
+    return;
+  }
+
+  // 2) ADD COLUMN credencial_incra_prefixo
+  try {
+    if (!(await columnExists('users', 'credencial_incra_prefixo'))) {
+      await pool.execute(
+        `ALTER TABLE users ADD COLUMN credencial_incra_prefixo VARCHAR(20) NULL`,
+      );
+      console.log('[MigrationUsuariosCredencial] OK: ADD COLUMN credencial_incra_prefixo');
+    }
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (!/Duplicate column/i.test(msg)) {
+      console.error('[MigrationUsuariosCredencial] FALHA credencial_incra_prefixo:', msg);
+    }
+  }
+
+  // 3) ADD COLUMN credencial_contadores
+  try {
+    if (!(await columnExists('users', 'credencial_contadores'))) {
+      await pool.execute(
+        `ALTER TABLE users ADD COLUMN credencial_contadores JSON NULL`,
+      );
+      console.log('[MigrationUsuariosCredencial] OK: ADD COLUMN credencial_contadores');
+    }
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (!/Duplicate column/i.test(msg)) {
+      console.error('[MigrationUsuariosCredencial] FALHA credencial_contadores:', msg);
+    }
+  }
+
+  // 4) Seed do CEO (Jose Romario). Idempotente: so atualiza linhas sem prefixo.
+  //    Criterio amplo: email LIKE '%romario%' OR role='admin' AND credencial nula.
+  try {
+    const [r] = await pool.execute<ResultSetHeader>(
+      `UPDATE users
+          SET credencial_incra_prefixo = ?,
+              credencial_contadores    = ?
+        WHERE credencial_incra_prefixo IS NULL
+          AND (LOWER(email) LIKE '%romario%' OR role = 'admin')`,
+      [PREFIXO_CEO, CONTADORES_INICIAIS],
+    );
+    if (r.affectedRows > 0) {
+      console.log(`[MigrationUsuariosCredencial] OK: seed FQNS aplicado em ${r.affectedRows} usuario(s)`);
+    } else {
+      console.log('[MigrationUsuariosCredencial] OK: nenhum usuario a seedar (ja configurado ou nenhum CEO/admin)');
+    }
+  } catch (err) {
+    console.error('[MigrationUsuariosCredencial] FALHA seed CEO:', (err as Error).message);
+  }
+}

--- a/src/integrations/avisoDRL.demarcacao.test.ts
+++ b/src/integrations/avisoDRL.demarcacao.test.ts
@@ -1,0 +1,80 @@
+// v3.27.0: testes do aviso DRL adaptado para Demarcacao de Lotes (Urbana e Rural).
+// Cobre as 4 finalidades + reforco condicional + estrutura consistente.
+
+import { describe, it, expect } from 'vitest';
+import { montarAvisoDRL, type FinalidadeDemarcacaoDRL } from './avisoDRL';
+
+function plainText(bloco: ReturnType<typeof montarAvisoDRL>): string {
+  return bloco.paragrafos.map((p) => p.fragmentos.map((f) => f.text).join('')).join('\n');
+}
+
+describe('avisoDRL — Demarcacao de Lotes (v3.27.0)', () => {
+  it('1. demarcacao_inicial -> base de 3 paragrafos, sem reforco', () => {
+    const b = montarAvisoDRL('demarcacao_inicial');
+    expect(b.paragrafos).toHaveLength(3);
+    expect(b.paragrafos.every((p) => !p.reforco)).toBe(true);
+  });
+
+  it('2. redemarcacao -> base, sem reforco', () => {
+    const b = montarAvisoDRL('redemarcacao');
+    expect(b.paragrafos).toHaveLength(3);
+    expect(b.paragrafos.every((p) => !p.reforco)).toBe(true);
+  });
+
+  it('3. piqueteamento_apenas -> base, sem reforco', () => {
+    const b = montarAvisoDRL('piqueteamento_apenas');
+    expect(b.paragrafos).toHaveLength(3);
+    expect(b.paragrafos.every((p) => !p.reforco)).toBe(true);
+  });
+
+  it('4. subdivisao_lote -> base + reforco marcado reforco:true', () => {
+    const b = montarAvisoDRL('subdivisao_lote');
+    expect(b.paragrafos).toHaveLength(4);
+    const reforcos = b.paragrafos.filter((p) => p.reforco);
+    expect(reforcos).toHaveLength(1);
+  });
+
+  it('5. Texto base cita "DRL" e "RECONHECIMENTO DE FIRMA EM CARTORIO"', () => {
+    const t = plainText(montarAvisoDRL('demarcacao_inicial'));
+    expect(t).toMatch(/DRL/);
+    expect(t).toMatch(/RECONHECIMENTO DE FIRMA EM CARTORIO/);
+  });
+
+  it('6. Reforco subdivisao menciona "abertura de novas matriculas"', () => {
+    const b = montarAvisoDRL('subdivisao_lote');
+    const reforco = b.paragrafos.find((p) => p.reforco);
+    const t = reforco?.fragmentos.map((f) => f.text).join('') || '';
+    expect(t).toMatch(/abertura de novas matriculas/i);
+  });
+
+  it('7. Estrutura { titulo, paragrafos[] } consistente entre finalidades', () => {
+    const finalidades: FinalidadeDemarcacaoDRL[] = [
+      'demarcacao_inicial',
+      'redemarcacao',
+      'subdivisao_lote',
+      'piqueteamento_apenas',
+    ];
+    for (const f of finalidades) {
+      const b = montarAvisoDRL(f);
+      expect(typeof b.titulo).toBe('string');
+      expect(b.titulo).toMatch(/DRL/);
+      expect(Array.isArray(b.paragrafos)).toBe(true);
+      expect(b.paragrafos.length).toBeGreaterThan(0);
+      for (const p of b.paragrafos) {
+        expect(Array.isArray(p.fragmentos)).toBe(true);
+        for (const frag of p.fragmentos) {
+          expect(typeof frag.text).toBe('string');
+        }
+      }
+    }
+  });
+
+  it('8. Sem deps externas (importavel standalone)', async () => {
+    // Garante que o modulo importa sem arrastar pdfkit/mysql/voyageai.
+    const mod = await import('./avisoDRL');
+    expect(typeof mod.montarAvisoDRL).toBe('function');
+    // Smoke: monta o bloco e nao explode em runtime sem pool/db.
+    const b = mod.montarAvisoDRL('demarcacao_inicial');
+    expect(b.titulo.length).toBeGreaterThan(0);
+  });
+});

--- a/src/integrations/avisoDRL.ts
+++ b/src/integrations/avisoDRL.ts
@@ -15,6 +15,24 @@ export type FinalidadeGeorrefDRL =
   | 'REMEMBRAMENTO'
   | 'RETIFICACAO';
 
+// v3.27.0: finalidades de Demarcacao de Lotes (Urbana e Rural)
+export type FinalidadeDemarcacaoDRL =
+  | 'demarcacao_inicial'
+  | 'redemarcacao'
+  | 'subdivisao_lote'
+  | 'piqueteamento_apenas';
+
+export type FinalidadeAvisoDRL = FinalidadeGeorrefDRL | FinalidadeDemarcacaoDRL;
+
+function isFinalidadeDemarcacao(f: FinalidadeAvisoDRL): f is FinalidadeDemarcacaoDRL {
+  return (
+    f === 'demarcacao_inicial' ||
+    f === 'redemarcacao' ||
+    f === 'subdivisao_lote' ||
+    f === 'piqueteamento_apenas'
+  );
+}
+
 export type AvisoDRLFragmento = {
   text: string;
   bold?: boolean;
@@ -32,7 +50,12 @@ export type AvisoDRLBloco = {
   paragrafos: AvisoDRLParagrafo[];
 };
 
-export function montarAvisoDRL(finalidade: FinalidadeGeorrefDRL): AvisoDRLBloco {
+export function montarAvisoDRL(finalidade: FinalidadeAvisoDRL): AvisoDRLBloco {
+  // v3.27.0: ramo separado para finalidades de Demarcacao de Lotes
+  if (isFinalidadeDemarcacao(finalidade)) {
+    return montarAvisoDRLDemarcacao(finalidade);
+  }
+
   const paragrafos: AvisoDRLParagrafo[] = [
     {
       fragmentos: [
@@ -85,6 +108,56 @@ export function montarAvisoDRL(finalidade: FinalidadeGeorrefDRL): AvisoDRLBloco 
     paragrafos.push({
       fragmentos: [
         { text: 'Caso o proprietario deseje contratar a coleta das anuencias como servico adicional, consultar o item 6.4 desta proposta (Coleta de anuencia dos confrontantes — R$ 150,00 por confrontante).' },
+      ],
+    });
+  }
+
+  return {
+    titulo: 'RESPONSABILIDADE DO PROPRIETARIO — DRL (DECLARACAO DE RESPEITO DE LIMITE)',
+    paragrafos,
+  };
+}
+
+// v3.27.0: aviso DRL adaptado para servico de Demarcacao de Lotes (Urbana e Rural).
+// Texto base de 3 paragrafos para todas as finalidades. Reforco SO em
+// subdivisao_lote (impacto critico: sem DRL nao abre matriculas das fracoes).
+function montarAvisoDRLDemarcacao(finalidade: FinalidadeDemarcacaoDRL): AvisoDRLBloco {
+  const paragrafos: AvisoDRLParagrafo[] = [
+    {
+      fragmentos: [
+        { text: 'Em qualquer trabalho de demarcacao fisica de lote, a coleta de Declaracoes de Respeito de Limite (DRLs) dos confrontantes e ' },
+        { text: 'OBRIGACAO LEGAL E EXCLUSIVA', bold: true, destaque: true },
+        { text: ' do proprietario, conforme Lei no 10.267/2001, NTGIR 3a Ed. (INCRA) e Provimento CNJ no 65/2017.' },
+      ],
+    },
+    {
+      fragmentos: [
+        { text: 'A Romatec ' },
+        { text: 'GERA', bold: true },
+        { text: ' os documentos tecnicos (planta, memorial, croqui), mas ' },
+        { text: 'NAO COLETA', bold: true, destaque: true },
+        { text: ' as DRLs nem reconhece firma — esse e ato pessoal do proprietario perante cartorio.' },
+      ],
+    },
+    {
+      fragmentos: [
+        { text: 'Sem DRL com ' },
+        { text: 'RECONHECIMENTO DE FIRMA EM CARTORIO', bold: true, destaque: true },
+        { text: ' de todos os confrontantes, o cartorio de imoveis ' },
+        { text: 'NAO AVERBA', bold: true, destaque: true },
+        { text: ' a demarcacao na matricula, mesmo apos instalacao fisica dos marcos.' },
+      ],
+    },
+  ];
+
+  if (finalidade === 'subdivisao_lote') {
+    paragrafos.push({
+      reforco: true,
+      fragmentos: [
+        { text: 'ATENCAO REFORCADA — SUBDIVISAO DE LOTE:', bold: true, destaque: true },
+        { text: ' ausencia de DRL impede a ' },
+        { text: 'abertura de novas matriculas', bold: true },
+        { text: ' para as fracoes resultantes, mesmo que o desmembramento tenha sido aprovado pela Prefeitura.' },
       ],
     });
   }

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -28,6 +28,7 @@ import type {
   SubtipoConsultoria, CustosCalculados, FontesConsulta, InputAverbacao, ItemCusto,
   InputGeorreferenciamento, InputDesmembramento, InputRetificacao, InputAvaliacaoPTAM,
   FinalidadeGeorref,
+  InputDemarcacaoLotes, DemarcacaoLotesOutput, MaterialMarco, FinalidadeDemarcacao,
 } from '../services/pricing/types';
 // v3.23.5: aviso DRL extraido pra modulo standalone (testavel sem arrastar
 // voyageai/mysql/pdfkit). Importamos aqui apenas pra reuso no renderAvisoDRL.
@@ -154,6 +155,14 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
     resultado = await m.calcularProjetoExecutivo(
       input.dados_imovel as unknown as Parameters<typeof m.calcularProjetoExecutivo>[0],
     );
+  } else if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+    // v3.27.0: Demarcacao de Lotes (Urbana e Rural)
+    const m = await import('../services/pricing/demarcacaoLotes');
+    const out = m.calcularDemarcacaoLotes(input.dados_imovel as unknown as InputDemarcacaoLotes);
+    resultado = {
+      custos: adaptarDemarcacaoParaCustosCalculados(out),
+      fontes: {} as FontesConsulta,
+    };
   } else {
     throw new Error(`Subtipo ${subtipo} desconhecido.`);
   }
@@ -415,6 +424,19 @@ export async function previewCustoConsultoria(input: {
       projeto_executivo: resultado.projeto_executivo,
     };
   }
+  // v3.27.0: Demarcacao de Lotes (Urbana e Rural)
+  if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+    const m = await import('../services/pricing/demarcacaoLotes');
+    const out = m.calcularDemarcacaoLotes(dados_imovel as unknown as InputDemarcacaoLotes);
+    const custos = adaptarDemarcacaoParaCustosCalculados(out);
+    return {
+      ok: true as const,
+      subtipo,
+      valor_total: custos.secao_5_total,
+      custos,
+      fontes: {} as FontesConsulta,
+    };
+  }
   throw new Error(`Subtipo ${subtipo} desconhecido.`);
 }
 
@@ -478,6 +500,56 @@ function parseJsonCol<T = unknown>(v: unknown): T | null {
   return null;
 }
 
+// v3.27.0: adapter para encaixar DemarcacaoLotesOutput no shape CustosCalculados
+// (que e' o que vai pra coluna custos_calculados do DB e pro PDF generico).
+function adaptarDemarcacaoParaCustosCalculados(out: DemarcacaoLotesOutput): CustosCalculados {
+  // Linhas de honorarios "viraveis" no PDF generico — mas o render real do
+  // Demarcacao usa honorarios_romatec_demarcacao diretamente.
+  const secao_3_honorarios: ItemCusto[] = [
+    { ordem: 1, descricao: 'TRT/CFT — Termo de Responsabilidade Tecnica', valor: out.honorarios_romatec.trt_cft },
+    { ordem: 2, descricao: 'Tecnicos de campo + Marcos + Deslocamento + Area (com complexidade e assessoria)',
+      valor: round2Lib(out.honorarios_romatec.total - out.honorarios_romatec.trt_cft + out.honorarios_romatec.desconto_valor) },
+  ];
+  if (out.honorarios_romatec.desconto_valor > 0) {
+    secao_3_honorarios.push({ ordem: 3, descricao: 'Desconto aplicado', valor: -out.honorarios_romatec.desconto_valor });
+  }
+  const custos: CustosCalculados = {
+    secao_1_projetos: [], // o render dedicado usa lista fixa ESCOPO_DEMARCACAO
+    secao_2_taxas: [],
+    secao_3_honorarios,
+    condicoes_pagamento: out.parcelas.map((p) => ({
+      rotulo: `${p.numero}a parcela — ${p.rotulo}`,
+      descricao: `${p.percentual}% do total`,
+      valor: p.valor,
+    })),
+    secao_4_checklist: [],
+    secao_5_total: out.honorarios_romatec.total,
+    avisos: [],
+    honorarios_romatec: {
+      trt: out.honorarios_romatec.trt_cft,
+      tecnicos: round2Lib(
+        out.honorarios_romatec.tecnicos_campo +
+        out.honorarios_romatec.marcos_subtotal +
+        out.honorarios_romatec.deslocamento +
+        out.honorarios_romatec.area_servico,
+      ),
+      assessoria: out.honorarios_romatec.assessoria,
+      total: out.honorarios_romatec.total,
+    },
+  };
+  // Campos extras (acessados via cast no renderDemarcacaoLotesBody)
+  (custos as unknown as { honorarios_romatec_demarcacao: DemarcacaoLotesOutput['honorarios_romatec'] }).honorarios_romatec_demarcacao = out.honorarios_romatec;
+  (custos as unknown as { secao_opcionais_demarcacao: DemarcacaoLotesOutput['secao_opcionais_demarcacao'] }).secao_opcionais_demarcacao = out.secao_opcionais_demarcacao;
+  if (out.codigos_mintados) {
+    (custos as unknown as { codigos_mintados: NonNullable<DemarcacaoLotesOutput['codigos_mintados']> }).codigos_mintados = out.codigos_mintados;
+  }
+  return custos;
+}
+
+function round2Lib(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
 // ── PDF de 5 secoes ────────────────────────────────────────────────────────
 
 const SUBTIPO_LABEL: Record<string, string> = {
@@ -488,6 +560,8 @@ const SUBTIPO_LABEL: Record<string, string> = {
   remembramento: 'REMEMBRAMENTO',
   retificacao_area: 'RETIFICACAO DE AREA',
   avaliacao_ptam: 'AVALIACAO DE IMOVEIS (PTAM)',
+  demarcacao_urbana: 'DEMARCACAO DE LOTE URBANO',
+  demarcacao_rural: 'DEMARCACAO DE IMOVEL RURAL',
 };
 
 // v3.23.5: render do corpo do PDF de Georreferenciamento Rural conforme modelo
@@ -1243,7 +1317,9 @@ export function renderGeorrefRuralBody(
 // NAO pode partir entre paginas — se nao couber inteiro, addPage antes.
 function renderAvisoDRL(
   doc: PDFKit.PDFDocument,
-  finalidade: 'CERTIFICACAO' | 'DESMEMBRAMENTO' | 'REMEMBRAMENTO' | 'RETIFICACAO',
+  finalidade:
+    | 'CERTIFICACAO' | 'DESMEMBRAMENTO' | 'REMEMBRAMENTO' | 'RETIFICACAO'
+    | 'demarcacao_inicial' | 'redemarcacao' | 'subdivisao_lote' | 'piqueteamento_apenas',
   colXIni: number,
   colW: number,
 ): void {
@@ -1313,6 +1389,430 @@ function renderAvisoDRL(
   doc.y = startY + alturaTotal + 10;
   doc.x = colXIni;
   doc.font('Helvetica').fillColor('#111');
+}
+
+// v3.27.0: render do corpo do PDF de Demarcacao de Lotes (Urbana e Rural).
+// Espelha o layout aprovado da v3.23.5 (Georref Rural), com 2 secoes extras:
+//   - 4-bis: Marcos Discriminados (tabela tipo x qtd x valor unit x subtotal)
+//   - 4-ter: Identificacao dos Marcos FQNS (codigos vitalicios INCRA)
+// Total: 11 secoes. Invocada SO para subtipo ∈ {demarcacao_urbana, demarcacao_rural}.
+const FINALIDADE_DEMARCACAO_TEXTOS: Record<FinalidadeDemarcacao, string> = {
+  demarcacao_inicial: 'Levantamento topografico de campo para implantacao fisica dos vertices definidos em projeto e materializacao da poligonal do imovel no terreno.',
+  redemarcacao: 'Repiqueteamento de vertices perdidos/deteriorados, restabelecendo a poligonal original conforme matricula e levantamento anterior.',
+  subdivisao_lote: 'Demarcacao fisica das fracoes resultantes de desmembramento/remembramento aprovado, com implantacao de marcos nas novas divisas.',
+  piqueteamento_apenas: 'Implantacao de marcos fisicos em vertices previamente calculados em escritorio (sem novo levantamento de campo).',
+};
+
+const ESCOPO_DEMARCACAO = [
+  'Levantamento topografico georreferenciado com GNSS RTK / Estacao Total nas divisas existentes',
+  'Implantacao fisica dos marcos nas vertices da poligonal conforme NTGIR/INCRA',
+  'Codificacao dos marcos com credencial INCRA do tecnico responsavel (rastreabilidade vitalicia)',
+  'Croqui ilustrativo da poligonal com identificacao dos marcos',
+  'Memorial Descritivo da demarcacao com coordenadas WGS84/SIRGAS2000',
+  'TRT/CFT — Termo de Responsabilidade Tecnica (CFT/MA)',
+  'Acompanhamento tecnico durante a instalacao dos marcos em campo',
+  'Orientacao ao proprietario sobre coleta de DRLs e averbacao em cartorio',
+];
+
+const MATERIAL_LABEL: Record<MaterialMarco, string> = {
+  concreto: 'Marco de Concreto Padrao INCRA',
+  tubo_galvanizado: 'Marco em Tubo Galvanizado',
+  madeira: 'Marco de Madeira de Lei (Piquete)',
+};
+
+function docsImprescindiveisDemarcacao(
+  subtipo: 'demarcacao_urbana' | 'demarcacao_rural',
+  finalidade: FinalidadeDemarcacao,
+): { texto: string; imprescindivel: boolean }[] {
+  const baseImpresc = [
+    { texto: 'RG/CPF do proprietario', imprescindivel: true },
+    { texto: 'Comprovante de residencia do proprietario', imprescindivel: false },
+  ];
+  if (finalidade === 'redemarcacao') {
+    return [
+      { texto: 'Levantamento topografico anterior OU matricula com descritivo de divisas', imprescindivel: true },
+      ...baseImpresc,
+    ];
+  }
+  if (finalidade === 'piqueteamento_apenas') {
+    return [
+      { texto: 'Coordenadas dos vertices em arquivo .csv ou .kml (georreferenciado)', imprescindivel: true },
+      { texto: 'Matricula atual', imprescindivel: true },
+      ...baseImpresc,
+    ];
+  }
+  if (subtipo === 'demarcacao_urbana') {
+    if (finalidade === 'subdivisao_lote') {
+      return [
+        { texto: 'Escritura ou matricula atual', imprescindivel: true },
+        { texto: 'Memorial do desmembramento aprovado', imprescindivel: true },
+        { texto: 'Planta carimbada pela Prefeitura', imprescindivel: true },
+        ...baseImpresc,
+      ];
+    }
+    // demarcacao_inicial urbana
+    return [
+      { texto: 'Escritura ou matricula atual', imprescindivel: true },
+      { texto: 'IPTU em dia (ultimo exercicio)', imprescindivel: true },
+      { texto: 'Projeto aprovado pela Prefeitura (quando houver)', imprescindivel: false },
+      ...baseImpresc,
+    ];
+  }
+  // demarcacao_rural
+  if (finalidade === 'subdivisao_lote') {
+    return [
+      { texto: 'Matricula atual', imprescindivel: true },
+      { texto: 'Georreferenciamento de origem certificado pelo INCRA', imprescindivel: true },
+      { texto: 'Memorial das fracoes resultantes', imprescindivel: true },
+      ...baseImpresc,
+    ];
+  }
+  return [
+    { texto: 'Matricula atual', imprescindivel: true },
+    { texto: 'CCIR vigente (INCRA)', imprescindivel: true },
+    { texto: 'ITR pago — ultimo exercicio', imprescindivel: false },
+    ...baseImpresc,
+  ];
+}
+
+function renderDemarcacaoLotesBody(
+  doc: PDFKit.PDFDocument,
+  p: Awaited<ReturnType<typeof buscarPropostaConsultoria>>,
+  dadosImovel: Record<string, unknown>,
+  custos: CustosCalculados,
+  corHex: string,
+): void {
+  const COL_X_INI = 48;
+  const COL_X_FIM = 547;
+  const COL_W = COL_X_FIM - COL_X_INI;
+
+  const COR_DOURADO_BG = '#fef3c7';
+  const COR_DOURADO_BORDA = '#d97706';
+  const COR_VERDE_BG = '#dcfce7';
+  const COR_VERDE_BORDA = '#16a34a';
+  const COR_CREME_BG = '#fef9c3';
+  const COR_CREME_BORDA = '#ca8a04';
+
+  const subtipo = p.subtipo as 'demarcacao_urbana' | 'demarcacao_rural';
+  const isUrbana = subtipo === 'demarcacao_urbana';
+
+  // Input persistido em dados_imovel
+  const di = dadosImovel as Partial<InputDemarcacaoLotes>;
+  const finalidade = (di.finalidade || 'demarcacao_inicial') as FinalidadeDemarcacao;
+  const codigos = (custos as unknown as { codigos_mintados?: DemarcacaoLotesOutput['codigos_mintados'] }).codigos_mintados;
+  const hr = (custos as unknown as { honorarios_romatec_demarcacao?: DemarcacaoLotesOutput['honorarios_romatec'] }).honorarios_romatec_demarcacao;
+
+  // ── 1. IDENTIFICACAO DO IMOVEL ────────────────────────────────────────
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('1. Identificacao do Imovel');
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+  doc.fontSize(9.5).fillColor('#111');
+
+  const municipio = di.municipio || '-';
+  const uf = di.uf || '';
+  const matricula = di.matricula || '-';
+  const cri = di.cri || `CRI de ${municipio}/${uf}`;
+  const perimetro = Number(di.perimetro_m || 0);
+  const vertices = Number(di.num_vertices || 0);
+
+  doc.text(`Municipio/UF:  ${municipio}${uf ? '/' + uf : ''}`);
+  doc.text(`Matricula:  ${matricula}    ·    Cartorio:  ${cri}`);
+  if (isUrbana) {
+    const lot = di.loteamento_nome ? `Loteamento ${di.loteamento_nome}` : '';
+    const qd = di.quadra ? `Quadra ${di.quadra}` : '';
+    const lt = di.lote ? `Lote ${di.lote}` : '';
+    const linha = [lot, qd, lt].filter(Boolean).join('    ·    ');
+    if (linha) doc.text(linha);
+    if (di.area_m2) {
+      doc.text(`Area:  ${Number(di.area_m2).toLocaleString('pt-BR', { minimumFractionDigits: 2 })} m²    ·    Vertices:  ${vertices}${perimetro > 0 ? '    ·    Perimetro:  ' + perimetro.toLocaleString('pt-BR', { minimumFractionDigits: 2 }) + ' m' : ''}`);
+    }
+  } else {
+    if (di.denominacao_imovel) doc.text(`Denominacao:  ${di.denominacao_imovel}${di.ccir ? '    ·    CCIR:  ' + di.ccir : ''}`);
+    if (di.area_hectares) {
+      doc.text(`Area:  ${Number(di.area_hectares).toLocaleString('pt-BR', { minimumFractionDigits: 4 })} ha    ·    Vertices:  ${vertices}${perimetro > 0 ? '    ·    Perimetro:  ' + perimetro.toLocaleString('pt-BR', { minimumFractionDigits: 2 }) + ' m' : ''}`);
+    }
+  }
+  doc.moveDown(0.6);
+
+  // ── 2. BOX DOURADO — FINALIDADE ───────────────────────────────────────
+  const textoFinal = FINALIDADE_DEMARCACAO_TEXTOS[finalidade];
+  const boxAltFin = doc.heightOfString(textoFinal, { width: COL_W - 28 }) + 28;
+  const boxYFin = doc.y;
+  doc.rect(COL_X_INI, boxYFin, COL_W, boxAltFin).fillAndStroke(COR_DOURADO_BG, COR_DOURADO_BORDA);
+  doc.fontSize(8.5).fillColor(COR_DOURADO_BORDA).font('Helvetica-Bold')
+    .text('FINALIDADE', COL_X_INI + 12, boxYFin + 8, { width: COL_W - 24 });
+  doc.fontSize(9.5).fillColor('#111').font('Helvetica')
+    .text(textoFinal, COL_X_INI + 12, boxYFin + 22, { width: COL_W - 24, align: 'justify' });
+  doc.y = boxYFin + boxAltFin + 8;
+  doc.x = COL_X_INI;
+
+  // ── 3. ESCOPO DO SERVICO ──────────────────────────────────────────────
+  if (doc.y > 700) doc.addPage();
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('3. Escopo do Servico');
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+  doc.fontSize(9.5).fillColor('#111');
+  ESCOPO_DEMARCACAO.forEach((item, i) => {
+    doc.text(`${i + 1}. ${item}`, { indent: 8, width: COL_W - 8 });
+  });
+  doc.moveDown(0.5);
+
+  // ── 4. HONORARIOS ROMATEC ─────────────────────────────────────────────
+  if (doc.y > 640) doc.addPage();
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4. Honorarios — Romatec Consultoria Total');
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+
+  const linhasHon: Array<{ label: string; valor: number; obs?: string }> = hr
+    ? [
+        { label: 'TRT/CFT — Termo de Responsabilidade Tecnica (CFT/MA)', valor: hr.trt_cft, obs: 'Tec. em Agrimensura CFT/MA n. 01209185369' },
+        { label: 'Tecnicos de campo', valor: hr.tecnicos_campo, obs: `${di.diarias_equipe || 0} diaria(s) x SM x fator CFT-MA 0,42 (Res. 12/2025)` },
+        { label: `Area do servico (${isUrbana ? 'm²' : 'hectare'})`, valor: hr.area_servico, obs: isUrbana ? `${di.area_m2 || 0} m² x valor unitario` : `${di.area_hectares || 0} ha x valor unitario` },
+        { label: 'Deslocamento', valor: hr.deslocamento, obs: `${di.km_deslocamento || 0} km x R$ 3,50/km` },
+        { label: `Multiplicador de complexidade (${di.complexidade || 'media'})`, valor: hr.subtotal_apos_complexidade - (hr.trt_cft + hr.tecnicos_campo + hr.marcos_subtotal + hr.deslocamento + hr.area_servico), obs: `x ${hr.complexidade_multiplicador}` },
+        { label: 'Assessoria (5%)', valor: hr.assessoria },
+      ]
+    : (custos.secao_3_honorarios || []).map((h) => ({ label: h.descricao, valor: Number(h.valor), obs: h.observacao }));
+
+  linhasHon.forEach((h) => {
+    const itemY0 = doc.y;
+    doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+      .text(h.label, COL_X_INI + 8, itemY0, { width: COL_W - 100 });
+    const itemY1 = doc.y;
+    doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+      .text(formatBRL(h.valor), COL_X_FIM - 80, itemY0, { width: 80, align: 'right' });
+    doc.y = itemY1;
+    if (h.obs) {
+      doc.font('Helvetica').fontSize(8).fillColor('#555')
+        .text(h.obs, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+    }
+    doc.font('Helvetica').fillColor('#111');
+    doc.moveDown(0.3);
+  });
+
+  if (hr && hr.desconto_valor > 0) {
+    doc.fontSize(9.5).fillColor('#dc2626').font('Helvetica-Bold')
+      .text(`Desconto aplicado: -${formatBRL(hr.desconto_valor)}`, { align: 'right', width: COL_W - 16 });
+    doc.font('Helvetica').fillColor('#111');
+  }
+  doc.moveDown(0.2);
+
+  // ── 4-bis. MARCOS DISCRIMINADOS ──────────────────────────────────────
+  if (hr && hr.marcos_discriminados.length > 0) {
+    if (doc.y > 650) doc.addPage();
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4.2 Marcos Discriminados');
+    doc.font('Helvetica');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+
+    hr.marcos_discriminados.forEach((md) => {
+      const y0 = doc.y;
+      const vu = md.qtd > 0 ? md.subtotal / md.qtd : 0;
+      doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+        .text(`${MATERIAL_LABEL[md.tipo]}  ·  ${md.qtd} un × ${formatBRL(vu)}`, COL_X_INI + 8, y0, { width: COL_W - 100 });
+      doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+        .text(formatBRL(md.subtotal), COL_X_FIM - 80, y0, { width: 80, align: 'right' });
+      doc.font('Helvetica').fillColor('#111');
+      doc.moveDown(0.2);
+    });
+    doc.moveDown(0.1);
+    doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+      .text(`Total dos marcos: ${formatBRL(hr.marcos_subtotal)}`, { align: 'right', width: COL_W - 16 });
+    doc.font('Helvetica').fillColor('#111');
+    doc.moveDown(0.4);
+  }
+
+  // ── 4-ter. IDENTIFICACAO DOS MARCOS (FQNS) ───────────────────────────
+  if (doc.y > 600) doc.addPage();
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4.3 Identificacao dos Marcos (Codificacao INCRA)');
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+
+  if (codigos) {
+    doc.fontSize(9).fillColor('#111')
+      .text('Os marcos a serem implantados em campo recebem codificacao INCRA padrao do tecnico responsavel, conforme NTGIR 3a Edicao:', { width: COL_W - 8, indent: 8, align: 'justify' });
+    doc.moveDown(0.3);
+    const linhasFQNS: Array<[string, string[]]> = [
+      [`▸ Vertices da poligonal (${codigos.vertices.length}):`, codigos.vertices],
+      [`▸ Marcos de concreto (${codigos.marcos_por_tipo.concreto.length}):`, codigos.marcos_por_tipo.concreto],
+      [`▸ Marcos de tubo galvanizado (${codigos.marcos_por_tipo.tubo_galvanizado.length}):`, codigos.marcos_por_tipo.tubo_galvanizado],
+      [`▸ Piquetes de madeira (${codigos.marcos_por_tipo.madeira.length}):`, codigos.marcos_por_tipo.madeira],
+    ];
+    for (const [label, lista] of linhasFQNS) {
+      doc.fontSize(8.5).fillColor('#444').font('Helvetica-Bold').text(label, { indent: 8, width: COL_W - 16 });
+      doc.font('Helvetica').fillColor('#111');
+      if (lista.length === 0) {
+        doc.text('  —', { indent: 16, width: COL_W - 24 });
+      } else if (lista.length <= 6) {
+        doc.text('  ' + lista.join(', '), { indent: 16, width: COL_W - 24 });
+      } else {
+        doc.text(`  ${lista[0]} a ${lista[lista.length - 1]}`, { indent: 16, width: COL_W - 24 });
+      }
+      doc.moveDown(0.1);
+    }
+    doc.moveDown(0.2);
+    doc.fontSize(8).fillColor('#555').font('Helvetica-Oblique')
+      .text('Cada marco e gravado/etiquetado fisicamente com seu codigo unico para rastreabilidade e responsabilidade tecnica perante INCRA/MPF.', { width: COL_W - 8, indent: 8, align: 'justify' });
+    doc.font('Helvetica').fillColor('#111');
+  } else {
+    doc.fontSize(9).fillColor('#555').font('Helvetica-Oblique')
+      .text('Os codigos definitivos dos marcos (formato FQNS-V-XXX, FQNS-M-XXXX-CC, etc.) serao atribuidos quando esta proposta for enviada ao cliente. Em rascunho, os codigos ainda nao foram reservados nos contadores INCRA do tecnico responsavel.', { width: COL_W - 8, indent: 8, align: 'justify' });
+    doc.font('Helvetica').fillColor('#111');
+  }
+  doc.moveDown(0.5);
+
+  // ── 5. BOX VERDE — VALOR TOTAL ────────────────────────────────────────
+  const totalRomatec = hr?.total ?? custos.honorarios_romatec?.total ?? custos.secao_5_total;
+  if (doc.y > 700) doc.addPage();
+  const txtTotalNota = 'Soma de TRT/CFT + Tecnicos de campo + Marcos + Deslocamento + Area, com complexidade e assessoria. Eventuais custos de cartorio para averbacao da demarcacao NAO estao inclusos.';
+  const boxYT = doc.y;
+  const boxAlturaT = doc.heightOfString(txtTotalNota, { width: COL_W - 24 }) + 38;
+  doc.rect(COL_X_INI, boxYT, COL_W, boxAlturaT).fillAndStroke(COR_VERDE_BG, COR_VERDE_BORDA);
+  doc.fontSize(10).fillColor(COR_VERDE_BORDA).font('Helvetica-Bold')
+    .text('VALOR TOTAL DA PROPOSTA (Romatec):', COL_X_INI + 12, boxYT + 8, { width: COL_W - 120 });
+  doc.fontSize(14).fillColor('#065f46').font('Helvetica-Bold')
+    .text(formatBRL(totalRomatec), COL_X_FIM - 130, boxYT + 8, { width: 118, align: 'right' });
+  doc.fontSize(8).fillColor('#166534').font('Helvetica')
+    .text(txtTotalNota, COL_X_INI + 12, boxYT + 26, { width: COL_W - 24, align: 'justify' });
+  doc.y = boxYT + boxAlturaT + 10;
+  doc.x = COL_X_INI;
+
+  // ── 6. CONDICOES DE PAGAMENTO ─────────────────────────────────────────
+  if (custos.condicoes_pagamento && custos.condicoes_pagamento.length > 0) {
+    if (doc.y > 680) doc.addPage();
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('6. Condicoes de Pagamento');
+    doc.font('Helvetica');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+    custos.condicoes_pagamento.forEach((cp) => {
+      const y0 = doc.y;
+      doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+        .text(cp.rotulo, COL_X_INI + 8, y0, { width: COL_W - 100 });
+      doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+        .text(formatBRL(cp.valor), COL_X_FIM - 80, y0, { width: 80, align: 'right' });
+      doc.font('Helvetica').fontSize(8.5).fillColor('#444')
+        .text(cp.descricao, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+      doc.font('Helvetica').fillColor('#111');
+      doc.moveDown(0.2);
+    });
+    doc.moveDown(0.3);
+  }
+
+  // ── 7. CUSTOS DE TERCEIROS — SO renderiza se houver linhas ────────────
+  if (custos.secao_2_taxas && custos.secao_2_taxas.length > 0) {
+    if (doc.y > 660) doc.addPage();
+    const txtAv = isUrbana
+      ? 'Emolumentos do CRI competente para averbacao da demarcacao. Pagos diretamente pelo cliente no cartorio.'
+      : 'Eventuais custos de SIGEF/INCRA, CCIR ou cartorio quando aplicaveis. Pagos diretamente pelo cliente.';
+    const boxYCT = doc.y;
+    const boxAlturaCT = doc.heightOfString(txtAv, { width: COL_W - 24 }) + 26;
+    doc.rect(COL_X_INI, boxYCT, COL_W, boxAlturaCT).fillAndStroke(COR_CREME_BG, COR_CREME_BORDA);
+    doc.fontSize(10).fillColor(COR_CREME_BORDA).font('Helvetica-Bold')
+      .text('7. CUSTOS DE TERCEIROS (INFORMATIVO — A CARGO DO CLIENTE)', COL_X_INI + 12, boxYCT + 6, { width: COL_W - 24 });
+    doc.fontSize(8).fillColor('#713f12').font('Helvetica')
+      .text(txtAv, COL_X_INI + 12, boxYCT + 20, { width: COL_W - 24, align: 'justify' });
+    doc.y = boxYCT + boxAlturaCT + 6;
+    doc.x = COL_X_INI;
+
+    custos.secao_2_taxas.forEach((t) => {
+      const y0 = doc.y;
+      doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+        .text(t.descricao, COL_X_INI + 8, y0, { width: COL_W - 100 });
+      const valorTxt = t.pendente ? 'A apurar' : (t.valor === 0 ? 'Gratuito' : formatBRL(t.valor));
+      doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+        .text(valorTxt, COL_X_FIM - 90, y0, { width: 90, align: 'right' });
+      if (t.observacao) {
+        doc.font('Helvetica').fontSize(8).fillColor('#666')
+          .text(t.observacao, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+      }
+      doc.font('Helvetica').fillColor('#111');
+      doc.moveDown(0.2);
+    });
+    doc.moveDown(0.4);
+  }
+
+  // ── 8. SERVICOS ADICIONAIS OPCIONAIS ──────────────────────────────────
+  const opcSec = (custos as unknown as { secao_opcionais_demarcacao?: DemarcacaoLotesOutput['secao_opcionais_demarcacao'] }).secao_opcionais_demarcacao;
+  if (opcSec && opcSec.linhas.length > 0) {
+    if (doc.y > 660) doc.addPage();
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('8. Servicos Adicionais Opcionais');
+    doc.font('Helvetica');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+    doc.fontSize(8).fillColor('#666').font('Helvetica-Oblique')
+      .text('NAO somam ao total da proposta. Marcados se contratados.', { indent: 8, width: COL_W - 8 });
+    doc.font('Helvetica').fillColor('#111');
+    doc.moveDown(0.2);
+    opcSec.linhas.forEach((l) => {
+      const y0 = doc.y;
+      const check = l.contratado ? '☑' : '☐';
+      doc.fontSize(9.5).fillColor('#111').font(l.contratado ? 'Helvetica-Bold' : 'Helvetica')
+        .text(`${check} ${l.rotulo}`, COL_X_INI + 8, y0, { width: COL_W - 100 });
+      const valorTxt = l.valor === 'sob_orcamento' ? 'Sob orcamento' : (l.contratado ? formatBRL(l.valor as number) : '—');
+      doc.fontSize(9.5).fillColor(l.contratado ? corHex : '#666').font(l.contratado ? 'Helvetica-Bold' : 'Helvetica')
+        .text(valorTxt, COL_X_FIM - 100, y0, { width: 100, align: 'right' });
+      doc.font('Helvetica').fillColor('#111');
+      doc.moveDown(0.1);
+    });
+    if (opcSec.subtotal > 0) {
+      doc.moveDown(0.2);
+      doc.fontSize(9.5).fillColor('#666').font('Helvetica-Bold')
+        .text(`Subtotal opcionais contratados: ${formatBRL(opcSec.subtotal)}  (cobrado a parte)`, { indent: 8, align: 'right', width: COL_W - 16 });
+      doc.font('Helvetica');
+    }
+    doc.moveDown(0.4);
+  }
+
+  // ── 9. DOCUMENTOS A SEREM FORNECIDOS ─────────────────────────────────
+  if (doc.y > 660) doc.addPage();
+  doc.x = COL_X_INI;
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold')
+    .text('9. Documentos a Serem Fornecidos pelo Cliente', COL_X_INI, doc.y, { width: COL_W });
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+  doc.fontSize(9.5).fillColor('#111');
+  const docsList = docsImprescindiveisDemarcacao(subtipo, finalidade);
+  docsList.forEach((d) => {
+    doc.x = COL_X_INI;
+    if (d.imprescindivel) {
+      doc.fillColor('#dc2626').font('Helvetica-Bold')
+        .text(`☐ [IMPRESCINDIVEL] ${d.texto}`, COL_X_INI + 8, doc.y, { width: COL_W - 16, continued: false });
+      doc.font('Helvetica').fillColor('#111');
+    } else {
+      doc.text(`☐ ${d.texto}`, COL_X_INI + 8, doc.y, { width: COL_W - 16, continued: false });
+    }
+  });
+  doc.moveDown(0.5);
+
+  // ── 10. AVISOS ────────────────────────────────────────────────────────
+  if (doc.y > 660) doc.addPage();
+  doc.x = COL_X_INI;
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold')
+    .text('10. Avisos e Condicoes Tecnicas', COL_X_INI, doc.y, { width: COL_W });
+  doc.font('Helvetica');
+  doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+  doc.moveDown(0.2);
+  doc.fontSize(8.5).fillColor('#444');
+  const avisosDem = [
+    'A demarcacao consiste na materializacao fisica das divisas. O servico nao constitui regularizacao fundiaria isolada — para averbacao no cartorio sao necessarios os documentos imprescindiveis acima.',
+    'O cliente deve coletar Declaracoes de Respeito de Limite (DRLs) com firma reconhecida em cartorio (ver box vermelho abaixo).',
+    'Os codigos INCRA dos marcos sao vitalicios e atrelados ao tecnico responsavel. Apos atribuidos no envio da proposta, nao podem ser realocados a outra obra.',
+  ];
+  avisosDem.forEach((a) => {
+    doc.x = COL_X_INI;
+    doc.text(`• ${a}`, COL_X_INI + 8, doc.y, { width: COL_W - 16, align: 'justify', continued: false });
+    doc.moveDown(0.15);
+  });
+  doc.fillColor('#111');
+  doc.moveDown(0.3);
+
+  // ── 10-bis. BOX VERMELHO — AVISO DRL ──────────────────────────────────
+  renderAvisoDRL(doc, finalidade, COL_X_INI, COL_W);
 }
 
 export async function gerarPdfPropostaConsultoria(
@@ -1390,6 +1890,10 @@ export async function gerarPdfPropostaConsultoria(
   } else if (p.subtipo === 'projeto_executivo') {
     // v3.24.5: Projeto Executivo — layout dedicado.
     renderProjetoExecutivoBody(doc, p, dadosImovel, custos, corHex);
+  } else if (p.subtipo === 'demarcacao_urbana' || p.subtipo === 'demarcacao_rural') {
+    // v3.27.0: Demarcacao de Lotes (Urbana/Rural) — layout dedicado com
+    // 11 secoes (10 do Georref + Marcos Discriminados + Identificacao FQNS).
+    renderDemarcacaoLotesBody(doc, p, dadosImovel, custos, corHex);
   } else {
 
   // v1.99.16: Remembramento detalhado — tabela de imóveis + área total destacada
@@ -2075,12 +2579,76 @@ function formatDataBR(d: Date | string): string {
 //   return new Promise((r) => setTimeout(r, ms));
 // }
 
+// v3.27.0: garante que a proposta de Demarcacao tenha codigos FQNS mintados
+// (idempotente — so minta uma vez por proposta; anti-replay via dados_imovel.codigos_mintados).
+// Invocado pelos senders WhatsApp/Telegram antes da transicao RASCUNHO->ENVIADA.
+export async function garantirCodigosMintadosDemarcacao(propostaId: number): Promise<void> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT subtipo_consultoria, status, dados_imovel, custos_calculados
+       FROM propostas WHERE id = ? AND deleted_at IS NULL`,
+    [propostaId],
+  );
+  if (!rows.length) return;
+  const subtipo = String(rows[0].subtipo_consultoria || '');
+  if (subtipo !== 'demarcacao_urbana' && subtipo !== 'demarcacao_rural') return;
+  if (String(rows[0].status || '').toUpperCase() !== 'RASCUNHO') return; // so minta na primeira transicao
+
+  const dadosImovel = parseJsonCol<Record<string, unknown> & { num_vertices?: number; marcos?: Array<{ tipo: string; quantidade: number }>; codigos_mintados?: unknown }>(rows[0].dados_imovel) || {};
+  if (dadosImovel.codigos_mintados) return; // ja mintado — anti-replay
+
+  // Localiza o tecnico responsavel: primeiro admin com prefixo configurado
+  const [userRows] = await pool.execute<RowDataPacket[]>(
+    `SELECT id FROM users
+      WHERE credencial_incra_prefixo IS NOT NULL AND credencial_incra_prefixo <> ''
+      ORDER BY (role = 'admin') DESC, id ASC
+      LIMIT 1`,
+  );
+  if (!userRows.length) {
+    console.warn(`[mint-fqns] proposta ${propostaId}: nenhum usuario com credencial INCRA — pulando mint`);
+    return;
+  }
+  const userId = Number(userRows[0].id);
+
+  const numVertices = Number(dadosImovel.num_vertices || 0);
+  const marcos = Array.isArray(dadosImovel.marcos)
+    ? (dadosImovel.marcos as Array<{ tipo: 'concreto' | 'tubo_galvanizado' | 'madeira'; quantidade: number; valor_unitario_congelado?: number }>)
+        .map((m) => ({ tipo: m.tipo, quantidade: Number(m.quantidade) || 0, valor_unitario_congelado: Number(m.valor_unitario_congelado) || 0 }))
+    : [];
+
+  const conn = await pool.getConnection();
+  try {
+    const m = await import('../services/pricing/mintCodigosDemarcacao');
+    const codigos = await m.mintarCodigosDemarcacao(conn, userId, {
+      num_vertices: numVertices,
+      marcos,
+    });
+    // Persiste em dados_imovel + custos_calculados.codigos_mintados
+    const dadosAtual = { ...dadosImovel, codigos_mintados: codigos };
+    const custosAtual = parseJsonCol<CustosCalculados>(rows[0].custos_calculados) || ({} as CustosCalculados);
+    (custosAtual as unknown as { codigos_mintados: typeof codigos }).codigos_mintados = codigos;
+    await pool.execute(
+      `UPDATE propostas SET dados_imovel = ?, custos_calculados = ? WHERE id = ?`,
+      [JSON.stringify(dadosAtual), JSON.stringify(custosAtual), propostaId],
+    );
+    console.log(`[mint-fqns] proposta ${propostaId}: ${codigos.vertices.length} V + ${codigos.marcos_por_tipo.concreto.length}/${codigos.marcos_por_tipo.tubo_galvanizado.length}/${codigos.marcos_por_tipo.madeira.length} marcos`);
+  } catch (err) {
+    console.error(`[mint-fqns] proposta ${propostaId} FALHOU:`, (err as Error).message);
+    // nao re-throw — envio continua, mint pode ser feito manualmente depois
+  } finally {
+    conn.release();
+  }
+}
+
 export async function enviarPropostaConsultoriaWhatsApp(input: { id: string; telefone?: string }) {
   const idNum = Number(input.id);
   if (!idNum) throw new Error('id obrigatorio');
   const p = await buscarPropostaConsultoria(input.id);
   const tel = (input.telefone?.trim()) || p.cliente?.telefone || '';
   if (!tel) throw new Error('Telefone obrigatorio (informe ou cadastre no cliente).');
+
+  // v3.27.0: minta os codigos FQNS antes de gerar o PDF (so demarcacao + RASCUNHO).
+  // Idempotente — chamadas repetidas nao re-mintam.
+  await garantirCodigosMintadosDemarcacao(idNum);
 
   // v3.23.10: PDF UNIFICADO (proposta + anexos no mesmo arquivo). Antes:
   // - v3.23.7-9: enviava proposta separado + cada anexo em mensagem propria
@@ -2110,6 +2678,8 @@ export async function enviarPropostaConsultoriaWhatsApp(input: { id: string; tel
 
 export async function enviarPropostaConsultoriaTelegram(input: { id: string; chatId?: string }) {
   const idNum = Number(input.id);
+  // v3.27.0: mint antes do envio (idempotente — so demarcacao + RASCUNHO).
+  if (idNum) await garantirCodigosMintadosDemarcacao(idNum);
   if (!idNum) throw new Error('id obrigatorio');
   const p = await buscarPropostaConsultoria(input.id);
 
@@ -2260,6 +2830,11 @@ export async function atualizarPropostaConsultoria(input: {
     } else if (subtipo === 'averbacao_residencial' || subtipo === 'averbacao_comercial') {
       const r = await calcularConsultoria({ subtipo, dados: dadosFinal });
       custosFinal = r.custos;
+    } else if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+      // v3.27.0: Demarcacao de Lotes
+      const m = await import('../services/pricing/demarcacaoLotes');
+      const out = m.calcularDemarcacaoLotes(dadosFinal as unknown as InputDemarcacaoLotes);
+      custosFinal = adaptarDemarcacaoParaCustosCalculados(out);
     } else {
       throw new Error(`Subtipo ${subtipo} nao suportado para edicao nesta fase.`);
     }

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -6550,6 +6550,9 @@ const SUBTIPOS_CONSULTORIA = [
   { slug: 'averbacao_residencial',     icone: '🏠', nome: 'Averbação Residencial',    disponivel: true },
   { slug: 'averbacao_comercial',       icone: '🏢', nome: 'Averbação Comercial',      disponivel: true },
   { slug: 'georreferenciamento_rural', icone: '🌾', nome: 'Georreferenciamento Rural', disponivel: true },
+  // v3.27.0: Demarcação de Lotes (Urbana e Rural) — agrupados após Georref Rural
+  { slug: 'demarcacao_urbana',         icone: '🌆', nome: 'Demarcação Urbana',        disponivel: true },
+  { slug: 'demarcacao_rural',          icone: '🌾', nome: 'Demarcação Rural',         disponivel: true },
   { slug: 'desmembramento',            icone: '✂️', nome: 'Desmembramento',           disponivel: true },
   { slug: 'remembramento',             icone: '🔗', nome: 'Remembramento',            disponivel: true },
   { slug: 'retificacao_area',          icone: '📐', nome: 'Retificação de Área',      disponivel: true },
@@ -6893,6 +6896,10 @@ async function renderConsultoriaFormInline(v, toggleHTML, subtipo) {
   }
   if (subtipo === 'projeto_executivo') {
     return renderConsultoriaFormProjetoExecutivo(v, toggleHTML);
+  }
+  // v3.27.0: Demarcação de Lotes (Urbana / Rural)
+  if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+    return renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo);
   }
   await loadPropostasClientes();
   const cliOpts = state.propostasClientes.map(c =>
@@ -8592,6 +8599,293 @@ const PROJETOS_PE_DEFAULT_FRONT = [
   { codigo: 'estrutural',     nome: 'Projeto Estrutural',                                   selecionado: true,  detalhamento: 'Planta de locacao de pilares, planta de formas por pavimento, detalhamento de vigas, lajes, pilares e fundacoes, memorial de calculo, especificacao de materiais (concreto e aco), em conformidade com NBR 6118 e NBR 6122.' },
   { codigo: 'pci',            nome: 'Projeto de Prevencao e Combate a Incendio (PCI)',      selecionado: false, detalhamento: 'Planta baixa de PCI com rotas de fuga, localizacao de extintores, hidrantes, iluminacao de emergencia e sinalizacao, memorial descritivo conforme Normas Tecnicas do CBMMA e NBR 9077, para protocolo junto ao Corpo de Bombeiros Militar do Maranhao.' },
 ];
+
+// v3.27.0: form de Demarcação de Lotes (Urbana e Rural). Espelha o padrão
+// do Georref Rural com 2 secoes extras: marcos discriminados + preview FQNS.
+async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
+  await loadPropostasClientes();
+  const cliOpts = state.propostasClientes.map(c =>
+    `<option value="${c.id}">${escape(c.nome)}${c.cpf_cnpj ? ' · ' + escape(c.cpf_cnpj) : ''}</option>`
+  ).join('');
+  const isUrbana = subtipo === 'demarcacao_urbana';
+  const subLabel = SUBTIPO_LABEL_FRONT[subtipo];
+  const editando = !!state.consultoriaEditandoId;
+  const tituloHeader = editando
+    ? `Editando ${state.consultoriaPropostaOriginal?.numero || ''}`
+    : `Nova Proposta — ${subLabel}`;
+  const cache = state.consultoriaFormCache && state.consultoriaFormCache.subtipo === subtipo
+    ? state.consultoriaFormCache
+    : null;
+
+  v.innerHTML = `
+    ${toggleHTML}
+    <div class="card" role="region" aria-label="Cabeçalho do formulário">
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap;">
+        <div>
+          <p class="section-title" style="margin:0;">${escape(tituloHeader)}</p>
+          <p style="margin:4px 0 0; font-size:13px; color:var(--gold);">${isUrbana ? '🌆' : '🌾'} ${escape(subLabel)} · NTGIR/INCRA · CFT/MA</p>
+        </div>
+        <button data-cons-voltar style="background:transparent;">← Voltar</button>
+      </div>
+    </div>
+    <div class="card" aria-live="polite">
+      <div style="display:grid; gap:10px; font-size:13px;">
+        <label>Cliente
+          <div style="display:flex; gap:6px;">
+            <select id="dmCliente" style="flex:1;"><option value="">— escolher —</option>${cliOpts}</select>
+            <button type="button" id="dmNovoCliente" style="white-space:nowrap; background:var(--success); color:#fff; border-color:var(--success);">+ Novo cliente</button>
+          </div>
+        </label>
+        <label>Endereço do imóvel
+          <input id="dmEndereco" placeholder="${isUrbana ? 'Rua, número, bairro, cidade-UF' : 'Sítio/Fazenda Tal, zona rural, município-UF'}" style="width:100%;" value="${escape(cache?.endereco || '')}">
+        </label>
+        <div class="lp-grid-2">
+          <label>Município <input id="dmMunicipio" value="${escape(cache?.municipio || 'Açailândia')}" style="width:100%;"></label>
+          <label>UF <input id="dmUf" maxlength="2" value="${escape(cache?.uf || 'MA')}" style="width:100%;"></label>
+        </div>
+        <label>🎯 Finalidade
+          <select id="dmFinalidade" style="width:100%;">
+            <option value="demarcacao_inicial">Demarcação inicial — implantação física de vértices</option>
+            <option value="redemarcacao">Redemarcação — repiqueteamento de vértices</option>
+            <option value="subdivisao_lote">Subdivisão de lote — frações resultantes</option>
+            <option value="piqueteamento_apenas">Piqueteamento apenas (sem novo levantamento)</option>
+          </select>
+        </label>
+        <div class="lp-grid-2">
+          <label>Matrícula (opcional) <input id="dmMatricula" value="${escape(cache?.matricula || '')}" style="width:100%;"></label>
+          <label>CRI / Cartório (opcional) <input id="dmCri" placeholder="default: CRI de {Município}/{UF}" value="${escape(cache?.cri || '')}" style="width:100%;"></label>
+        </div>
+
+        ${isUrbana ? `
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">🌆 Loteamento</p>
+        <div class="lp-grid-2">
+          <label>Loteamento <input id="dmLoteamento" value="${escape(cache?.loteamento_nome || '')}" style="width:100%;"></label>
+          <label>Quadra <input id="dmQuadra" value="${escape(cache?.quadra || '')}" style="width:100%;"></label>
+        </div>
+        <div class="lp-grid-2">
+          <label>Lote <input id="dmLote" value="${escape(cache?.lote || '')}" style="width:100%;"></label>
+          <label>Área (m²) <input id="dmAreaM2" type="number" min="1" step="0.01" value="${cache?.area_m2 ?? ''}" style="width:100%;"></label>
+        </div>` : `
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">🌾 Imóvel rural</p>
+        <div class="lp-grid-2">
+          <label>Denominação <input id="dmDenom" value="${escape(cache?.denominacao_imovel || '')}" style="width:100%;"></label>
+          <label>CCIR (opcional) <input id="dmCcir" value="${escape(cache?.ccir || '')}" style="width:100%;"></label>
+        </div>
+        <label>Área (hectares) <input id="dmAreaHa" type="number" min="0.01" step="0.01" value="${cache?.area_hectares ?? ''}" style="width:100%;"></label>`}
+
+        <div class="lp-grid-2">
+          <label>Perímetro (m, opcional) <input id="dmPerimetro" type="number" min="0" step="0.01" value="${cache?.perimetro_m ?? ''}" style="width:100%;"></label>
+          <label>Nº de vértices (≥3) <input id="dmVertices" type="number" min="3" step="1" value="${cache?.num_vertices ?? ''}" style="width:100%;"></label>
+        </div>
+        <label>Complexidade
+          <select id="dmComplex" style="width:100%;">
+            <option value="simples">Simples (1.0x)</option>
+            <option value="media" selected>Média (1.3x)</option>
+            <option value="alta">Alta (1.6x)</option>
+          </select>
+        </label>
+
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">📌 Marcos</p>
+        <label style="display:flex; gap:6px; align-items:center;">
+          <input id="dmPiquet" type="checkbox" ${cache?.servico_piqueteamento ? 'checked' : ''}>
+          <span>Serviço de Piqueteamento (Σ marcos === nº de vértices)</span>
+        </label>
+        <div id="dmMarcosWrap" style="display:grid; gap:6px;">
+          <div class="lp-grid-2">
+            <label>Concreto (R$ 120/un) <input id="dmMarcoConcreto" type="number" min="0" step="1" value="${cache?.marcos_concreto ?? 0}" style="width:100%;"></label>
+            <label>Tubo galv. (R$ 85/un) <input id="dmMarcoTubo" type="number" min="0" step="1" value="${cache?.marcos_tubo ?? 0}" style="width:100%;"></label>
+          </div>
+          <label>Madeira (R$ 35/un) <input id="dmMarcoMadeira" type="number" min="0" step="1" value="${cache?.marcos_madeira ?? 0}" style="width:100%;"></label>
+          <div id="dmMarcosCheck" style="font-size:11px; color:var(--text-muted);"></div>
+        </div>
+
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">🚚 Logística</p>
+        <div class="lp-grid-2">
+          <label>Diárias equipe (≥1) <input id="dmDiarias" type="number" min="1" step="1" value="${cache?.diarias_equipe ?? 1}" style="width:100%;"></label>
+          <label>Km deslocamento <input id="dmKm" type="number" min="0" step="1" value="${cache?.km_deslocamento ?? 0}" style="width:100%;"></label>
+        </div>
+
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">💰 Negociação</p>
+        <div class="lp-grid-2">
+          <label>R$/${isUrbana ? 'm²' : 'ha'} (override, opcional) <input id="dmValUnit" type="number" min="0" step="0.01" value="${cache?.valor_unitario_area ?? ''}" placeholder="${isUrbana ? '1,50 default' : '80,00 default'}" style="width:100%;"></label>
+          <label>Desconto % (0–30) <input id="dmDesc" type="number" min="0" max="30" step="0.1" value="${cache?.desconto_pct ?? 0}" style="width:100%;"></label>
+        </div>
+        <label>Validade (dias) <input id="dmValidade" type="number" min="1" step="1" value="${cache?.validade_dias ?? 15}" style="width:100%;"></label>
+
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">➕ Opcionais (não somam ao total)</p>
+        <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcLaudo" type="checkbox"> Laudo Técnico (1 SM)</label>
+        <div class="lp-grid-2">
+          <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcAlinh" type="checkbox"> Alinhamento de Cerca</label>
+          <label>Metros <input id="dmOpcAlinhM" type="number" min="0" step="1" value="0" style="width:100%;"></label>
+        </div>
+        <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcCroqui" type="checkbox"> Croqui Assinado em Cartório (R$ 180)</label>
+        <div class="lp-grid-2">
+          <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcAcomp" type="checkbox"> Acompanhamento de Obra</label>
+          <label>Diárias <input id="dmOpcAcompD" type="number" min="0" step="1" value="0" style="width:100%;"></label>
+        </div>
+        <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcJurid" type="checkbox"> Consultoria Jurídica (Sob orçamento)</label>
+
+        <div id="dmFqnsPreview" style="margin-top:12px; padding:10px; background:rgba(0,180,255,0.06); border-left:3px solid #0ea5e9; font-size:12px; color:var(--text-muted); border-radius:4px;">
+          Esta proposta receberá códigos FQNS-V (vértices), FQNS-M-CC (concreto), FQNS-M-TG (tubo) e FQNS-P-MD (madeira) ao ser enviada. Códigos definitivos aparecerão no PDF após envio.
+        </div>
+
+        <div style="display:flex; gap:6px; margin-top:12px;">
+          <button id="dmPreview" style="flex:1; background:var(--success); color:#fff; border-color:var(--success);">🧮 Calcular preview</button>
+          <button class="btn-secondary" id="dmCancelar">Cancelar</button>
+        </div>
+      </div>
+    </div>`;
+
+  // Handlers
+  document.querySelectorAll('[data-toggle-tipo]').forEach(b => b.onclick = () => {
+    state.tipoPropostaAtivo = b.dataset.toggleTipo;
+    state.consultoriaView = 'lista';
+    render();
+  });
+  const voltarParaEscolha = () => {
+    state.consultoriaFormCache = null;
+    state.consultoriaAnexosTemp = [];
+    state.consultoriaAnexosExistentes = [];
+    if (state.consultoriaEditandoId) {
+      state.consultoriaEditandoId = null;
+      state.consultoriaPropostaOriginal = null;
+      setConsultoriaView('lista');
+    } else {
+      setConsultoriaView('escolha');
+    }
+  };
+  document.querySelector('[data-cons-voltar]').onclick = voltarParaEscolha;
+  document.getElementById('dmCancelar').onclick = voltarParaEscolha;
+  document.getElementById('dmNovoCliente').onclick = () => abrirCadastroClienteModal(subtipo);
+
+  if (cache?.cliente_id) document.getElementById('dmCliente').value = cache.cliente_id;
+  if (cache?.finalidade) document.getElementById('dmFinalidade').value = cache.finalidade;
+  if (cache?.complexidade) document.getElementById('dmComplex').value = cache.complexidade;
+
+  // Validação live: Σ marcos === num_vertices quando piqueteamento marcado
+  function recalcMarcosCheck() {
+    const piquet = document.getElementById('dmPiquet').checked;
+    const v = parseInt(document.getElementById('dmVertices').value, 10) || 0;
+    const c = parseInt(document.getElementById('dmMarcoConcreto').value, 10) || 0;
+    const t = parseInt(document.getElementById('dmMarcoTubo').value, 10) || 0;
+    const m = parseInt(document.getElementById('dmMarcoMadeira').value, 10) || 0;
+    const soma = c + t + m;
+    const el = document.getElementById('dmMarcosCheck');
+    if (piquet) {
+      if (soma === v && v >= 3) {
+        el.textContent = `✔ Σ marcos (${soma}) = nº de vértices (${v})`;
+        el.style.color = '#10b981';
+      } else {
+        el.textContent = `⚠ Σ marcos (${soma}) ≠ nº de vértices (${v}). Em piqueteamento, devem ser iguais.`;
+        el.style.color = '#ff3366';
+      }
+    } else {
+      el.textContent = `Piqueteamento desativado — Σ marcos livre.`;
+      el.style.color = 'var(--text-muted)';
+    }
+  }
+  ['dmPiquet', 'dmVertices', 'dmMarcoConcreto', 'dmMarcoTubo', 'dmMarcoMadeira'].forEach(id => {
+    document.getElementById(id).addEventListener('input', recalcMarcosCheck);
+    document.getElementById(id).addEventListener('change', recalcMarcosCheck);
+  });
+  recalcMarcosCheck();
+
+  function montarDadosImovel() {
+    const finalidade = document.getElementById('dmFinalidade').value;
+    const num_vertices = parseInt(document.getElementById('dmVertices').value, 10) || 0;
+    const piquet = document.getElementById('dmPiquet').checked;
+    const c = parseInt(document.getElementById('dmMarcoConcreto').value, 10) || 0;
+    const t = parseInt(document.getElementById('dmMarcoTubo').value, 10) || 0;
+    const m = parseInt(document.getElementById('dmMarcoMadeira').value, 10) || 0;
+    const marcos = [];
+    // Valor unitário CONGELADO na submissão (lido da tabela pricing-params espelhada no front)
+    const VU = { concreto: 120, tubo_galvanizado: 85, madeira: 35 };
+    if (c > 0) marcos.push({ tipo: 'concreto',         quantidade: c, valor_unitario_congelado: VU.concreto });
+    if (t > 0) marcos.push({ tipo: 'tubo_galvanizado', quantidade: t, valor_unitario_congelado: VU.tubo_galvanizado });
+    if (m > 0) marcos.push({ tipo: 'madeira',          quantidade: m, valor_unitario_congelado: VU.madeira });
+
+    const opcionais = {};
+    if (document.getElementById('dmOpcLaudo').checked)
+      opcionais.laudo_tecnico = { contratado: true, valor_unitario_sm_multiplicador: 1.0 };
+    if (document.getElementById('dmOpcAlinh').checked)
+      opcionais.alinhamento_cerca = { contratado: true, metros: parseFloat(document.getElementById('dmOpcAlinhM').value) || 0, valor_unitario: 4.5 };
+    if (document.getElementById('dmOpcCroqui').checked)
+      opcionais.croqui_assinado = { contratado: true, valor_unitario: 180 };
+    if (document.getElementById('dmOpcAcomp').checked)
+      opcionais.acompanhamento_obra = { contratado: true, diarias: parseInt(document.getElementById('dmOpcAcompD').value, 10) || 0, valor_unitario: 350 };
+    if (document.getElementById('dmOpcJurid').checked)
+      opcionais.consultoria_juridica = { contratado: true, valor: 'sob_orcamento' };
+
+    const dados = {
+      subtipo, finalidade,
+      municipio: document.getElementById('dmMunicipio').value.trim(),
+      uf: document.getElementById('dmUf').value.trim(),
+      matricula: document.getElementById('dmMatricula').value.trim() || undefined,
+      cri: document.getElementById('dmCri').value.trim() || undefined,
+      perimetro_m: parseFloat(document.getElementById('dmPerimetro').value) || undefined,
+      num_vertices,
+      servico_piqueteamento: piquet,
+      marcos,
+      diarias_equipe: parseInt(document.getElementById('dmDiarias').value, 10) || 1,
+      km_deslocamento: parseFloat(document.getElementById('dmKm').value) || 0,
+      complexidade: document.getElementById('dmComplex').value,
+      valor_unitario_area: parseFloat(document.getElementById('dmValUnit').value) || undefined,
+      desconto_pct: parseFloat(document.getElementById('dmDesc').value) || 0,
+      validade_dias: parseInt(document.getElementById('dmValidade').value, 10) || 15,
+      opcionais,
+    };
+    if (isUrbana) {
+      dados.loteamento_nome = document.getElementById('dmLoteamento').value.trim() || undefined;
+      dados.quadra = document.getElementById('dmQuadra').value.trim() || undefined;
+      dados.lote = document.getElementById('dmLote').value.trim() || undefined;
+      dados.area_m2 = parseFloat(document.getElementById('dmAreaM2').value) || undefined;
+    } else {
+      dados.denominacao_imovel = document.getElementById('dmDenom').value.trim() || undefined;
+      dados.ccir = document.getElementById('dmCcir').value.trim() || undefined;
+      dados.area_hectares = parseFloat(document.getElementById('dmAreaHa').value) || undefined;
+    }
+    return dados;
+  }
+
+  document.getElementById('dmPreview').onclick = async () => {
+    const cli = document.getElementById('dmCliente').value;
+    if (!cli) { alert('Selecione um cliente'); return; }
+    const dados = montarDadosImovel();
+    // Cache do form pra restaurar ao voltar
+    state.consultoriaFormCache = {
+      subtipo, cliente_id: cli,
+      endereco: document.getElementById('dmEndereco').value,
+      ...dados,
+      marcos_concreto: parseInt(document.getElementById('dmMarcoConcreto').value, 10) || 0,
+      marcos_tubo: parseInt(document.getElementById('dmMarcoTubo').value, 10) || 0,
+      marcos_madeira: parseInt(document.getElementById('dmMarcoMadeira').value, 10) || 0,
+    };
+    try {
+      const r = await api('/api/propostas-consultoria/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subtipo, dados_imovel: dados }),
+      });
+      state.consultoriaPreviewData = {
+        ctx: {
+          subtipo,
+          cliente_id: cli,
+          endereco_imovel: document.getElementById('dmEndereco').value,
+          dados_imovel: dados,
+          validade_dias: dados.validade_dias,
+        },
+        resultado: {
+          custos: r.custos,
+          valor_total: r.valor_total,
+          fontes: r.fontes || {},
+        },
+      };
+      setConsultoriaView('preview');
+    } catch (err) {
+      alert('Falha ao calcular preview: ' + (err.message || err));
+    }
+  };
+}
 
 async function renderConsultoriaFormProjetoExecutivo(v, toggleHTML) {
   await loadPropostasClientes();

--- a/src/public/recibo-validar.html
+++ b/src/public/recibo-validar.html
@@ -123,6 +123,41 @@
     cancelado:'⊘ Cancelado'
   };
 
+  // v3.27.0: aviso DRL adaptado para Demarcacao de Lotes (4 finalidades:
+  // demarcacao_inicial, redemarcacao, subdivisao_lote, piqueteamento_apenas).
+  // Reforco SO em subdivisao_lote.
+  function avisoDRLDemarcacaoHtml(finalidade) {
+    const f = finalidade || 'demarcacao_inicial';
+    const paragrafos = [
+      `Em qualquer trabalho de demarcação física de lote, a coleta de <strong>Declarações de Respeito de Limite</strong> (DRLs) dos confrontantes é <strong>OBRIGAÇÃO LEGAL E EXCLUSIVA</strong> do proprietário, conforme Lei nº 10.267/2001, NTGIR 3ª Ed. (INCRA) e Provimento CNJ nº 65/2017.`,
+      `A Romatec <strong>GERA</strong> os documentos técnicos (planta, memorial, croqui), mas <strong>NÃO COLETA</strong> as DRLs nem reconhece firma — esse é ato pessoal do proprietário perante cartório.`,
+      `Sem DRL com <strong>RECONHECIMENTO DE FIRMA EM CARTÓRIO</strong> de todos os confrontantes, o cartório de imóveis <strong>NÃO AVERBA</strong> a demarcação na matrícula, mesmo após instalação física dos marcos.`,
+    ];
+    let finalP = '';
+    if (f === 'subdivisao_lote') {
+      finalP = `<p class="reforco"><strong>⚠ ATENÇÃO REFORÇADA — SUBDIVISÃO DE LOTE:</strong> ausência de DRL impede a <strong>abertura de novas matrículas</strong> para as frações resultantes, mesmo que o desmembramento tenha sido aprovado pela Prefeitura.</p>`;
+    }
+    return `
+      <div class="aviso-drl">
+        <h3>⚠ Responsabilidade do Proprietário — DRL (Declaração de Respeito de Limite)</h3>
+        ${paragrafos.map(p => `<p>${p}</p>`).join('')}
+        ${finalP}
+      </div>`;
+  }
+
+  const FINALIDADE_DEMARCACAO_TEXTOS = {
+    demarcacao_inicial: 'Demarcação inicial — implantação física dos vértices definidos em projeto.',
+    redemarcacao: 'Redemarcação — repiqueteamento de vértices perdidos/deteriorados.',
+    subdivisao_lote: 'Subdivisão de lote — demarcação das frações resultantes de desmembramento aprovado.',
+    piqueteamento_apenas: 'Piqueteamento — implantação de marcos sem novo levantamento de campo.',
+  };
+
+  const MATERIAL_MARCO_LABEL = {
+    concreto: 'Marco de concreto padrão INCRA',
+    tubo_galvanizado: 'Marco em tubo galvanizado',
+    madeira: 'Piquete de madeira de lei',
+  };
+
   // v3.23.5: monta o HTML do aviso DRL (espelha renderAvisoDRL do PDF).
   // Texto regulamentar fixo — sempre presente em proposta de georref_rural,
   // qualquer finalidade. Reforco adicional para RETIFICACAO; paragrafo extra
@@ -205,9 +240,99 @@
       // v3.23.5: render proposta — especial pro subtipo georreferenciamento_rural
       // (mostra finalidade + opcionais contratados). Outros subtipos mostram
       // resumo basico (numero, cliente, valor, validade).
+      // v3.27.0: render dedicado para demarcacao_urbana / demarcacao_rural.
       const p = payload.proposta;
       const dados = p.dados_imovel || {};
-      const isGeo = (p.subtipo_consultoria || p.subtipo) === 'georreferenciamento_rural';
+      const subtipoEff = p.subtipo_consultoria || p.subtipo;
+      const isGeo = subtipoEff === 'georreferenciamento_rural';
+      const isDemarc = subtipoEff === 'demarcacao_urbana' || subtipoEff === 'demarcacao_rural';
+
+      if (isDemarc) {
+        const statusUpD = String(p.status || '').toUpperCase();
+        const statusClassD =
+          statusUpD === 'APROVADA' ? 'status-ok' :
+          statusUpD === 'EXPIRADA' || statusUpD === 'CANCELADA' ? 'status-no' :
+          'status-pending';
+        const finD = dados.finalidade || 'demarcacao_inicial';
+        const finTexto = FINALIDADE_DEMARCACAO_TEXTOS[finD] || finD;
+        const isUrbana = subtipoEff === 'demarcacao_urbana';
+        const marcos = Array.isArray(dados.marcos) ? dados.marcos : [];
+        const marcosHtml = marcos.length > 0
+          ? `<div class="card">
+               <h2>Marcos a implantar</h2>
+               <ul style="font-size:13px;color:#333;line-height:1.7;margin-left:18px">
+                 ${marcos.map(m => `<li>${m.quantidade}× ${escapeHtml(MATERIAL_MARCO_LABEL[m.tipo] || m.tipo)}</li>`).join('')}
+               </ul>
+             </div>`
+          : '';
+        const cm = dados.codigos_mintados;
+        const codigosHtml = cm
+          ? `<div class="card">
+               <h2>Códigos FQNS atribuídos (rastreabilidade INCRA)</h2>
+               <dl>
+                 <dt>Prefixo</dt><dd><strong>${escapeHtml(cm.prefixo || 'FQNS')}</strong></dd>
+                 <dt>Vértices</dt><dd>${(cm.vertices||[]).length} (${(cm.vertices||[])[0] || '-'} ${cm.vertices && cm.vertices.length>1 ? 'a ' + cm.vertices[cm.vertices.length-1] : ''})</dd>
+                 <dt>Concreto</dt><dd>${(cm.marcos_por_tipo?.concreto||[]).length}</dd>
+                 <dt>Tubo galv.</dt><dd>${(cm.marcos_por_tipo?.tubo_galvanizado||[]).length}</dd>
+                 <dt>Madeira</dt><dd>${(cm.marcos_por_tipo?.madeira||[]).length}</dd>
+                 <dt>Atribuído em</dt><dd>${escapeHtml(fmtData(cm.mintado_em))}</dd>
+               </dl>
+             </div>`
+          : '';
+        const opc = dados.opcionais || {};
+        const opcContratados = [];
+        if (opc.laudo_tecnico?.contratado) opcContratados.push('<li>Laudo Técnico de Demarcação</li>');
+        if (opc.alinhamento_cerca?.contratado) opcContratados.push(`<li>Alinhamento de Cerca — ${opc.alinhamento_cerca.metros||0} m × ${fmtBRL(opc.alinhamento_cerca.valor_unitario||0)}</li>`);
+        if (opc.croqui_assinado?.contratado) opcContratados.push(`<li>Croqui Assinado em Cartório — ${fmtBRL(opc.croqui_assinado.valor_unitario||0)}</li>`);
+        if (opc.acompanhamento_obra?.contratado) opcContratados.push(`<li>Acompanhamento de Obra — ${opc.acompanhamento_obra.diarias||0} diária(s) × ${fmtBRL(opc.acompanhamento_obra.valor_unitario||0)}</li>`);
+        if (opc.consultoria_juridica?.contratado) opcContratados.push('<li>Consultoria Jurídica — <em>Sob orçamento</em></li>');
+        const opcHtml = opcContratados.length > 0
+          ? `<div class="card"><h2>Serviços adicionais opcionais</h2><ul style="font-size:13px;color:#333;line-height:1.7;margin-left:18px">${opcContratados.join('')}</ul></div>`
+          : '';
+
+        root.innerHTML = `
+          ${headerHtml}
+          <div class="stamp">
+            <div class="check">✓</div>
+            <h1>Proposta autenticada</h1>
+            <p>Documento emitido oficialmente pelo sistema</p>
+          </div>
+          <div class="card">
+            <h2>Detalhes da proposta</h2>
+            <dl>
+              <dt>Número</dt><dd>${escapeHtml(p.numero || '-')}</dd>
+              <dt>Status</dt><dd><span class="status ${statusClassD}">${escapeHtml(statusUpD || 'RASCUNHO')}</span></dd>
+              <dt>Cliente</dt><dd>${escapeHtml(p.cliente?.nome || '-')}</dd>
+              ${p.cliente?.cpf_cnpj ? `<dt>Documento</dt><dd>${escapeHtml(p.cliente.cpf_cnpj)}</dd>` : ''}
+              <dt>Município</dt><dd>${escapeHtml(dados.municipio || '-')}${dados.uf ? '/'+escapeHtml(dados.uf) : ''}</dd>
+              ${dados.matricula ? `<dt>Matrícula</dt><dd>${escapeHtml(dados.matricula)}</dd>` : ''}
+              ${isUrbana && dados.area_m2 ? `<dt>Área</dt><dd>${Number(dados.area_m2).toLocaleString('pt-BR',{minimumFractionDigits:2})} m²</dd>` : ''}
+              ${!isUrbana && dados.area_hectares ? `<dt>Área</dt><dd>${Number(dados.area_hectares).toLocaleString('pt-BR',{minimumFractionDigits:4})} ha</dd>` : ''}
+              <dt>Vértices</dt><dd>${dados.num_vertices || '-'}</dd>
+              <dt>Valor total</dt><dd><strong>${escapeHtml(fmtBRL(p.valor_total))}</strong></dd>
+              <dt>Emitida em</dt><dd>${escapeHtml(fmtData(p.data_proposta || p.criado_em))}</dd>
+              <dt>Validade</dt><dd>${p.validade_dias || 15} dias</dd>
+            </dl>
+            <a href="/v/${encodeURIComponent(hash)}/pdf" class="pdf-link">📄 Abrir PDF original</a>
+          </div>
+          <div class="card" style="background:#fef3c7;border:1px solid #d97706">
+            <h2 style="color:#92400e">Finalidade</h2>
+            <p style="font-size:13px;color:#111;font-weight:600">${escapeHtml(finTexto)}</p>
+          </div>
+          ${marcosHtml}
+          ${codigosHtml}
+          ${opcHtml}
+          ${avisoDRLDemarcacaoHtml(finD)}
+          <div class="card">
+            <h2>Hash de autenticidade</h2>
+            <div class="hash-box">${escapeHtml(p.hash_validacao || hash)}</div>
+            <p style="font-size:11px;color:#9ca3af;margin-top:8px">
+              Este hash é único e imutável. Vinculado ao conteúdo do PDF no momento da emissão.
+            </p>
+          </div>`;
+        return;
+      }
+
       const statusUp = String(p.status || '').toUpperCase();
       const statusClass =
         statusUp === 'APROVADA' ? 'status-ok' :

--- a/src/server.ts
+++ b/src/server.ts
@@ -4142,6 +4142,17 @@ app.listen(PORT, () => {
     }
   })();
 
+  // v3.27.0: credencial INCRA do tecnico (FQNS prefixo + contadores vitalicios).
+  // Migration idempotente em users (auth SaaS) — ZERO ALTER em propostas.
+  void (async () => {
+    try {
+      const m = await import('./database/migrations-usuarios-credencial-incra');
+      await m.runMigrationsUsuariosCredencialIncra();
+    } catch (err) {
+      console.error('[MigrationUsuariosCredencial] FALHA fatal:', err);
+    }
+  })();
+
   // v3.17.0: tabela laudos_demarcacao_arquivos (anexos vetoriais DXF/DWG/KML)
   // + seeds de configurações de upload/download em `configuracoes`.
   void (async () => {

--- a/src/services/pricing/demarcacaoLotes.test.ts
+++ b/src/services/pricing/demarcacaoLotes.test.ts
@@ -1,0 +1,247 @@
+// v3.27.0: testes do engine de Demarcacao de Lotes (Urbana e Rural).
+// Cobre validacoes, cenarios canonicos, guard de fechamento, opcionais e
+// runtime read de SALARIO_MINIMO_VIGENTE.
+
+import { describe, it, expect } from 'vitest';
+import { calcularDemarcacaoLotes } from './demarcacaoLotes';
+import type { InputDemarcacaoLotes, MarcoDiscriminado } from './types';
+
+const SM_2026 = 1621.0; // pricing-params.salario_minimo_2026
+
+function marcoConcreto(qtd: number): MarcoDiscriminado {
+  return { tipo: 'concreto', quantidade: qtd, valor_unitario_congelado: 120.0 };
+}
+function marcoTubo(qtd: number): MarcoDiscriminado {
+  return { tipo: 'tubo_galvanizado', quantidade: qtd, valor_unitario_congelado: 85.0 };
+}
+function marcoMadeira(qtd: number): MarcoDiscriminado {
+  return { tipo: 'madeira', quantidade: qtd, valor_unitario_congelado: 35.0 };
+}
+
+const baseUrbana: InputDemarcacaoLotes = {
+  subtipo: 'demarcacao_urbana',
+  finalidade: 'demarcacao_inicial',
+  municipio: 'Acailandia',
+  uf: 'MA',
+  area_m2: 500,
+  num_vertices: 8,
+  servico_piqueteamento: true,
+  marcos: [marcoConcreto(8)],
+  diarias_equipe: 2,
+  km_deslocamento: 30,
+  complexidade: 'media',
+};
+
+const baseRural: InputDemarcacaoLotes = {
+  subtipo: 'demarcacao_rural',
+  finalidade: 'demarcacao_inicial',
+  municipio: 'Acailandia',
+  uf: 'MA',
+  area_hectares: 5,
+  num_vertices: 12,
+  servico_piqueteamento: true,
+  marcos: [marcoConcreto(8), marcoMadeira(4)],
+  diarias_equipe: 2,
+  km_deslocamento: 60,
+  complexidade: 'alta',
+};
+
+describe('calcularDemarcacaoLotes — validacoes', () => {
+  it('1. Urbana valida (area_m2 preenchida, area_hectares undefined)', () => {
+    const r = calcularDemarcacaoLotes(baseUrbana);
+    expect(r.honorarios_romatec.total).toBeGreaterThan(0);
+  });
+
+  it('2. Rural valida (area_hectares preenchida, area_m2 undefined)', () => {
+    const r = calcularDemarcacaoLotes(baseRural);
+    expect(r.honorarios_romatec.total).toBeGreaterThan(0);
+  });
+
+  it('3. Ambas areas preenchidas (urbana) -> throw', () => {
+    expect(() => calcularDemarcacaoLotes({ ...baseUrbana, area_hectares: 1 } as InputDemarcacaoLotes))
+      .toThrow(/nao deve informar area_hectares/);
+  });
+
+  it('4. Rural sem area_hectares -> throw', () => {
+    const bad = { ...baseRural, area_hectares: undefined } as unknown as InputDemarcacaoLotes;
+    expect(() => calcularDemarcacaoLotes(bad)).toThrow(/area_hectares/);
+  });
+
+  it('5. piqueteamento=true + Σmarcos=num_vertices -> aceita', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      num_vertices: 10,
+      marcos: [marcoConcreto(6), marcoTubo(4)],
+    });
+    expect(r.honorarios_romatec.marcos_subtotal).toBeCloseTo(6 * 120 + 4 * 85, 2);
+  });
+
+  it('6. piqueteamento=true + Σmarcos ≠ num_vertices -> throw', () => {
+    expect(() => calcularDemarcacaoLotes({
+      ...baseUrbana,
+      num_vertices: 8,
+      marcos: [marcoConcreto(5)],
+    })).toThrow(/servico_piqueteamento=true exige/);
+  });
+
+  it('7. piqueteamento=false + marcos=[] -> aceita', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      servico_piqueteamento: false,
+      marcos: [],
+    });
+    expect(r.honorarios_romatec.marcos_subtotal).toBe(0);
+  });
+
+  it('8. piqueteamento=false + marcos com Σ != vertices -> aceita', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      servico_piqueteamento: false,
+      num_vertices: 8,
+      marcos: [marcoConcreto(3)],
+    });
+    expect(r.honorarios_romatec.marcos_subtotal).toBeCloseTo(360, 2);
+  });
+});
+
+describe('calcularDemarcacaoLotes — calculo principal', () => {
+  it('9. Marcos discriminados: 3 tipos diferentes -> subtotais separados', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseRural,
+      num_vertices: 12,
+      marcos: [marcoConcreto(4), marcoTubo(3), marcoMadeira(5)],
+    });
+    const md = r.honorarios_romatec.marcos_discriminados;
+    expect(md).toHaveLength(3);
+    const concreto = md.find((m) => m.tipo === 'concreto');
+    const tubo = md.find((m) => m.tipo === 'tubo_galvanizado');
+    const madeira = md.find((m) => m.tipo === 'madeira');
+    expect(concreto?.subtotal).toBeCloseTo(4 * 120, 2);
+    expect(tubo?.subtotal).toBeCloseTo(3 * 85, 2);
+    expect(madeira?.subtotal).toBeCloseTo(5 * 35, 2);
+    expect(r.honorarios_romatec.marcos_subtotal).toBeCloseTo(4 * 120 + 3 * 85 + 5 * 35, 2);
+  });
+
+  it('10. Cenario canonico urbano: 500m² · 8 vertices · 8 concreto · 2 diarias · 30km · media · 10% desc', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, desconto_pct: 10 });
+    const h = r.honorarios_romatec;
+    expect(h.trt_cft).toBe(93.4);
+    expect(h.tecnicos_campo).toBeCloseTo(2 * SM_2026 * 0.42, 2);
+    expect(h.marcos_subtotal).toBeCloseTo(960, 2);
+    expect(h.deslocamento).toBeCloseTo(105, 2);
+    expect(h.area_servico).toBeCloseTo(750, 2);
+    expect(h.complexidade_multiplicador).toBe(1.3);
+    // total fecha com guard interno; teste auto-consistente
+    expect(h.total).toBeGreaterThan(0);
+  });
+
+  it('11. Cenario canonico rural: 5ha · 12 vertices · 8 concreto + 4 madeira · alta', () => {
+    const r = calcularDemarcacaoLotes(baseRural);
+    const h = r.honorarios_romatec;
+    expect(h.complexidade_multiplicador).toBe(1.6);
+    expect(h.area_servico).toBeCloseTo(5 * 80, 2);
+    expect(h.marcos_subtotal).toBeCloseTo(8 * 120 + 4 * 35, 2);
+    expect(h.total).toBeGreaterThan(0);
+  });
+
+  it('12. Guard de fechamento em simples/media/alta', () => {
+    for (const complexidade of ['simples', 'media', 'alta'] as const) {
+      const r = calcularDemarcacaoLotes({ ...baseUrbana, complexidade });
+      const soma = r.parcelas.reduce((s, p) => s + p.valor, 0);
+      expect(Math.abs(soma - r.honorarios_romatec.total)).toBeLessThan(0.02);
+    }
+  });
+
+  it('13. Minimo garantido (2 SM) aplicado quando calculo fica abaixo', () => {
+    const r = calcularDemarcacaoLotes({
+      subtipo: 'demarcacao_urbana',
+      finalidade: 'piqueteamento_apenas',
+      municipio: 'X',
+      uf: 'MA',
+      area_m2: 0.01,
+      num_vertices: 3,
+      servico_piqueteamento: false,
+      marcos: [],
+      diarias_equipe: 1,
+      km_deslocamento: 0,
+      complexidade: 'simples',
+    });
+    const minimo = 2 * SM_2026;
+    expect(r.honorarios_romatec.total).toBe(Math.round(minimo * 100) / 100);
+  });
+
+  it('14. Desconto 0% nao altera valor', () => {
+    const r0 = calcularDemarcacaoLotes({ ...baseUrbana, desconto_pct: 0 });
+    const rDef = calcularDemarcacaoLotes(baseUrbana);
+    expect(r0.honorarios_romatec.total).toBe(rDef.honorarios_romatec.total);
+    expect(r0.honorarios_romatec.desconto_valor).toBe(0);
+  });
+
+  it('15. Desconto 31% -> throw', () => {
+    expect(() => calcularDemarcacaoLotes({ ...baseUrbana, desconto_pct: 31 }))
+      .toThrow(/desconto_pct invalido/);
+  });
+
+  it('16. Override de valor_unitario_area substitui o default', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, valor_unitario_area: 5 });
+    expect(r.honorarios_romatec.area_servico).toBeCloseTo(500 * 5, 2);
+  });
+
+  it('17. R$/km lido de pricing-params, nao hardcoded', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, km_deslocamento: 100 });
+    // valor_km_deslocamento default = 3.50 (pricing-params)
+    expect(r.honorarios_romatec.deslocamento).toBeCloseTo(100 * 3.5, 2);
+  });
+});
+
+describe('calcularDemarcacaoLotes — opcionais', () => {
+  it('18. Opcionais: 5 linhas sempre, mesmo com nenhum contratado', () => {
+    const r = calcularDemarcacaoLotes(baseUrbana);
+    expect(r.secao_opcionais_demarcacao.linhas).toHaveLength(5);
+    expect(r.secao_opcionais_demarcacao.subtotal).toBe(0);
+  });
+
+  it('19. alinhamento_cerca com metros=120 -> subtotal = 120 × 4.50', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      opcionais: { alinhamento_cerca: { contratado: true, metros: 120, valor_unitario: 4.5 } },
+    });
+    const linha = r.secao_opcionais_demarcacao.linhas.find((l) => /Alinhamento/i.test(l.rotulo));
+    expect(linha?.valor).toBeCloseTo(120 * 4.5, 2);
+    expect(linha?.contratado).toBe(true);
+  });
+
+  it('20. consultoria_juridica = "sob_orcamento" (string literal)', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      opcionais: { consultoria_juridica: { contratado: true, valor: 'sob_orcamento' } },
+    });
+    const linha = r.secao_opcionais_demarcacao.linhas.find((l) => /Juridica/i.test(l.rotulo));
+    expect(linha?.valor).toBe('sob_orcamento');
+    expect(linha?.contratado).toBe(true);
+  });
+
+  it('21. Opcionais NAO somam ao total Romatec', () => {
+    const semOpc = calcularDemarcacaoLotes(baseUrbana);
+    const comOpc = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      opcionais: {
+        laudo_tecnico: { contratado: true, valor_unitario_sm_multiplicador: 1.0 },
+        alinhamento_cerca: { contratado: true, metros: 100, valor_unitario: 4.5 },
+        croqui_assinado: { contratado: true, valor_unitario: 180 },
+      },
+    });
+    expect(comOpc.honorarios_romatec.total).toBe(semOpc.honorarios_romatec.total);
+    expect(comOpc.secao_opcionais_demarcacao.subtotal).toBeGreaterThan(0);
+  });
+
+  it('22. SALARIO_MINIMO_VIGENTE mudado em runtime -> novo calculo reflete', () => {
+    const r1 = calcularDemarcacaoLotes(baseUrbana, { salarioMinimoOverride: 1500 });
+    const r2 = calcularDemarcacaoLotes(baseUrbana, { salarioMinimoOverride: 2000 });
+    expect(r1.honorarios_romatec.tecnicos_campo).toBeCloseTo(2 * 1500 * 0.42, 2);
+    expect(r2.honorarios_romatec.tecnicos_campo).toBeCloseTo(2 * 2000 * 0.42, 2);
+    expect(r2.honorarios_romatec.tecnicos_campo).toBeGreaterThan(r1.honorarios_romatec.tecnicos_campo);
+    expect(r1.salario_minimo_usado).toBe(1500);
+    expect(r2.salario_minimo_usado).toBe(2000);
+  });
+});

--- a/src/services/pricing/demarcacaoLotes.ts
+++ b/src/services/pricing/demarcacaoLotes.ts
@@ -1,0 +1,308 @@
+// v3.27.0: motor de calculo de Demarcacao de Lotes (Urbana e Rural).
+// Espelha 1:1 o padrao da v3.23.5 (Georref Rural PROP-2026-0011-R1):
+//   - TRT/CFT em linha propria (R$ 93,40 tabela CFT 2026)
+//   - Tecnicos de campo: diarias * SM * fator_diaria_tecnico (CFT-MA Res. 12/2025)
+//   - Marcos discriminados por tipo (valor congelado por linha)
+//   - Deslocamento por km
+//   - Area * valor unitario (m2 urbano OU hectare rural)
+//   - Multiplicador de complexidade (simples 1.0 / media 1.3 / alta 1.6)
+//   - Assessoria 5% sobre subtotal apos complexidade
+//   - Desconto sobre (subtotal + assessoria)
+//   - Minimo garantido 2 SM
+//   - 3 parcelas 40/30/30
+//   - Opcionais NAO somam (secao informativa propria)
+//
+// Modulo standalone (zero deps de mysql/pdfkit/voyageai) — testavel sem arrastar
+// integracoes. So importa round2 de georreferenciamento.ts (sem alterar logica
+// daquele modulo, que esta na lista de PROIBIDO MODIFICAR).
+//
+// Base normativa:
+//   - Lei 10.267/2001 (CNIR)
+//   - NTGIR 3a Edicao (INCRA) — codificacao de marcos com credencial do tecnico
+//   - Lei 6.766/79 (parcelamento de solo urbano) + Lei 5.868/72 (CNIR rural)
+//   - Tabela CFT 2026 — Tec. em Agrimensura CFT/MA no 01209185369
+
+import type {
+  InputDemarcacaoLotes,
+  DemarcacaoLotesOutput,
+  MaterialMarco,
+  OpcionaisDemarcacao,
+} from './types';
+import { round2 } from './georreferenciamento';
+import { getParams, salarioMinimo, anotacaoTecnica } from './params';
+
+const COMPLEX_KEYS: Array<'simples' | 'media' | 'alta'> = ['simples', 'media', 'alta'];
+
+export interface CalcularDemarcacaoLotesOpts {
+  // Permite injetar SM customizado nos testes; default: lerSalarioMinimoVigenteRuntime()
+  salarioMinimoOverride?: number;
+}
+
+export function calcularDemarcacaoLotes(
+  input: InputDemarcacaoLotes,
+  opts: CalcularDemarcacaoLotesOpts = {},
+): DemarcacaoLotesOutput {
+  const params = getParams();
+  const cfg = params.demarcacao_lotes_2026;
+  if (!cfg) throw new Error('Bloco demarcacao_lotes_2026 ausente em pricing-params.json');
+
+  const SM = opts.salarioMinimoOverride ?? salarioMinimo();
+  if (!Number.isFinite(SM) || SM <= 0) {
+    throw new Error(`Salario minimo invalido: ${SM}`);
+  }
+
+  // ── Validacoes ─────────────────────────────────────────────────────────
+  if (input.subtipo !== 'demarcacao_urbana' && input.subtipo !== 'demarcacao_rural') {
+    throw new Error(`subtipo invalido: ${input.subtipo} (esperado: demarcacao_urbana | demarcacao_rural)`);
+  }
+
+  if (input.subtipo === 'demarcacao_urbana') {
+    if (!Number.isFinite(input.area_m2 as number) || (input.area_m2 as number) <= 0) {
+      throw new Error('subtipo=demarcacao_urbana exige area_m2 > 0');
+    }
+    if (input.area_hectares != null) {
+      throw new Error('subtipo=demarcacao_urbana nao deve informar area_hectares');
+    }
+  } else {
+    if (!Number.isFinite(input.area_hectares as number) || (input.area_hectares as number) <= 0) {
+      throw new Error('subtipo=demarcacao_rural exige area_hectares > 0');
+    }
+    if (input.area_m2 != null) {
+      throw new Error('subtipo=demarcacao_rural nao deve informar area_m2');
+    }
+  }
+
+  if (!Number.isFinite(input.num_vertices) || input.num_vertices < 3) {
+    throw new Error('num_vertices deve ser >= 3 (poligonal minima)');
+  }
+
+  if (!COMPLEX_KEYS.includes(input.complexidade)) {
+    throw new Error(`complexidade invalida: ${input.complexidade} (esperado: simples | media | alta)`);
+  }
+
+  const desconto_pct = Number(input.desconto_pct ?? 0);
+  if (!Number.isFinite(desconto_pct) || desconto_pct < 0 || desconto_pct > cfg.desconto_max_pct) {
+    throw new Error(`desconto_pct invalido: ${desconto_pct} (esperado [0, ${cfg.desconto_max_pct}])`);
+  }
+
+  if (!Number.isFinite(input.diarias_equipe) || input.diarias_equipe < 1) {
+    throw new Error('diarias_equipe deve ser >= 1');
+  }
+  if (!Number.isFinite(input.km_deslocamento) || input.km_deslocamento < 0) {
+    throw new Error('km_deslocamento deve ser >= 0');
+  }
+
+  const marcos = Array.isArray(input.marcos) ? input.marcos : [];
+  const somaMarcos = marcos.reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+
+  if (input.servico_piqueteamento === true) {
+    if (somaMarcos !== input.num_vertices) {
+      throw new Error(
+        `servico_piqueteamento=true exige Σ marcos.quantidade (${somaMarcos}) === num_vertices (${input.num_vertices})`,
+      );
+    }
+  }
+  // servico_piqueteamento=false: marcos pode estar vazio OU ter qualquer soma (sem restricao).
+
+  // ── 1. TRT/CFT (tabela 2026) ──────────────────────────────────────────
+  const at = anotacaoTecnica('trt_cft');
+  const trt_cft = round2(at.valor);
+
+  // ── 2. Tecnicos de campo ─────────────────────────────────────────────
+  const tecnicos_campo = round2(input.diarias_equipe * SM * cfg.fator_diaria_tecnico);
+
+  // ── 3. Marcos discriminados ──────────────────────────────────────────
+  const marcosOrdem: MaterialMarco[] = ['concreto', 'tubo_galvanizado', 'madeira'];
+  const marcos_discriminados: { tipo: MaterialMarco; qtd: number; subtotal: number }[] = [];
+  let marcos_subtotal = 0;
+  for (const tipo of marcosOrdem) {
+    const itensTipo = marcos.filter((m) => m.tipo === tipo);
+    const qtd = itensTipo.reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+    const subtotal = round2(
+      itensTipo.reduce(
+        (s, m) => s + (Number(m.quantidade) || 0) * (Number(m.valor_unitario_congelado) || 0),
+        0,
+      ),
+    );
+    if (qtd > 0) {
+      marcos_discriminados.push({ tipo, qtd, subtotal });
+      marcos_subtotal = round2(marcos_subtotal + subtotal);
+    }
+  }
+
+  // ── 4. Deslocamento ──────────────────────────────────────────────────
+  const valor_km = cfg.valor_km_deslocamento;
+  const deslocamento = round2(input.km_deslocamento * valor_km);
+
+  // ── 5. Area * valor unitario ─────────────────────────────────────────
+  let area_servico = 0;
+  if (input.subtipo === 'demarcacao_urbana') {
+    const vUnit = input.valor_unitario_area ?? cfg.valor_m2_urbano_default;
+    area_servico = round2((input.area_m2 as number) * vUnit);
+  } else {
+    const vUnit = input.valor_unitario_area ?? cfg.valor_hectare_rural_default;
+    area_servico = round2((input.area_hectares as number) * vUnit);
+  }
+
+  // ── 6. Subtotal bruto ────────────────────────────────────────────────
+  const subtotal_bruto = round2(trt_cft + tecnicos_campo + marcos_subtotal + deslocamento + area_servico);
+
+  // ── 7. Complexidade ──────────────────────────────────────────────────
+  const complexidade_multiplicador = cfg.complexidade_multiplicadores[input.complexidade];
+  const subtotal_apos_complexidade = round2(subtotal_bruto * complexidade_multiplicador);
+
+  // ── 8. Assessoria ────────────────────────────────────────────────────
+  const assessoria = round2(subtotal_apos_complexidade * cfg.assessoria_pct);
+
+  // ── 9. Desconto ──────────────────────────────────────────────────────
+  const base_desconto = round2(subtotal_apos_complexidade + assessoria);
+  const desconto_valor = round2((base_desconto * desconto_pct) / 100);
+
+  // ── 10. Total Romatec ────────────────────────────────────────────────
+  let total = round2(base_desconto - desconto_valor);
+
+  // ── 11. Minimo garantido ─────────────────────────────────────────────
+  const minimo = round2(cfg.minimo_garantido_sm * SM);
+  const aplicouMinimo = total < minimo;
+  if (aplicouMinimo) {
+    total = minimo;
+  }
+
+  // Guard de fechamento (defensivo — catch bug cedo)
+  const guardSubBruto = round2(trt_cft + tecnicos_campo + marcos_subtotal + deslocamento + area_servico);
+  const guardApos = round2(guardSubBruto * complexidade_multiplicador);
+  const guardComAssess = round2(guardApos + assessoria);
+  const guardFinal = round2(guardComAssess - desconto_valor);
+  if (aplicouMinimo) {
+    if (round2(total) !== round2(minimo)) {
+      throw new Error(`Guard minimo: esperado ${minimo}, obtido ${total}`);
+    }
+  } else {
+    if (round2(guardFinal) !== round2(total)) {
+      throw new Error(`Guard fechamento: esperado ${guardFinal}, obtido ${total}`);
+    }
+  }
+
+  // ── Opcionais (5 linhas sempre, NAO somam ao total) ──────────────────
+  const opcionais = input.opcionais ?? {};
+  const linhasOpcionais = montarLinhasOpcionais(opcionais, SM, cfg.opcionais);
+  const subtotalOpcionais = round2(
+    linhasOpcionais
+      .filter((l) => l.contratado && typeof l.valor === 'number')
+      .reduce((s, l) => s + (l.valor as number), 0),
+  );
+
+  // ── Parcelas 40/30/30 ────────────────────────────────────────────────
+  const parcelasCfg = cfg.parcelas;
+  const parcelasOut: { numero: 1 | 2 | 3; rotulo: string; valor: number; percentual: number }[] = parcelasCfg.map(
+    (p, i, arr) => {
+      const numero = (i + 1) as 1 | 2 | 3;
+      // Ultima parcela absorve o residuo de arredondamento pra fechar com total.
+      let valor: number;
+      if (i === arr.length - 1) {
+        const somaAnteriores = arr.slice(0, -1).reduce((s, x) => s + round2((total * x.percentual) / 100), 0);
+        valor = round2(total - somaAnteriores);
+      } else {
+        valor = round2((total * p.percentual) / 100);
+      }
+      return { numero, rotulo: p.rotulo, valor, percentual: p.percentual };
+    },
+  );
+
+  // Guard parcelas
+  const somaParcelas = round2(parcelasOut.reduce((s, p) => s + p.valor, 0));
+  if (Math.abs(somaParcelas - total) > 0.01) {
+    throw new Error(`Erro fechamento parcelas: soma=${somaParcelas} total=${total}`);
+  }
+
+  return {
+    honorarios_romatec: {
+      trt_cft,
+      tecnicos_campo,
+      marcos_discriminados,
+      marcos_subtotal,
+      deslocamento,
+      area_servico,
+      complexidade_multiplicador,
+      subtotal_apos_complexidade,
+      assessoria,
+      desconto_valor,
+      total,
+    },
+    secao_opcionais_demarcacao: {
+      linhas: linhasOpcionais,
+      subtotal: subtotalOpcionais,
+    },
+    parcelas: parcelasOut,
+    validade_dias: Number(input.validade_dias) > 0 ? Number(input.validade_dias) : cfg.validade_dias_default,
+    salario_minimo_usado: SM,
+  };
+}
+
+function montarLinhasOpcionais(
+  opcionais: OpcionaisDemarcacao,
+  SM: number,
+  cfgOpc: NonNullable<ReturnType<typeof getParams>['demarcacao_lotes_2026']>['opcionais'],
+): { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[] {
+  // 5 linhas SEMPRE renderizadas, na ordem fixa abaixo.
+  const linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[] = [];
+
+  // 1. Laudo Tecnico
+  {
+    const it = opcionais.laudo_tecnico;
+    const contratado = !!it?.contratado;
+    const mult = it?.valor_unitario_sm_multiplicador ?? cfgOpc.laudo_tecnico.valor_unitario_sm_multiplicador;
+    linhas.push({
+      rotulo: cfgOpc.laudo_tecnico.rotulo,
+      contratado,
+      valor: contratado ? round2(mult * SM) : 0,
+    });
+  }
+  // 2. Alinhamento de cerca
+  {
+    const it = opcionais.alinhamento_cerca;
+    const contratado = !!it?.contratado;
+    const metros = Number(it?.metros ?? 0);
+    const vUnit = Number(it?.valor_unitario ?? cfgOpc.alinhamento_cerca.valor_unitario);
+    linhas.push({
+      rotulo: cfgOpc.alinhamento_cerca.rotulo,
+      contratado,
+      valor: contratado ? round2(metros * vUnit) : 0,
+    });
+  }
+  // 3. Croqui assinado
+  {
+    const it = opcionais.croqui_assinado;
+    const contratado = !!it?.contratado;
+    const vUnit = Number(it?.valor_unitario ?? cfgOpc.croqui_assinado.valor_unitario);
+    linhas.push({
+      rotulo: cfgOpc.croqui_assinado.rotulo,
+      contratado,
+      valor: contratado ? round2(vUnit) : 0,
+    });
+  }
+  // 4. Acompanhamento de obra
+  {
+    const it = opcionais.acompanhamento_obra;
+    const contratado = !!it?.contratado;
+    const diarias = Number(it?.diarias ?? 0);
+    const vUnit = Number(it?.valor_unitario ?? cfgOpc.acompanhamento_obra.valor_unitario);
+    linhas.push({
+      rotulo: cfgOpc.acompanhamento_obra.rotulo,
+      contratado,
+      valor: contratado ? round2(diarias * vUnit) : 0,
+    });
+  }
+  // 5. Consultoria juridica (literal 'sob_orcamento' — NUNCA numero)
+  {
+    const it = opcionais.consultoria_juridica;
+    const contratado = !!it?.contratado;
+    linhas.push({
+      rotulo: cfgOpc.consultoria_juridica.rotulo,
+      contratado,
+      valor: 'sob_orcamento',
+    });
+  }
+
+  return linhas;
+}

--- a/src/services/pricing/mintCodigosDemarcacao.test.ts
+++ b/src/services/pricing/mintCodigosDemarcacao.test.ts
@@ -1,0 +1,182 @@
+// v3.27.0: testes do mint atomico FQNS — usa mysql2 mock + vi.fn().
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mintarCodigosDemarcacao, mintarDeltaDemarcacao } from './mintCodigosDemarcacao';
+import type { MarcoDiscriminado, CodigosMintadosFQNS } from './types';
+
+interface MockState {
+  prefixo: string | null;
+  contadores: { V: number; M_CC: number; M_TG: number; P: number };
+  commitCount: number;
+  rollbackCount: number;
+  selectQueries: string[];
+}
+
+function makeMockConn(state: MockState) {
+  const conn = {
+    beginTransaction: vi.fn(async () => {}),
+    commit: vi.fn(async () => {
+      state.commitCount++;
+    }),
+    rollback: vi.fn(async () => {
+      state.rollbackCount++;
+    }),
+    query: vi.fn(async (sql: string, _params?: unknown[]) => {
+      const sqlNorm = String(sql).replace(/\s+/g, ' ').trim();
+      state.selectQueries.push(sqlNorm);
+      if (/SELECT[\s\S]*FROM users/i.test(sqlNorm)) {
+        if (state.prefixo == null) return [[], []] as unknown;
+        return [
+          [
+            {
+              credencial_incra_prefixo: state.prefixo,
+              credencial_contadores: { ...state.contadores },
+            },
+          ],
+          [],
+        ] as unknown;
+      }
+      if (/UPDATE users/i.test(sqlNorm)) {
+        const params = _params as unknown[] | undefined;
+        if (params && typeof params[0] === 'string') {
+          state.contadores = JSON.parse(params[0]);
+        }
+        return [{ affectedRows: 1 }, []] as unknown;
+      }
+      return [[], []] as unknown;
+    }),
+  };
+  return conn as unknown as Parameters<typeof mintarCodigosDemarcacao>[0];
+}
+
+function marco(tipo: MarcoDiscriminado['tipo'], qtd: number): MarcoDiscriminado {
+  return { tipo, quantidade: qtd, valor_unitario_congelado: 100 };
+}
+
+let state: MockState;
+beforeEach(() => {
+  state = {
+    prefixo: 'FQNS',
+    contadores: { V: 0, M_CC: 0, M_TG: 0, P: 0 },
+    commitCount: 0,
+    rollbackCount: 0,
+    selectQueries: [],
+  };
+});
+
+describe('mintarCodigosDemarcacao — atomicidade FQNS (v3.27.0)', () => {
+  it('1. Vertices: 8 vertices, contador zerado -> gera V-001 a V-008 com padding 3 digitos', async () => {
+    const conn = makeMockConn(state);
+    const r = await mintarCodigosDemarcacao(conn, 1, { num_vertices: 8, marcos: [] });
+    expect(r.vertices).toEqual([
+      'FQNS-V-001', 'FQNS-V-002', 'FQNS-V-003', 'FQNS-V-004',
+      'FQNS-V-005', 'FQNS-V-006', 'FQNS-V-007', 'FQNS-V-008',
+    ]);
+    expect(state.commitCount).toBe(1);
+    expect(state.contadores.V).toBe(8);
+  });
+
+  it('2. Marcos concreto: 6 marcos -> M-0001-CC a M-0006-CC; M_TG nao incrementa', async () => {
+    const conn = makeMockConn(state);
+    const r = await mintarCodigosDemarcacao(conn, 1, {
+      num_vertices: 0,
+      marcos: [marco('concreto', 6)],
+    });
+    expect(r.marcos_por_tipo.concreto).toEqual([
+      'FQNS-M-0001-CC', 'FQNS-M-0002-CC', 'FQNS-M-0003-CC',
+      'FQNS-M-0004-CC', 'FQNS-M-0005-CC', 'FQNS-M-0006-CC',
+    ]);
+    expect(state.contadores.M_CC).toBe(6);
+    expect(state.contadores.M_TG).toBe(0);
+    expect(state.contadores.P).toBe(0);
+  });
+
+  it('3. Marcos mistos: 4 concreto + 2 tubo + 3 madeira -> 3 contadores avancam independentemente', async () => {
+    const conn = makeMockConn(state);
+    const r = await mintarCodigosDemarcacao(conn, 1, {
+      num_vertices: 9,
+      marcos: [marco('concreto', 4), marco('tubo_galvanizado', 2), marco('madeira', 3)],
+    });
+    expect(r.marcos_por_tipo.concreto).toHaveLength(4);
+    expect(r.marcos_por_tipo.tubo_galvanizado).toHaveLength(2);
+    expect(r.marcos_por_tipo.madeira).toHaveLength(3);
+    expect(r.vertices).toHaveLength(9);
+    // V-codes sem sufixo material
+    expect(r.vertices.every((c) => !/-(?:CC|TG|MD)$/.test(c))).toBe(true);
+    expect(state.contadores).toEqual({ V: 9, M_CC: 4, M_TG: 2, P: 3 });
+  });
+
+  it('4. Contador vitalicio: proposta 1 com M_CC=0001..0008, proposta 2 comeca em M_CC=0009', async () => {
+    const conn = makeMockConn(state);
+    await mintarCodigosDemarcacao(conn, 1, { num_vertices: 0, marcos: [marco('concreto', 8)] });
+    expect(state.contadores.M_CC).toBe(8);
+    const r2 = await mintarCodigosDemarcacao(conn, 1, { num_vertices: 0, marcos: [marco('concreto', 2)] });
+    expect(r2.marcos_por_tipo.concreto).toEqual(['FQNS-M-0009-CC', 'FQNS-M-0010-CC']);
+    expect(state.contadores.M_CC).toBe(10);
+  });
+
+  it('5. Delta-mint: idempotencia quando nao ha mudancas -> retorna os codigos existentes sem tocar contador', async () => {
+    const conn = makeMockConn(state);
+    const existentes: CodigosMintadosFQNS = {
+      prefixo: 'FQNS',
+      mintado_em: '2026-05-01T10:00:00.000Z',
+      vertices: ['FQNS-V-001', 'FQNS-V-002'],
+      marcos_por_tipo: { concreto: ['FQNS-M-0001-CC'], tubo_galvanizado: [], madeira: [] },
+    };
+    const r = await mintarDeltaDemarcacao(conn, 1, {
+      delta_vertices: 0,
+      delta_marcos: [],
+      codigos_existentes: existentes,
+    });
+    expect(r).toBe(existentes);
+    expect(state.contadores).toEqual({ V: 0, M_CC: 0, M_TG: 0, P: 0 });
+    expect(state.commitCount).toBe(0); // Nem chamou begin
+  });
+
+  it('6. Delta-mint em revisao: 4 concreto -> +2 -> codigos novos concatenados aos 4 originais', async () => {
+    state.contadores = { V: 8, M_CC: 4, M_TG: 0, P: 0 };
+    const conn = makeMockConn(state);
+    const existentes: CodigosMintadosFQNS = {
+      prefixo: 'FQNS',
+      mintado_em: '2026-05-01T10:00:00.000Z',
+      vertices: ['FQNS-V-001', 'FQNS-V-002', 'FQNS-V-003', 'FQNS-V-004', 'FQNS-V-005', 'FQNS-V-006', 'FQNS-V-007', 'FQNS-V-008'],
+      marcos_por_tipo: {
+        concreto: ['FQNS-M-0001-CC', 'FQNS-M-0002-CC', 'FQNS-M-0003-CC', 'FQNS-M-0004-CC'],
+        tubo_galvanizado: [],
+        madeira: [],
+      },
+    };
+    const r = await mintarDeltaDemarcacao(conn, 1, {
+      delta_vertices: 0,
+      delta_marcos: [marco('concreto', 2)],
+      codigos_existentes: existentes,
+    });
+    expect(r.marcos_por_tipo.concreto).toEqual([
+      'FQNS-M-0001-CC', 'FQNS-M-0002-CC', 'FQNS-M-0003-CC', 'FQNS-M-0004-CC',
+      'FQNS-M-0005-CC', 'FQNS-M-0006-CC',
+    ]);
+    expect(r.mintado_em).toBe(existentes.mintado_em); // timestamp original preservado
+    expect(state.contadores.M_CC).toBe(6);
+  });
+
+  it('7. Usuario sem credencial_incra_prefixo -> throw com mensagem clara', async () => {
+    state.prefixo = '';
+    const conn = makeMockConn(state);
+    await expect(
+      mintarCodigosDemarcacao(conn, 1, { num_vertices: 3, marcos: [] }),
+    ).rejects.toThrow(/sem credencial INCRA/i);
+    expect(state.rollbackCount).toBe(1);
+  });
+
+  it('8. Lock atomico: 2 chamadas sequenciais com mesmo conn nao colidem (ordem preservada via FOR UPDATE)', async () => {
+    const conn = makeMockConn(state);
+    const r1 = await mintarCodigosDemarcacao(conn, 1, { num_vertices: 3, marcos: [marco('concreto', 1)] });
+    const r2 = await mintarCodigosDemarcacao(conn, 1, { num_vertices: 3, marcos: [marco('concreto', 1)] });
+    expect(r1.vertices[0]).toBe('FQNS-V-001');
+    expect(r2.vertices[0]).toBe('FQNS-V-004');
+    expect(r1.marcos_por_tipo.concreto[0]).toBe('FQNS-M-0001-CC');
+    expect(r2.marcos_por_tipo.concreto[0]).toBe('FQNS-M-0002-CC');
+    // FOR UPDATE foi usado em todas as selects
+    expect(state.selectQueries.filter((q) => /FOR UPDATE/i.test(q)).length).toBe(2);
+  });
+});

--- a/src/services/pricing/mintCodigosDemarcacao.ts
+++ b/src/services/pricing/mintCodigosDemarcacao.ts
@@ -1,0 +1,212 @@
+// v3.27.0: mint atomico de codigos INCRA FQNS para marcos e vertices de
+// Demarcacao de Lotes (Urbana e Rural).
+//
+// Decisoes:
+//   - Lock pessimista FOR UPDATE no row do usuario (contador unico por tecnico).
+//     Volume Romatec: baixo (~1-5 propostas/dia). Se escalar pra dezenas de
+//     tecnicos concorrentes, considerar migrar pra Redis com INCRBY.
+//   - Contadores vitalicios (V, M_CC, M_TG, P) — nunca resetam. Mesmo apos
+//     cancelamento de proposta, os codigos JA FORAM CONSUMIDOS (trade-off:
+//     integridade da numeracao > eficiencia do contador).
+//   - Snapshot em dados_imovel.codigos_mintados (caller responsavel pela
+//     persistencia). Anti-replay e' DELEGADO ao caller — antes de invocar,
+//     verificar se codigos_mintados ja existe.
+//
+// Formato dos codigos:
+//   Vertices:           FQNS-V-024
+//   Marcos concreto:    FQNS-M-0142-CC
+//   Marcos tubo galv:   FQNS-M-0089-TG
+//   Marcos madeira:     FQNS-P-0067-MD   (P = piquete; madeira tem funcao P)
+//
+// Larguras (largura_numero do pricing-params):
+//   V: 3 digitos | M: 4 digitos | P: 3 digitos
+
+import type { PoolConnection, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import type { MarcoDiscriminado, CodigosMintadosFQNS } from './types';
+
+interface ContadoresFQNS {
+  V: number;
+  M_CC: number;
+  M_TG: number;
+  P: number;
+}
+
+export interface MintInput {
+  num_vertices: number;
+  marcos: MarcoDiscriminado[];
+}
+
+export async function mintarCodigosDemarcacao(
+  conn: PoolConnection,
+  userId: number,
+  input: MintInput,
+): Promise<CodigosMintadosFQNS> {
+  await conn.beginTransaction();
+  try {
+    // 1) Lock pessimista no row do usuario
+    const [rows] = await conn.query<RowDataPacket[]>(
+      `SELECT credencial_incra_prefixo, credencial_contadores
+         FROM users
+        WHERE id = ?
+        FOR UPDATE`,
+      [userId],
+    );
+    if (!rows.length) {
+      throw new Error(`Usuario ${userId} nao encontrado`);
+    }
+    const prefixo = String(rows[0].credencial_incra_prefixo || '').trim();
+    if (!prefixo) {
+      throw new Error(`Usuario ${userId} sem credencial INCRA configurada (credencial_incra_prefixo vazio)`);
+    }
+
+    // mysql2 JSON columns: pode vir como string OU objeto ja parseado
+    const raw = rows[0].credencial_contadores;
+    let contadores: ContadoresFQNS;
+    if (raw == null) {
+      contadores = { V: 0, M_CC: 0, M_TG: 0, P: 0 };
+    } else if (typeof raw === 'string') {
+      contadores = JSON.parse(raw) as ContadoresFQNS;
+    } else {
+      contadores = raw as ContadoresFQNS;
+    }
+
+    // Normaliza chaves ausentes
+    contadores = {
+      V: Number(contadores.V) || 0,
+      M_CC: Number(contadores.M_CC) || 0,
+      M_TG: Number(contadores.M_TG) || 0,
+      P: Number(contadores.P) || 0,
+    };
+
+    // 2) Quantidades por sufixo
+    const qtdConcreto = input.marcos
+      .filter((m) => m.tipo === 'concreto')
+      .reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+    const qtdTubo = input.marcos
+      .filter((m) => m.tipo === 'tubo_galvanizado')
+      .reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+    const qtdMadeira = input.marcos
+      .filter((m) => m.tipo === 'madeira')
+      .reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+
+    // 3) Gera as listas (largura: V/P=3, M=4)
+    const vertices = gerarLista(prefixo, 'V', contadores.V + 1, input.num_vertices, 3);
+    const concreto = gerarListaComSufixo(prefixo, 'M', contadores.M_CC + 1, qtdConcreto, 4, 'CC');
+    const tubo = gerarListaComSufixo(prefixo, 'M', contadores.M_TG + 1, qtdTubo, 4, 'TG');
+    const madeira = gerarListaComSufixo(prefixo, 'P', contadores.P + 1, qtdMadeira, 3, 'MD');
+
+    // 4) Atualiza contadores
+    const novos: ContadoresFQNS = {
+      V: contadores.V + input.num_vertices,
+      M_CC: contadores.M_CC + qtdConcreto,
+      M_TG: contadores.M_TG + qtdTubo,
+      P: contadores.P + qtdMadeira,
+    };
+    await conn.query<ResultSetHeader>(
+      `UPDATE users SET credencial_contadores = ? WHERE id = ?`,
+      [JSON.stringify(novos), userId],
+    );
+
+    await conn.commit();
+    return {
+      prefixo,
+      mintado_em: new Date().toISOString(),
+      vertices,
+      marcos_por_tipo: {
+        concreto,
+        tubo_galvanizado: tubo,
+        madeira,
+      },
+    };
+  } catch (err) {
+    try {
+      await conn.rollback();
+    } catch {
+      /* swallow */
+    }
+    console.error('[MintFQNS]', (err as Error).message);
+    throw err;
+  }
+}
+
+// ── Delta-mint para revisao R2+ ───────────────────────────────────────────
+// Quando uma proposta ja ENVIADA recebe PUT com mais marcos, os marcos
+// pre-existentes preservam codigos e apenas o DELTA consome contador.
+//
+// Caller computa o delta = novos.qtd - existentes.qtd (por tipo + vertices)
+// e chama mintarCodigosDemarcacao com o delta. Os codigos retornados sao
+// concatenados aos existentes.
+//
+// Por simetria de API e' uma funcao separada que valida deltas >= 0 e
+// chama o mint principal.
+export interface DeltaMintInput {
+  delta_vertices: number;          // 0+ adicionais (novos)
+  delta_marcos: MarcoDiscriminado[]; // SO o delta — qtd positiva
+  codigos_existentes: CodigosMintadosFQNS;
+}
+
+export async function mintarDeltaDemarcacao(
+  conn: PoolConnection,
+  userId: number,
+  input: DeltaMintInput,
+): Promise<CodigosMintadosFQNS> {
+  if (input.delta_vertices < 0) throw new Error('delta_vertices deve ser >= 0');
+  for (const m of input.delta_marcos) {
+    if (Number(m.quantidade) < 0) throw new Error('delta de marco com quantidade < 0');
+  }
+
+  // Se nao ha delta, retorna codigos existentes sem tocar no contador
+  const algumaCoisa =
+    input.delta_vertices > 0 ||
+    input.delta_marcos.some((m) => Number(m.quantidade) > 0);
+  if (!algumaCoisa) return input.codigos_existentes;
+
+  const novosCodigos = await mintarCodigosDemarcacao(conn, userId, {
+    num_vertices: input.delta_vertices,
+    marcos: input.delta_marcos,
+  });
+
+  // Mescla preservando os existentes na frente
+  return {
+    prefixo: input.codigos_existentes.prefixo,
+    mintado_em: input.codigos_existentes.mintado_em, // mantem timestamp original do primeiro mint
+    vertices: [...input.codigos_existentes.vertices, ...novosCodigos.vertices],
+    marcos_por_tipo: {
+      concreto: [
+        ...input.codigos_existentes.marcos_por_tipo.concreto,
+        ...novosCodigos.marcos_por_tipo.concreto,
+      ],
+      tubo_galvanizado: [
+        ...input.codigos_existentes.marcos_por_tipo.tubo_galvanizado,
+        ...novosCodigos.marcos_por_tipo.tubo_galvanizado,
+      ],
+      madeira: [
+        ...input.codigos_existentes.marcos_por_tipo.madeira,
+        ...novosCodigos.marcos_por_tipo.madeira,
+      ],
+    },
+  };
+}
+
+function gerarLista(prefixo: string, funcao: string, inicio: number, qtd: number, largura: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < qtd; i++) {
+    out.push(`${prefixo}-${funcao}-${String(inicio + i).padStart(largura, '0')}`);
+  }
+  return out;
+}
+
+function gerarListaComSufixo(
+  prefixo: string,
+  funcao: string,
+  inicio: number,
+  qtd: number,
+  largura: number,
+  sufixo: string,
+): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < qtd; i++) {
+    out.push(`${prefixo}-${funcao}-${String(inicio + i).padStart(largura, '0')}-${sufixo}`);
+  }
+  return out;
+}

--- a/src/services/pricing/params.ts
+++ b/src/services/pricing/params.ts
@@ -68,6 +68,33 @@ interface PricingParams {
     anuencia:    { rotulo: string; valor_unitario: number; unidade?: string; editavel?: boolean };
     retificacao: { rotulo: string; valor: 'sob_orcamento' };
   };
+  // v3.27.0: Demarcacao de Lotes (Urbana e Rural)
+  demarcacao_lotes_2026?: {
+    valor_m2_urbano_default: number;
+    valor_hectare_rural_default: number;
+    fator_diaria_tecnico: number;
+    fator_diaria_tecnico_fonte?: string;
+    valor_km_deslocamento: number;
+    marcos: {
+      concreto:         { valor_unitario: number; rotulo: string; codigo_funcao: string; codigo_material: string; largura_numero: number };
+      madeira:          { valor_unitario: number; rotulo: string; codigo_funcao: string; codigo_material: string; largura_numero: number };
+      tubo_galvanizado: { valor_unitario: number; rotulo: string; codigo_funcao: string; codigo_material: string; largura_numero: number };
+    };
+    vertices: { codigo_funcao: string; largura_numero: number };
+    opcionais: {
+      laudo_tecnico:        { rotulo: string; valor_unitario_sm_multiplicador: number };
+      alinhamento_cerca:    { rotulo: string; valor_unitario: number; unidade?: string };
+      croqui_assinado:      { rotulo: string; valor_unitario: number };
+      acompanhamento_obra:  { rotulo: string; valor_unitario: number; unidade?: string };
+      consultoria_juridica: { rotulo: string; valor: 'sob_orcamento' };
+    };
+    minimo_garantido_sm: number;
+    complexidade_multiplicadores: { simples: number; media: number; alta: number };
+    assessoria_pct: number;
+    desconto_max_pct: number;
+    parcelas: Array<{ numero: number; rotulo: string; percentual: number }>;
+    validade_dias_default: number;
+  };
   _meta?: { ultima_atualizacao: string; atualizado_por: string; versao: string };
 }
 

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -9,7 +9,9 @@ export type SubtipoConsultoria =
   | 'remembramento'
   | 'retificacao_area'
   | 'avaliacao_ptam'
-  | 'projeto_executivo';
+  | 'projeto_executivo'
+  | 'demarcacao_urbana'
+  | 'demarcacao_rural';
 
 export type PadraoConstrutivo = 'popular' | 'normal' | 'alto';
 export type ResponsavelObra = 'PF' | 'PJ_com_contabilidade' | 'PJ_sem_contabilidade';
@@ -441,4 +443,103 @@ export interface InputProjetoExecutivo {
   // DEPRECATED v3.24.6 — usar forma_pagamento_tag
   forma_pagamento?: string;
   observacoes?: string;
+}
+
+// ============================================================
+// DEMARCACAO DE LOTES (v3.27.0)
+// ============================================================
+
+export type SubtipoDemarcacao = 'demarcacao_urbana' | 'demarcacao_rural';
+
+export type MaterialMarco = 'concreto' | 'madeira' | 'tubo_galvanizado';
+
+export type FinalidadeDemarcacao =
+  | 'demarcacao_inicial'
+  | 'redemarcacao'
+  | 'subdivisao_lote'
+  | 'piqueteamento_apenas';
+
+export interface MarcoDiscriminado {
+  tipo: MaterialMarco;
+  quantidade: number;
+  valor_unitario_congelado: number;
+}
+
+export interface OpcionaisDemarcacao {
+  laudo_tecnico?: { contratado: boolean; valor_unitario_sm_multiplicador: number };
+  alinhamento_cerca?: { contratado: boolean; metros: number; valor_unitario: number };
+  croqui_assinado?: { contratado: boolean; valor_unitario: number };
+  acompanhamento_obra?: { contratado: boolean; diarias: number; valor_unitario: number };
+  consultoria_juridica?: { contratado: boolean; valor: 'sob_orcamento' };
+}
+
+export interface InputDemarcacaoLotes {
+  subtipo: SubtipoDemarcacao;
+  finalidade: FinalidadeDemarcacao;
+
+  municipio: string;
+  uf: string;
+  matricula?: string;
+  cri?: string;
+
+  loteamento_nome?: string;
+  quadra?: string;
+  lote?: string;
+  area_m2?: number;
+
+  denominacao_imovel?: string;
+  ccir?: string;
+  area_hectares?: number;
+
+  perimetro_m?: number;
+
+  num_vertices: number;
+  servico_piqueteamento: boolean;
+  marcos: MarcoDiscriminado[];
+
+  diarias_equipe: number;
+  km_deslocamento: number;
+  complexidade: 'simples' | 'media' | 'alta';
+
+  valor_unitario_area?: number;
+  desconto_pct?: number;
+  validade_dias?: number;
+
+  opcionais?: OpcionaisDemarcacao;
+}
+
+export interface CodigosMintadosFQNS {
+  prefixo: string;
+  mintado_em: string;
+  vertices: string[];
+  marcos_por_tipo: {
+    concreto: string[];
+    tubo_galvanizado: string[];
+    madeira: string[];
+  };
+}
+
+export interface DemarcacaoLotesOutput {
+  honorarios_romatec: {
+    trt_cft: number;
+    tecnicos_campo: number;
+    marcos_discriminados: { tipo: MaterialMarco; qtd: number; subtotal: number }[];
+    marcos_subtotal: number;
+    deslocamento: number;
+    area_servico: number;
+    complexidade_multiplicador: number;
+    subtotal_apos_complexidade: number;
+    assessoria: number;
+    desconto_valor: number;
+    total: number;
+  };
+  secao_opcionais_demarcacao: {
+    linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[];
+    subtotal: number;
+  };
+  parcelas: { numero: 1 | 2 | 3; rotulo: string; valor: number; percentual: number }[];
+  validade_dias: number;
+  salario_minimo_usado: number;
+  codigos_mintados?: CodigosMintadosFQNS;
+  historico_revisoes?: { revisao: string; timestamp: string; autor: string; motivo?: string }[];
 }


### PR DESCRIPTION
…NS (v3.27.0)

Implementa 2 novos subtipos de Proposta de Consultoria (demarcacao_urbana, demarcacao_rural) espelhando 1:1 o padrao aprovado PROP-2026-0011-R1 (Georref Rural v3.23.5), com codificacao automatica de marcos via credencial INCRA FQNS do tecnico (rastreabilidade vitalicia perante INCRA/MPF).

Backend:
- src/services/pricing/types.ts: tipos novos (SubtipoDemarcacao, MaterialMarco, FinalidadeDemarcacao, MarcoDiscriminado, OpcionaisDemarcacao, InputDemarcacaoLotes, CodigosMintadosFQNS, DemarcacaoLotesOutput).
- src/services/pricing/demarcacaoLotes.ts: engine standalone (TRT/CFT + tecnicos campo + marcos discriminados + deslocamento + area x valor unit + complexidade + assessoria 5% + desconto + minimo 2 SM + parcelas 40/30/30).
- src/services/pricing/mintCodigosDemarcacao.ts: mint atomico FOR UPDATE no contador vitalicio do usuario, com delta-mint pra revisao R2+.
- src/integrations/avisoDRL.ts: ramo adaptado para 4 finalidades de demarcacao com reforco SO em subdivisao_lote.
- src/database/migrations-usuarios-credencial-incra.ts: ALTER idempotente em users (auth SaaS — NAO em propostas) + seed CEO com prefixo FQNS.
- config/pricing-params.json: bloco demarcacao_lotes_2026 (valores R$/m2, R$/ha, fator diaria CFT-MA 0.42, marcos por tipo, opcionais, complexidade, parcelas, validade default).

PDF + Frontend:
- src/integrations/propostasConsultoria.ts: renderDemarcacaoLotesBody() com 11 secoes (10 do Georref + Marcos Discriminados + Identificacao FQNS). Invocacao SO para os 2 subtipos. Wire-up de garantirCodigosMintadosDemarcacao() nos senders WhatsApp/Telegram antes da transicao rascunho->enviada (idempotente).
- src/public/obras.html: 2 cards novos (🌆 Urbana, 🌾 Rural) apos Georref + renderConsultoriaFormDemarcacao() com validacao live de Sigma(marcos)===vertices, preview FQNS informativo, opcionais 5 linhas.
- src/public/recibo-validar.html: detector e render dedicado em /v/:hash com finalidade, marcos, codigos FQNS, opcionais e box DRL adaptado.

Testes: 38 novos (22 calculo + 8 DRL + 8 mint). Suite total: 693 passing, 1 skipped, 0 failures.

Principios honrados: ZERO ALTER em propostas (campos novos em dados_imovel JSON), ZERO endpoint novo (reusa /api/propostas-consultoria/* poliglota), arquivos proibidos preservados (tools.ts, think.ts, aiCascade.ts, pricing/georreferenciamento.ts).