### PR TITLE
feat(propostas): aditivo de insalubridade/periculosidade transversal …

### DIFF
--- a/06-Changelog/v3.29.0-aditivo-insalubridade-campo.md
+++ b/06-Changelog/v3.29.0-aditivo-insalubridade-campo.md
@@ -1,0 +1,139 @@
+# v3.29.0 — Aditivo de Insalubridade / Periculosidade (transversal)
+
+**Data:** 2026-05-27
+**Branch:** `feature/aditivo-insalubridade-campo-v3.29.0`
+**Base:** `main` (v3.28.0)
+**Versão alvo:** v3.29.0
+
+## Resumo
+
+Implementa **Adicional de Insalubridade / Periculosidade** transversal a todos os subtipos de Proposta de Consultoria que envolvem trabalho de campo, com:
+
+1. Cálculo automático sobre **diárias técnico + diárias equipamento** (base comercial defensável, documentada inline no PDF).
+2. **Bloco explicativo amber** no PDF da proposta, justificando ao cliente com base em CLT art. 192-193 + NR-15 + NR-16 (Portaria MTE 3.214/78).
+3. **4 templates seedados** em `aditivo_campo_config`:
+   - Insalubridade grau **mínimo** (10%) — CLT art. 192 + NR-15 Anexos 7/11/14
+   - Insalubridade grau **médio** (20%) — atividade rural com mata densa
+   - Insalubridade grau **máximo** (40%) — risco epidemiológico elevado
+   - **Periculosidade** (30%) — proximidade de redes elétricas, rodovias, alturas
+4. **Snapshot imutável** do `texto_pdf_md` em `propostas_aditivos_campo` no momento da emissão (admin pode editar template depois sem afetar PDFs antigos).
+5. **Defaults por subtipo** (espelho front/back):
+   - Rural/mata → grau médio habilitado
+   - Urbano/vegetação rasa → grau mínimo habilitado
+   - PTAM / Projeto Executivo (escritório) → desabilitado por default
+
+## Princípios honrados
+
+- ✅ Migrations **TS idempotentes** (não SQL files) — padrão do repo.
+- ✅ Validação manual (Zod não existe no repo).
+- ✅ Calculator **standalone** com repo injetado (testável sem mysql).
+- ✅ Aditivo **não** multiplica pelo fator de complexidade — direito trabalhista ≠ margem comercial (recomendação técnica do prompt original).
+- ✅ Insalubridade × Periculosidade são excludentes (CLT art. 193 §2º) — validado no calculator + UI.
+
+## Mudanças por arquivo
+
+### Backend
+
+- `src/database/migrations-aditivo-campo.ts` (NOVO) — tabela `aditivo_campo_config` + seed dos 4 templates (INSERT IGNORE) + tabela polimórfica `propostas_aditivos_campo`.
+- `src/services/aditivoCampoCalculator.ts` (NOVO) — engine standalone com `validarCombinacao()` + `calcularAditivoCampo()`. Round HALF_UP 2 casas.
+- `src/services/aditivoCampoDefaults.ts` (NOVO) — mapa `ADITIVO_DEFAULTS` por subtipo + `defaultParaSubtipo()`.
+- `src/repositories/aditivoCampoRepo.ts` (NOVO) — repo dos templates (config) + repo do snapshot polimórfico (propostas_aditivos_campo) com upsert idempotente por (proposta_tipo, proposta_id).
+- `src/integrations/propostasConsultoria.ts`:
+  - Aceita `aditivo_campo` em `CriarPropostaConsultoriaInput` (opcional).
+  - Após criar a proposta, chama `aplicarAditivoCampo()` que: calcula via engine, persiste snapshot, atualiza `secao_5_total` e injeta `aditivo_campo` em `custos_calculados`.
+  - `renderAditivoCampoBody()` novo helper — bloco amber com título, valor aplicado, corpo markdown (parser minimalista cobrindo `##`, `**bold**`, `- bullet`, parágrafos) e rodapé legal. Renderizado para **todos os subtipos** antes do QR/hash.
+- `src/server.ts`:
+  - 3 endpoints novos em `/api/aditivos-campo/*`:
+    - `GET /configs` — lista templates ativos
+    - `GET /configs/:id` — detalhe
+    - `POST /calcular` — prévia (aceita `{base_calculo_valor}` como shortcut split 50/50, ou objeto completo)
+  - Migration registrada no boot.
+
+### Frontend
+
+- `src/public/obras.html`:
+  - `ADITIVO_DEFAULTS_FRONT` espelhando o backend.
+  - `renderAditivoCampoForm(subtipo, baseCalculoSugerida, containerId, cache)` — componente reutilizável (vanilla JS) com checkbox habilitar + radio Insal/Peric + select grau + prévia em tempo real (fetch `/api/aditivos-campo/calcular`) + textarea observação técnica + botão "Por que isso é cobrado?" expandível.
+  - `lerAditivoCampoForm()` — leitor do estado pro submit.
+  - **POC: wireado no form de Demarcação** (`<div id="dmAditivoContainer"></div>`). Base inicial = `diarias × SM × 0.42`. Recalcula prévia quando diárias mudam ou checkbox marcado. Submit envia `aditivo_campo` no body do POST.
+  - Cache do form (volta do preview) preserva escolha do aditivo.
+
+## Tabelas criadas
+
+```sql
+aditivo_campo_config (
+  id INT PK,
+  tipo ENUM('insalubridade','periculosidade'),
+  grau ENUM('minimo','medio','maximo','unico'),
+  percentual DECIMAL(5,2),
+  aplicar_sobre ENUM(...) DEFAULT 'ambas',
+  descricao_curta, fundamentacao_legal, texto_explicativo_md,
+  ativo, created_at, updated_at,
+  UNIQUE (tipo, grau)
+)
+
+propostas_aditivos_campo (
+  id INT PK,
+  proposta_tipo VARCHAR(40),  -- ex: 'demarcacao_urbana'
+  proposta_id INT,
+  aditivo_config_id INT,
+  tipo, grau, percentual_aplicado,
+  base_calculo_descricao, base_calculo_valor, valor_aditivo,
+  texto_pdf_md (snapshot imutável),
+  observacao_tecnica TEXT NULL,
+  created_at, updated_at,
+  UNIQUE (proposta_tipo, proposta_id),
+  INDEX (aditivo_config_id)
+)
+```
+
+## Endpoints
+
+```
+GET    /api/aditivos-campo/configs              (requireAuth)
+       → { items: AditivoConfig[] }
+
+GET    /api/aditivos-campo/configs/:id          (requireAuth)
+       → AditivoConfig (com texto_explicativo_md completo)
+
+POST   /api/aditivos-campo/calcular             (requireAuth)
+       Body: { tipo, grau, base_calculo_valor }
+       ou:   { tipo, grau, base_calculo: { diarias_tecnico_valor, diarias_equipamento_valor }, observacao_tecnica? }
+       → AditivoCampoResultado
+```
+
+## Testes
+
+- `src/services/aditivoCampoCalculator.test.ts` — **17 testes** cobrindo:
+  - Validação de combinações (insal+unico → throw, peric+não-unico → throw)
+  - Cálculo de todos os 4 graus
+  - Config inativa/inexistente → throw
+  - Observação técnica concatenada (e ignorada quando vazia)
+  - Base de cálculo negativa → throw
+  - Defaults por subtipo (rural=médio, urbano=mínimo, ptam=desabilitado)
+  - `defaultParaSubtipo()` fallback p/ subtipos desconhecidos
+
+**Total**: 17 novos testes. Suite completa: **734 passing, 1 skipped, 0 failures** (baseline 717 + 17).
+
+## Cálculo
+
+```
+base_calculo = diarias_tecnico_valor + diarias_equipamento_valor
+valor_aditivo = round2(base_calculo × percentual / 100)
+secao_5_total = total_servicos + valor_aditivo
+```
+
+**Ordem:** aditivo soma ao subtotal **antes** do desconto, **depois** das demais composições. **Não** multiplica pelo fator de complexidade.
+
+## Follow-ups (não bloqueiam merge)
+
+1. **Wire-up em outros forms**: hoje só Demarcação tem o `<div id="dmAditivoContainer">`. Replicar o pattern em Georref, Averbação, Desmembramento, Remembramento, Retificação, PTAM, Projeto Executivo.
+2. **Bloco extra na composição visual do PDF** (linha "⚠ Adicional Insalubridade (20%)") entre Subtotal Serviços e Total — hoje o bloco amber explicativo aparece, mas a linha discriminada na tabela de honorários ainda não.
+3. **Tela admin** pra editar templates dos 4 aditivos via Configurações → Aditivos de Campo.
+4. **Versioning histórico** dos templates (`aditivo_campo_config_versoes`) — pra log de alterações administrativas.
+5. **Acumulação** de aditivos (ex: insalubridade biológica + insalubridade calor) — fora do escopo desta release.
+6. **Webhook Z-API** pra mensagem WhatsApp incluir preview "+ R$ X (insalubridade 20%)".
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/database/migrations-aditivo-campo.ts
+++ b/src/database/migrations-aditivo-campo.ts
@@ -1,0 +1,158 @@
+// v3.29.0: aditivo de campo (insalubridade/periculosidade) — config + seed
+// + vinculo polimorfico com propostas. Tudo idempotente, executado no boot.
+//
+// 4 templates seedados:
+//   - insalubridade grau minimo (10%)
+//   - insalubridade grau medio  (20%)
+//   - insalubridade grau maximo (40%)
+//   - periculosidade unico      (30%)
+//
+// Base legal: CLT art. 192-193 + NR-15 + NR-16 (Portaria MTE 3.214/78).
+
+import pool from './connection';
+
+const SEED_TEMPLATES: Array<{
+  tipo: 'insalubridade' | 'periculosidade';
+  grau: 'minimo' | 'medio' | 'maximo' | 'unico';
+  percentual: number;
+  descricao: string;
+  fundamentacao: string;
+  texto: string;
+}> = [
+  {
+    tipo: 'insalubridade', grau: 'minimo', percentual: 10.0,
+    descricao: 'Adicional de Insalubridade (grau minimo — 10%)',
+    fundamentacao: 'CLT art. 192 c/c NR-15 (Anexos 7, 11 e 14) — Portaria MTE 3.214/78',
+    texto: `## Sobre o Adicional de Insalubridade
+
+O presente orcamento inclui **Adicional de Insalubridade em grau minimo (10%)**, em conformidade com o **art. 192 da Consolidacao das Leis do Trabalho (CLT)** e a **Norma Regulamentadora no 15 (NR-15)** do Ministerio do Trabalho e Emprego.
+
+A atividade de levantamento topografico/agrimensura em campo expoe o profissional tecnico a agentes insalubres caracterizados, dentre eles:
+
+- **Agentes biologicos** (NR-15 Anexo 14) — exposicao a mosquitos vetores de dengue, zika, chikungunya, malaria, carrapatos transmissores de doenca de Lyme e febre maculosa, abelhas africanizadas, animais peconhentos (serpentes, escorpioes e aranhas);
+- **Calor excessivo** (NR-15 Anexo 3) — exposicao prolongada a temperaturas superiores aos limites de tolerancia (IBUTG > 30°C em regioes de clima tropical seco);
+- **Radiacao nao ionizante** (NR-15 Anexo 7) — exposicao direta e prolongada a radiacao solar ultravioleta durante a jornada de campo.
+
+O adicional e direito trabalhista irrenunciavel e compoe o custo legitimo do servico tecnico prestado em campo, sendo aqui repassado de forma transparente ao contratante. **Nao constitui lucro adicional, mas tao somente o ressarcimento do encargo trabalhista incidente sobre a remuneracao do profissional exposto.**`,
+  },
+  {
+    tipo: 'insalubridade', grau: 'medio', percentual: 20.0,
+    descricao: 'Adicional de Insalubridade (grau medio — 20%)',
+    fundamentacao: 'CLT art. 192 c/c NR-15 (Anexos 7, 11, 12 e 14) — Portaria MTE 3.214/78',
+    texto: `## Sobre o Adicional de Insalubridade
+
+O presente orcamento inclui **Adicional de Insalubridade em grau medio (20%)**, em conformidade com o **art. 192 da Consolidacao das Leis do Trabalho (CLT)** e a **Norma Regulamentadora no 15 (NR-15)** do Ministerio do Trabalho e Emprego.
+
+A atividade prevista — levantamento topografico/demarcacao em area rural com vegetacao densa, mata fechada ou cerrado nativo — caracteriza exposicao a agentes insalubres de **grau medio**, dentre eles:
+
+- **Agentes biologicos** (NR-15 Anexo 14) — exposicao intensificada a animais peconhentos em mata nativa (jararacas, cascaveis, surucucus, escorpioes amarelos), vetores de doencas tropicais (Aedes aegypti, Anopheles, carrapato-estrela), e abelhas africanizadas;
+- **Poeiras minerais** (NR-15 Anexo 12) — em areas de solo exposto, vias nao pavimentadas ou em periodos de seca;
+- **Radiacao nao ionizante** (NR-15 Anexo 7) — exposicao direta e prolongada a radiacao solar ultravioleta tipo A e B;
+- **Calor excessivo** (NR-15 Anexo 3) — exposicao a IBUTG > 30°C em jornada integral, sem possibilidade de abrigo.
+
+O adicional e direito trabalhista irrenunciavel (CLT art. 193 §3o) e compoe o custo legitimo do servico tecnico de campo. **Nao constitui margem comercial, mas o ressarcimento do encargo trabalhista incidente sobre a remuneracao do profissional exposto** — repassado de forma transparente ao contratante, em atendimento ao principio da boa-fe contratual.`,
+  },
+  {
+    tipo: 'insalubridade', grau: 'maximo', percentual: 40.0,
+    descricao: 'Adicional de Insalubridade (grau maximo — 40%)',
+    fundamentacao: 'CLT art. 192 c/c NR-15 (Anexos 13 e 14) — Portaria MTE 3.214/78',
+    texto: `## Sobre o Adicional de Insalubridade
+
+O presente orcamento inclui **Adicional de Insalubridade em grau maximo (40%)**, em conformidade com o **art. 192 da Consolidacao das Leis do Trabalho (CLT)** e a **Norma Regulamentadora no 15 (NR-15)** do Ministerio do Trabalho e Emprego.
+
+A atividade prevista caracteriza exposicao a agentes insalubres em **grau maximo**, dentre os quais:
+
+- **Agentes biologicos criticos** (NR-15 Anexo 14) — atividade em areas com risco epidemiologico elevado (febre amarela, malaria endemica, leishmaniose), contato direto com efluentes nao tratados, areas alagadas com risco de leptospirose;
+- **Agentes quimicos** (NR-15 Anexo 13) — contato com produtos quimicos agricolas residuais em areas recentemente tratadas;
+- **Calor excessivo** critico — exposicao em areas sem cobertura vegetal, com IBUTG severo.
+
+O adicional e direito trabalhista irrenunciavel e compoe o custo legitimo do servico, sendo aqui repassado de forma transparente ao contratante.`,
+  },
+  {
+    tipo: 'periculosidade', grau: 'unico', percentual: 30.0,
+    descricao: 'Adicional de Periculosidade (30%)',
+    fundamentacao: 'CLT art. 193 c/c NR-16 — Portaria MTE 3.214/78',
+    texto: `## Sobre o Adicional de Periculosidade
+
+O presente orcamento inclui **Adicional de Periculosidade (30%)**, em conformidade com o **art. 193 da Consolidacao das Leis do Trabalho (CLT)** e a **Norma Regulamentadora no 16 (NR-16)** do Ministerio do Trabalho e Emprego.
+
+A atividade prevista — levantamento topografico/demarcacao em **proximidade de redes eletricas energizadas, linhas de transmissao, subestacoes, faixas de dominio de rodovias federais/estaduais com trafego intenso, ou em pontes/viadutos** — caracteriza atividade perigosa nos termos do **art. 193, incisos I e II da CLT**, expondo o profissional a:
+
+- **Risco de eletrocussao** (NR-16 Anexo 4) — proximidade de redes de alta tensao, equipamentos energizados, sistemas eletricos de potencia;
+- **Atropelamento em rodovias** — atividade em faixa de dominio com trafego nao interrompido;
+- **Queda em altura** — pontes, viadutos, edificacoes elevadas, taludes verticais.
+
+A periculosidade e incompativel com o adicional de insalubridade, devendo o trabalhador optar pelo mais benefico (CLT art. 193 §2o). Nesta proposta foi adotada a periculosidade, por ser o adicional aplicavel ao tipo de exposicao preponderante no local de execucao.
+
+O adicional e direito trabalhista irrenunciavel e compoe o custo legitimo do servico, sendo aqui repassado de forma transparente ao contratante.`,
+  },
+];
+
+export async function runMigrationsAditivoCampo(): Promise<void> {
+  // 1) Tabela de config
+  try {
+    await pool.execute(`
+      CREATE TABLE IF NOT EXISTS aditivo_campo_config (
+        id INT PRIMARY KEY AUTO_INCREMENT,
+        tipo ENUM('insalubridade','periculosidade') NOT NULL,
+        grau ENUM('minimo','medio','maximo','unico') NOT NULL,
+        percentual DECIMAL(5,2) NOT NULL,
+        aplicar_sobre ENUM('diaria_tecnico','diaria_equipamento','ambas','salario_minimo','salario_base')
+          NOT NULL DEFAULT 'ambas',
+        descricao_curta VARCHAR(160) NOT NULL,
+        fundamentacao_legal TEXT NOT NULL,
+        texto_explicativo_md MEDIUMTEXT NOT NULL,
+        ativo TINYINT(1) NOT NULL DEFAULT 1,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uq_tipo_grau (tipo, grau)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  } catch (err) {
+    console.error('[aditivo-campo-migrations] FALHA tabela config:', (err as Error).message);
+    return;
+  }
+
+  // 2) Seed dos 4 templates (INSERT IGNORE — idempotente via UNIQUE tipo+grau)
+  for (const t of SEED_TEMPLATES) {
+    try {
+      await pool.execute(
+        `INSERT IGNORE INTO aditivo_campo_config
+          (tipo, grau, percentual, aplicar_sobre, descricao_curta, fundamentacao_legal, texto_explicativo_md, ativo)
+         VALUES (?, ?, ?, 'ambas', ?, ?, ?, 1)`,
+        [t.tipo, t.grau, t.percentual, t.descricao, t.fundamentacao, t.texto],
+      );
+    } catch (err) {
+      console.error(`[aditivo-campo-migrations] FALHA seed ${t.tipo}/${t.grau}:`, (err as Error).message);
+    }
+  }
+  console.log('[aditivo-campo-migrations] OK: aditivo_campo_config + 4 templates');
+
+  // 3) Tabela polimorfica de vinculo
+  try {
+    await pool.execute(`
+      CREATE TABLE IF NOT EXISTS propostas_aditivos_campo (
+        id INT PRIMARY KEY AUTO_INCREMENT,
+        proposta_tipo VARCHAR(40) NOT NULL,
+        proposta_id INT NOT NULL,
+        aditivo_config_id INT NOT NULL,
+        tipo ENUM('insalubridade','periculosidade') NOT NULL,
+        grau ENUM('minimo','medio','maximo','unico') NOT NULL,
+        percentual_aplicado DECIMAL(5,2) NOT NULL,
+        base_calculo_descricao VARCHAR(255) NOT NULL,
+        base_calculo_valor DECIMAL(12,2) NOT NULL,
+        valor_aditivo DECIMAL(12,2) NOT NULL,
+        texto_pdf_md MEDIUMTEXT NOT NULL,
+        observacao_tecnica TEXT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_proposta (proposta_tipo, proposta_id),
+        INDEX idx_aditivo_config (aditivo_config_id),
+        UNIQUE KEY uq_proposta (proposta_tipo, proposta_id)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+    console.log('[aditivo-campo-migrations] OK: propostas_aditivos_campo');
+  } catch (err) {
+    console.error('[aditivo-campo-migrations] FALHA tabela vinculo:', (err as Error).message);
+  }
+}

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -89,6 +89,21 @@ export interface CriarPropostaConsultoriaInput {
   custos_override?: CustosCalculados;
   // v1.66.9: anexos enviados junto na criacao (Planta/Mapa em PDF/PNG/JPEG)
   anexos?: Array<{ filename: string; mimetype: string; conteudo_b64: string }>;
+  // v3.29.0: aditivo de campo (insalubridade/periculosidade) — opcional.
+  // Quando habilitado, o calculator e' chamado apos a criacao e o snapshot
+  // vai pra propostas_aditivos_campo. O valor entra na composicao no PDF.
+  aditivo_campo?: {
+    habilitado: boolean;
+    tipo: 'insalubridade' | 'periculosidade';
+    grau: 'minimo' | 'medio' | 'maximo' | 'unico';
+    observacao_tecnica?: string;
+    // Base de calculo opcional — se nao fornecida, o caller monta a partir
+    // do custos_calculados (50/50 default entre tecnico e equipamento).
+    base_calculo?: {
+      diarias_tecnico_valor: number;
+      diarias_equipamento_valor: number;
+    };
+  };
 }
 
 export interface PropostaConsultoriaRow extends RowDataPacket {
@@ -320,6 +335,36 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
     console.warn(`[propostas-consultoria] falha gerar hash da #${r.insertId}: ${(err as Error).message}`);
   }
 
+  // v3.29.0: aplica aditivo de campo (insalubridade/periculosidade) se solicitado.
+  // Snapshot persistido em propostas_aditivos_campo e secao_5_total atualizado
+  // no UPDATE do custos_calculados.
+  let aditivoSnapshot: AditivoSnapshotComputado | null = null;
+  if (input.aditivo_campo?.habilitado) {
+    try {
+      aditivoSnapshot = await aplicarAditivoCampo({
+        proposta_id: r.insertId,
+        subtipo,
+        custos: resultado.custos,
+        input: input.aditivo_campo,
+      });
+      if (aditivoSnapshot) {
+        // Persiste novo total + aditivo em custos_calculados.aditivo_campo
+        const custosAtualizados = {
+          ...resultado.custos,
+          secao_5_total: round2Lib(resultado.custos.secao_5_total + aditivoSnapshot.valor_aditivo),
+        };
+        (custosAtualizados as unknown as { aditivo_campo: AditivoSnapshotComputado }).aditivo_campo = aditivoSnapshot;
+        await pool.execute(
+          `UPDATE propostas SET custos_calculados = ?, valor_total = ? WHERE id = ?`,
+          [JSON.stringify(custosAtualizados), custosAtualizados.secao_5_total, r.insertId],
+        );
+        resultado.custos = custosAtualizados;
+      }
+    } catch (err) {
+      console.warn(`[aditivo-campo] proposta ${r.insertId} FALHOU: ${(err as Error).message}`);
+    }
+  }
+
   return {
     ok: true as const,
     insertId: r.insertId,
@@ -330,7 +375,88 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
     fontes_consulta: resultado.fontes,
     anexos_criados: anexosCriados,
     hash_validacao: hashValidacao,
-    message: `Proposta de Consultoria ${numero} (${subtipo}) criada. Valor R$ ${resultado.custos.secao_5_total.toFixed(2)}.${anexosCriados > 0 ? ` ${anexosCriados} anexo(s) salvos.` : ''}`,
+    aditivo_campo: aditivoSnapshot,
+    message: `Proposta de Consultoria ${numero} (${subtipo}) criada. Valor R$ ${resultado.custos.secao_5_total.toFixed(2)}.${anexosCriados > 0 ? ` ${anexosCriados} anexo(s) salvos.` : ''}${aditivoSnapshot ? ` Aditivo: +R$ ${aditivoSnapshot.valor_aditivo.toFixed(2)}.` : ''}`,
+  };
+}
+
+// v3.29.0: aditivo de campo — calcula, persiste snapshot, retorna objeto pronto
+// pro PDF. Caller atualiza secao_5_total na coluna custos_calculados.
+interface AditivoSnapshotComputado {
+  config_id: number;
+  tipo: 'insalubridade' | 'periculosidade';
+  grau: 'minimo' | 'medio' | 'maximo' | 'unico';
+  percentual: number;
+  base_calculo_descricao: string;
+  base_calculo_valor: number;
+  valor_aditivo: number;
+  descricao_curta: string;
+  fundamentacao_legal: string;
+  texto_pdf_md: string;
+  observacao_tecnica?: string;
+}
+
+async function aplicarAditivoCampo(args: {
+  proposta_id: number;
+  subtipo: SubtipoConsultoria;
+  custos: CustosCalculados;
+  input: NonNullable<CriarPropostaConsultoriaInput['aditivo_campo']>;
+}): Promise<AditivoSnapshotComputado | null> {
+  const fc = await import('../services/aditivoCampoCalculator');
+  const repoMod = await import('../repositories/aditivoCampoRepo');
+
+  // Base de calculo: se o caller forneceu, usa; senao, deriva do custos
+  // (procura linha tipo "tecnicos" no secao_3_honorarios).
+  let dtec = args.input.base_calculo?.diarias_tecnico_valor ?? 0;
+  let deq = args.input.base_calculo?.diarias_equipamento_valor ?? 0;
+  if (dtec === 0 && deq === 0) {
+    const linhasHon = args.custos.secao_3_honorarios || [];
+    const linhaTec = linhasHon.find((h) =>
+      /tecnico|tecnicos\s+de\s+campo|campo|levantamento|honorarios\s+tecnicos/i.test(h.descricao),
+    );
+    if (linhaTec) {
+      dtec = Number(linhaTec.valor) || 0;
+    }
+    // Sem linha de equipamento explicita; assume 0 (ou usar 50/50 split — opcao do caller)
+  }
+  if (dtec === 0 && deq === 0) {
+    console.warn(`[aditivo-campo] proposta ${args.proposta_id}: base de calculo zerada, pulando`);
+    return null;
+  }
+
+  const r = await fc.calcularAditivoCampo({
+    tipo: args.input.tipo,
+    grau: args.input.grau,
+    base_calculo: { diarias_tecnico_valor: dtec, diarias_equipamento_valor: deq },
+    observacao_tecnica: args.input.observacao_tecnica,
+  }, repoMod.aditivoCampoConfigRepo);
+
+  await repoMod.propostasAditivosCampoRepo.upsert({
+    proposta_tipo: args.subtipo,
+    proposta_id: args.proposta_id,
+    aditivo_config_id: r.config_id,
+    tipo: r.tipo,
+    grau: r.grau,
+    percentual_aplicado: r.percentual,
+    base_calculo_descricao: r.base_calculo_descricao,
+    base_calculo_valor: r.base_calculo_valor,
+    valor_aditivo: r.valor_aditivo,
+    texto_pdf_md: r.texto_pdf_md,
+    observacao_tecnica: args.input.observacao_tecnica?.trim() || null,
+  });
+
+  return {
+    config_id: r.config_id,
+    tipo: r.tipo,
+    grau: r.grau,
+    percentual: r.percentual,
+    base_calculo_descricao: r.base_calculo_descricao,
+    base_calculo_valor: r.base_calculo_valor,
+    valor_aditivo: r.valor_aditivo,
+    descricao_curta: r.descricao_curta,
+    fundamentacao_legal: r.fundamentacao_legal,
+    texto_pdf_md: r.texto_pdf_md,
+    observacao_tecnica: args.input.observacao_tecnica?.trim() || undefined,
   };
 }
 
@@ -1391,6 +1517,117 @@ function renderAvisoDRL(
   doc.font('Helvetica').fillColor('#111');
 }
 
+// v3.29.0: bloco amber com aviso de aditivo de campo (insalubridade/periculosidade).
+// Renderizado no fim do body, ANTES do QR + hash, em todos os subtipos.
+// Markdown parser minimalista (sem dep externa): parser linha-a-linha cobrindo
+// `## titulo`, `**negrito**`, `- bullet` e paragrafos.
+function renderAditivoCampoBody(
+  doc: PDFKit.PDFDocument,
+  snap: AditivoSnapshotComputado,
+  colX: number,
+  colW: number,
+): void {
+  const COR_AMBER_BORDA = '#B45309';     // amber-700
+  const COR_AMBER_BG = '#FEF3C7';        // amber-100
+  const COR_AMBER_TITULO = '#92400E';    // amber-900
+  const PADDING = 12;
+
+  // Pre-render: calcula altura aproximada (linhas + paragrafos)
+  // Como o markdown e' arbitrario, estima por chars/linha + bullets.
+  const linhas = snap.texto_pdf_md.split('\n');
+  doc.fontSize(9).font('Helvetica');
+  let alturaEstimada = 60; // titulo + padding + rodape legal
+  for (const ln of linhas) {
+    if (!ln.trim()) { alturaEstimada += 4; continue; }
+    const limpo = ln
+      .replace(/^##\s+/, '')
+      .replace(/^[-*]\s+/, '• ')
+      .replace(/\*\*(.+?)\*\*/g, '$1');
+    alturaEstimada += doc.heightOfString(limpo, { width: colW - 2 * PADDING }) + 2;
+  }
+
+  if (doc.y + alturaEstimada + 16 > doc.page.height - doc.page.margins.bottom - 80) {
+    doc.addPage();
+  }
+
+  const startY = doc.y;
+  // Box amber
+  doc.save()
+     .roundedRect(colX, startY, colW, alturaEstimada, 6)
+     .lineWidth(1.2)
+     .fillAndStroke(COR_AMBER_BG, COR_AMBER_BORDA);
+  doc.restore();
+
+  doc.x = colX + PADDING;
+  doc.y = startY + PADDING;
+
+  // Titulo
+  doc.fontSize(11).fillColor(COR_AMBER_TITULO).font('Helvetica-Bold');
+  doc.text(`⚠ ${snap.descricao_curta.toUpperCase()}`, { width: colW - 2 * PADDING, lineBreak: true });
+  doc.moveDown(0.3);
+
+  // Linha do valor
+  doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold');
+  doc.text(
+    `Valor aplicado: R$ ${snap.valor_aditivo.toFixed(2)}  ·  ${snap.percentual.toFixed(0)}% sobre R$ ${snap.base_calculo_valor.toFixed(2)}  (${snap.base_calculo_descricao})`,
+    { width: colW - 2 * PADDING },
+  );
+  doc.moveDown(0.4);
+
+  // Render markdown linha a linha
+  doc.fontSize(8.5).fillColor('#111').font('Helvetica');
+  for (const ln of linhas) {
+    if (!ln.trim()) { doc.moveDown(0.25); continue; }
+    let texto = ln;
+    let estilo: 'titulo' | 'bullet' | 'paragrafo' = 'paragrafo';
+    if (/^##\s+/.test(texto)) {
+      texto = texto.replace(/^##\s+/, '');
+      estilo = 'titulo';
+    } else if (/^[-*]\s+/.test(texto)) {
+      texto = '  • ' + texto.replace(/^[-*]\s+/, '');
+      estilo = 'bullet';
+    }
+
+    if (estilo === 'titulo') {
+      // ja temos titulo principal — usa subtitulo
+      doc.fontSize(9.5).fillColor(COR_AMBER_TITULO).font('Helvetica-Bold');
+      const plain = texto.replace(/\*\*(.+?)\*\*/g, '$1');
+      doc.text(plain, { width: colW - 2 * PADDING });
+      doc.fontSize(8.5).fillColor('#111').font('Helvetica');
+      doc.moveDown(0.2);
+      continue;
+    }
+
+    // Tokenize bold inline: split por `**...**`
+    const tokens = texto.split(/(\*\*[^*]+\*\*)/);
+    doc.x = colX + PADDING;
+    const segmentos = tokens.filter((t) => t.length > 0);
+    segmentos.forEach((seg, i) => {
+      const isLast = i === segmentos.length - 1;
+      const bold = /^\*\*[^*]+\*\*$/.test(seg);
+      const limpo = bold ? seg.slice(2, -2) : seg;
+      doc.font(bold ? 'Helvetica-Bold' : 'Helvetica');
+      doc.text(limpo, {
+        continued: !isLast,
+        width: colW - 2 * PADDING,
+      });
+    });
+    doc.font('Helvetica');
+    doc.moveDown(0.15);
+  }
+
+  // Rodape legal
+  doc.moveDown(0.3);
+  doc.fontSize(7.5).fillColor('#6B7280').font('Helvetica-Oblique');
+  doc.text(`Fundamentação legal: ${snap.fundamentacao_legal}`, {
+    width: colW - 2 * PADDING, align: 'left',
+  });
+
+  doc.font('Helvetica').fillColor('#111');
+  doc.y = startY + alturaEstimada + 12;
+  doc.x = colX;
+}
+
 // v3.27.0: render do corpo do PDF de Demarcacao de Lotes (Urbana e Rural).
 // Espelha o layout aprovado da v3.23.5 (Georref Rural), com 2 secoes extras:
 //   - 4-bis: Marcos Discriminados (tabela tipo x qtd x valor unit x subtotal)
@@ -2428,6 +2665,19 @@ export async function gerarPdfPropostaConsultoria(
     doc.fontSize(6.5).fillColor('#666').font('Helvetica')
        .text(`Cert: ${signatureMeta.issuer_cn || '—'} · Válido até ${validadeFmt} · Validar em validar.iti.gov.br`,
              boxX + 6, cy + 42, { width: boxW - 12, align: 'center', lineBreak: false });
+  }
+
+  // v3.29.0: aditivo de campo (insalubridade/periculosidade) — bloco amber
+  // com texto explicativo. Renderizado SO se houver snapshot no custos_calculados.
+  // Caller responsavel por garantir que `aditivo_campo` esta presente quando
+  // habilitado (criarPropostaConsultoria escreve em custos_calculados.aditivo_campo).
+  try {
+    const aditivoSnap = (custos as unknown as { aditivo_campo?: AditivoSnapshotComputado }).aditivo_campo;
+    if (aditivoSnap) {
+      renderAditivoCampoBody(doc, aditivoSnap, 48, 499);
+    }
+  } catch (err) {
+    console.warn(`[propostas-consultoria-pdf] falha aditivo: ${(err as Error).message}`);
   }
 
   // v3.23.7: QR Code + hash de autenticidade renderizados RELATIVO a doc.y, garantindo

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -6565,6 +6565,126 @@ const SUBTIPOS_CONSULTORIA = [
 
 const SUBTIPO_LABEL_FRONT = Object.fromEntries(SUBTIPOS_CONSULTORIA.map(s => [s.slug, s.nome]));
 
+// v3.29.0: defaults sugeridos do aditivo de campo por subtipo (espelha
+// src/services/aditivoCampoDefaults.ts no backend).
+const ADITIVO_DEFAULTS_FRONT = {
+  demarcacao_rural:          { habilitado: true,  tipo: 'insalubridade', grau: 'medio' },
+  georreferenciamento_rural: { habilitado: true,  tipo: 'insalubridade', grau: 'medio' },
+  demarcacao_urbana:         { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  averbacao_residencial:     { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  averbacao_comercial:       { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  desmembramento:            { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  remembramento:             { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  retificacao_area:          { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  avaliacao_ptam:            { habilitado: false, tipo: 'insalubridade', grau: 'minimo' },
+  projeto_executivo:         { habilitado: false, tipo: 'insalubridade', grau: 'minimo' },
+};
+
+// v3.29.0: renderiza bloco de aditivo de campo dentro de QUALQUER form de
+// proposta. O estado e' lido depois via lerAditivoCampoForm(containerId).
+function renderAditivoCampoForm(subtipo, baseCalculoSugerida, containerId, cache = null) {
+  const def = ADITIVO_DEFAULTS_FRONT[subtipo] || { habilitado: false, tipo: 'insalubridade', grau: 'minimo' };
+  const cur = cache || def;
+  const habilitado = !!cur.habilitado;
+  const tipo = cur.tipo || 'insalubridade';
+  const grau = cur.grau || 'minimo';
+  const obs = cur.observacao_tecnica || '';
+  const esc = (s) => String(s == null ? '' : s).replace(/[<>&"']/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
+
+  const el = document.getElementById(containerId);
+  if (!el) return;
+  el.innerHTML = `
+    <fieldset class="aditivo-campo" style="border:1px solid var(--border); border-radius:8px; padding:12px; margin:14px 0; background:rgba(180,83,9,0.04);">
+      <legend style="padding:0 8px; font-weight:600; color:#B45309; font-size:13px;">⚠️ Adicional de Insalubridade / Periculosidade</legend>
+      <label style="display:flex; align-items:center; gap:8px; cursor:pointer; margin-bottom:8px;">
+        <input type="checkbox" id="adcHabilitado" ${habilitado ? 'checked' : ''}>
+        <span style="font-size:13px;">Aplicar adicional de campo (CLT art. 192-193 / NR-15 / NR-16)</span>
+      </label>
+      <div id="adcCorpo" style="${habilitado ? '' : 'display:none;'}">
+        <div style="display:flex; gap:12px; flex-wrap:wrap; margin-bottom:8px;">
+          <label style="font-size:13px;">Tipo:
+            <select id="adcTipo" style="margin-left:4px;">
+              <option value="insalubridade" ${tipo==='insalubridade'?'selected':''}>Insalubridade</option>
+              <option value="periculosidade" ${tipo==='periculosidade'?'selected':''}>Periculosidade</option>
+            </select>
+          </label>
+          <label id="adcGrauLabel" style="font-size:13px;${tipo==='periculosidade'?'display:none;':''}">Grau:
+            <select id="adcGrau" style="margin-left:4px;">
+              <option value="minimo" ${grau==='minimo'?'selected':''}>Mínimo (10%)</option>
+              <option value="medio"  ${grau==='medio'?'selected':''}>Médio (20%) — recomendado p/ mata</option>
+              <option value="maximo" ${grau==='maximo'?'selected':''}>Máximo (40%)</option>
+            </select>
+          </label>
+        </div>
+        <div id="adcPrevia" style="font-size:12px; background:#FEF3C7; border:1px solid #FCD34D; padding:8px 10px; border-radius:6px; color:#92400E; margin-bottom:8px;">Calculando...</div>
+        <label style="display:block; font-size:12px; margin-bottom:8px;">
+          Observação técnica (opcional, até 500 caracteres):
+          <textarea id="adcObs" maxlength="500" rows="2" style="width:100%; padding:6px 8px; font-size:12px; margin-top:4px;" placeholder="Ex: Imóvel com 60% de mata nativa, presença documentada de animais peçonhentos">${esc(obs)}</textarea>
+        </label>
+        <button type="button" id="adcVerTexto" style="background:transparent; border:1px solid #FCD34D; color:#92400E; padding:6px 10px; border-radius:4px; cursor:pointer; font-size:11px;">ℹ️ Por que isso é cobrado?</button>
+        <div id="adcTextoExpandido" style="display:none; margin-top:8px; padding:10px; background:#FFF7ED; border-left:3px solid #B45309; font-size:11px; line-height:1.5; color:#451A03; max-height:300px; overflow-y:auto; white-space:pre-wrap;"></div>
+      </div>
+    </fieldset>
+  `;
+
+  const tipoSel = document.getElementById('adcTipo');
+  const grauSel = document.getElementById('adcGrau');
+  const grauLabel = document.getElementById('adcGrauLabel');
+  const habCk = document.getElementById('adcHabilitado');
+  const corpo = document.getElementById('adcCorpo');
+  const previaEl = document.getElementById('adcPrevia');
+  const verTextoBtn = document.getElementById('adcVerTexto');
+  const textoEl = document.getElementById('adcTextoExpandido');
+  el._aditivoState = { base_calculo_sugerida: Number(baseCalculoSugerida) || 0 };
+
+  async function recalc() {
+    if (!habCk.checked) { previaEl.textContent = 'Adicional desligado.'; return; }
+    const tp = tipoSel.value;
+    let gr = grauSel.value;
+    if (tp === 'periculosidade') gr = 'unico';
+    try {
+      const r = await fetch('/api/aditivos-campo/calcular', {
+        method: 'POST', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tipo: tp, grau: gr, base_calculo_valor: el._aditivoState.base_calculo_sugerida }),
+      });
+      if (!r.ok) { previaEl.textContent = 'Falha ao calcular prévia.'; previaEl.style.color = '#991B1B'; return; }
+      const j = await r.json();
+      previaEl.style.color = '#92400E';
+      previaEl.innerHTML = `<strong>Valor do adicional: R$ ${Number(j.valor_aditivo).toFixed(2)}</strong> <span style="opacity:.7;">(${Number(j.percentual).toFixed(0)}% sobre R$ ${Number(j.base_calculo_valor).toFixed(2)} — ${j.base_calculo_descricao})</span>`;
+      textoEl.textContent = j.texto_pdf_md;
+    } catch (err) {
+      previaEl.textContent = 'Erro de rede ao calcular prévia.'; previaEl.style.color = '#991B1B';
+    }
+  }
+  habCk.addEventListener('change', () => { corpo.style.display = habCk.checked ? '' : 'none'; if (habCk.checked) recalc(); });
+  tipoSel.addEventListener('change', () => {
+    grauLabel.style.display = tipoSel.value === 'periculosidade' ? 'none' : '';
+    if (tipoSel.value === 'periculosidade') grauSel.value = 'unico';
+    else if (grauSel.value === 'unico') grauSel.value = 'medio';
+    recalc();
+  });
+  grauSel.addEventListener('change', recalc);
+  verTextoBtn.addEventListener('click', () => { textoEl.style.display = textoEl.style.display === 'none' ? 'block' : 'none'; });
+  if (habilitado) recalc();
+}
+
+function lerAditivoCampoForm() {
+  const habCk = document.getElementById('adcHabilitado');
+  if (!habCk || !habCk.checked) return null;
+  const tipoSel = document.getElementById('adcTipo');
+  const grauSel = document.getElementById('adcGrau');
+  const obsEl = document.getElementById('adcObs');
+  let grau = grauSel?.value || 'minimo';
+  if (tipoSel?.value === 'periculosidade') grau = 'unico';
+  return {
+    habilitado: true,
+    tipo: tipoSel?.value || 'insalubridade',
+    grau,
+    observacao_tecnica: (obsEl?.value || '').trim() || undefined,
+  };
+}
+
 async function loadPropostasConsultoria() {
   try {
     const r = await api('/api/propostas-consultoria?limite=200');
@@ -8729,6 +8849,9 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
           Esta proposta receberá códigos FQNS-V (vértices), FQNS-M-CC (concreto), FQNS-M-TG (tubo) e FQNS-P-MD (madeira) ao ser enviada. Códigos definitivos aparecerão no PDF após envio.
         </div>
 
+        <!-- v3.29.0: aditivo de campo (insalubridade/periculosidade) -->
+        <div id="dmAditivoContainer"></div>
+
         <div style="display:flex; gap:6px; margin-top:12px;">
           <button id="dmPreview" style="flex:1; background:var(--success); color:#fff; border-color:var(--success);">🧮 Calcular preview</button>
           <button class="btn-secondary" id="dmCancelar">Cancelar</button>
@@ -8789,6 +8912,25 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     document.getElementById(id).addEventListener('change', recalcMarcosCheck);
   });
   recalcMarcosCheck();
+
+  // v3.29.0: aditivo de campo — base estimada inicial = diarias × ~SM × 0.42
+  // (espelho do calculo de tecnicos_campo em demarcacaoLotes.ts). Sera
+  // recalculada no submit pelo backend a partir do custos final.
+  const SM_ESTIMADO = 1621; // SM 2026 — mesmo valor do pricing-params
+  function baseAditivoEstimada() {
+    const diarias = parseInt(document.getElementById('dmDiarias').value, 10) || 1;
+    return Math.round(diarias * SM_ESTIMADO * 0.42 * 100) / 100;
+  }
+  renderAditivoCampoForm(subtipo, baseAditivoEstimada(), 'dmAditivoContainer', cache?.aditivo_campo);
+  // Atualiza base quando diarias muda
+  document.getElementById('dmDiarias').addEventListener('input', () => {
+    const cont = document.getElementById('dmAditivoContainer');
+    if (cont?._aditivoState) {
+      cont._aditivoState.base_calculo_sugerida = baseAditivoEstimada();
+      const habCk = document.getElementById('adcHabilitado');
+      if (habCk?.checked) habCk.dispatchEvent(new Event('change'));
+    }
+  });
 
   function montarDadosImovel() {
     const finalidade = document.getElementById('dmFinalidade').value;
@@ -8851,6 +8993,8 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     const cli = document.getElementById('dmCliente').value;
     if (!cli) { alert('Selecione um cliente'); return; }
     const dados = montarDadosImovel();
+    // v3.29.0: ler estado do aditivo de campo
+    const aditivo = lerAditivoCampoForm();
     // Cache do form pra restaurar ao voltar
     state.consultoriaFormCache = {
       subtipo, cliente_id: cli,
@@ -8859,6 +9003,7 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
       marcos_concreto: parseInt(document.getElementById('dmMarcoConcreto').value, 10) || 0,
       marcos_tubo: parseInt(document.getElementById('dmMarcoTubo').value, 10) || 0,
       marcos_madeira: parseInt(document.getElementById('dmMarcoMadeira').value, 10) || 0,
+      aditivo_campo: aditivo,
     };
     try {
       const r = await api('/api/propostas-consultoria/preview', {
@@ -8873,6 +9018,7 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
           endereco_imovel: document.getElementById('dmEndereco').value,
           dados_imovel: dados,
           validade_dias: dados.validade_dias,
+          aditivo_campo: aditivo,
         },
         resultado: {
           custos: r.custos,
@@ -10425,6 +10571,10 @@ function renderPreviewConsultoria(r, ctx) {
     btn.disabled = true; btn.textContent = 'Salvando...';
     try {
       const endereco = document.getElementById('cnsEndereco').value.trim();
+      // v3.29.0: passa aditivo_campo se o form do subtipo capturou
+      const aditivoCampo = ctx.aditivo_campo
+        || (state.consultoriaPreviewData?.ctx?.aditivo_campo)
+        || null;
       const r2 = await api('/api/propostas-consultoria', {
         method: 'POST',
         body: JSON.stringify({
@@ -10432,6 +10582,7 @@ function renderPreviewConsultoria(r, ctx) {
           cliente_id: ctx.cliId,
           endereco_imovel: endereco || null,
           dados_imovel: ctx.dados_imovel,
+          aditivo_campo: aditivoCampo || undefined,
         }),
       });
 

--- a/src/repositories/aditivoCampoRepo.ts
+++ b/src/repositories/aditivoCampoRepo.ts
@@ -1,0 +1,129 @@
+// v3.29.0: repos do aditivo de campo — config (templates) + vinculos (snapshots).
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../database/connection';
+import type {
+  AditivoConfig,
+  AditivoConfigRepoLike,
+  AditivoTipo,
+  AditivoGrau,
+} from '../services/aditivoCampoCalculator';
+
+function rowToConfig(r: RowDataPacket): AditivoConfig {
+  return {
+    id: Number(r.id),
+    tipo: r.tipo as AditivoTipo,
+    grau: r.grau as AditivoGrau,
+    percentual: Number(r.percentual),
+    descricao_curta: String(r.descricao_curta),
+    fundamentacao_legal: String(r.fundamentacao_legal),
+    texto_explicativo_md: String(r.texto_explicativo_md),
+    ativo: Number(r.ativo) === 1,
+  };
+}
+
+export const aditivoCampoConfigRepo: AditivoConfigRepoLike & {
+  listarAtivos(): Promise<AditivoConfig[]>;
+  buscarPorId(id: number): Promise<AditivoConfig | null>;
+} = {
+  async findByTipoGrau(tipo: AditivoTipo, grau: AditivoGrau): Promise<AditivoConfig | null> {
+    const [rows] = await pool.execute<RowDataPacket[]>(
+      `SELECT * FROM aditivo_campo_config WHERE tipo = ? AND grau = ? LIMIT 1`,
+      [tipo, grau],
+    );
+    if (!rows.length) return null;
+    return rowToConfig(rows[0]);
+  },
+  async listarAtivos(): Promise<AditivoConfig[]> {
+    const [rows] = await pool.execute<RowDataPacket[]>(
+      `SELECT * FROM aditivo_campo_config WHERE ativo = 1
+        ORDER BY tipo ASC, FIELD(grau, 'minimo','medio','maximo','unico')`,
+    );
+    return rows.map(rowToConfig);
+  },
+  async buscarPorId(id: number): Promise<AditivoConfig | null> {
+    const [rows] = await pool.execute<RowDataPacket[]>(
+      `SELECT * FROM aditivo_campo_config WHERE id = ? LIMIT 1`,
+      [id],
+    );
+    if (!rows.length) return null;
+    return rowToConfig(rows[0]);
+  },
+};
+
+// ── Snapshot do aditivo aplicado em uma proposta ───────────────────────────
+
+export interface AditivoSnapshot {
+  proposta_tipo: string;
+  proposta_id: number;
+  aditivo_config_id: number;
+  tipo: AditivoTipo;
+  grau: AditivoGrau;
+  percentual_aplicado: number;
+  base_calculo_descricao: string;
+  base_calculo_valor: number;
+  valor_aditivo: number;
+  texto_pdf_md: string;
+  observacao_tecnica: string | null;
+}
+
+export const propostasAditivosCampoRepo = {
+  async upsert(snap: AditivoSnapshot): Promise<void> {
+    await pool.execute<ResultSetHeader>(
+      `INSERT INTO propostas_aditivos_campo
+        (proposta_tipo, proposta_id, aditivo_config_id, tipo, grau,
+         percentual_aplicado, base_calculo_descricao, base_calculo_valor,
+         valor_aditivo, texto_pdf_md, observacao_tecnica)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         aditivo_config_id      = VALUES(aditivo_config_id),
+         tipo                   = VALUES(tipo),
+         grau                   = VALUES(grau),
+         percentual_aplicado    = VALUES(percentual_aplicado),
+         base_calculo_descricao = VALUES(base_calculo_descricao),
+         base_calculo_valor     = VALUES(base_calculo_valor),
+         valor_aditivo          = VALUES(valor_aditivo),
+         texto_pdf_md           = VALUES(texto_pdf_md),
+         observacao_tecnica     = VALUES(observacao_tecnica),
+         updated_at             = CURRENT_TIMESTAMP`,
+      [
+        snap.proposta_tipo, snap.proposta_id, snap.aditivo_config_id,
+        snap.tipo, snap.grau, snap.percentual_aplicado,
+        snap.base_calculo_descricao, snap.base_calculo_valor,
+        snap.valor_aditivo, snap.texto_pdf_md, snap.observacao_tecnica,
+      ],
+    );
+  },
+  async buscar(proposta_tipo: string, proposta_id: number): Promise<AditivoSnapshot | null> {
+    const [rows] = await pool.execute<RowDataPacket[]>(
+      `SELECT proposta_tipo, proposta_id, aditivo_config_id, tipo, grau,
+              percentual_aplicado, base_calculo_descricao, base_calculo_valor,
+              valor_aditivo, texto_pdf_md, observacao_tecnica
+         FROM propostas_aditivos_campo
+        WHERE proposta_tipo = ? AND proposta_id = ?
+        LIMIT 1`,
+      [proposta_tipo, proposta_id],
+    );
+    if (!rows.length) return null;
+    const r = rows[0];
+    return {
+      proposta_tipo: String(r.proposta_tipo),
+      proposta_id: Number(r.proposta_id),
+      aditivo_config_id: Number(r.aditivo_config_id),
+      tipo: r.tipo as AditivoTipo,
+      grau: r.grau as AditivoGrau,
+      percentual_aplicado: Number(r.percentual_aplicado),
+      base_calculo_descricao: String(r.base_calculo_descricao),
+      base_calculo_valor: Number(r.base_calculo_valor),
+      valor_aditivo: Number(r.valor_aditivo),
+      texto_pdf_md: String(r.texto_pdf_md),
+      observacao_tecnica: r.observacao_tecnica != null ? String(r.observacao_tecnica) : null,
+    };
+  },
+  async remover(proposta_tipo: string, proposta_id: number): Promise<void> {
+    await pool.execute(
+      `DELETE FROM propostas_aditivos_campo WHERE proposta_tipo = ? AND proposta_id = ?`,
+      [proposta_tipo, proposta_id],
+    );
+  },
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -2407,6 +2407,68 @@ app.post('/api/galeria/:id/enviar', requireCeoToken, async (req: Request, res: R
   }
 });
 
+// v3.29.0: aditivo de campo (insalubridade/periculosidade) — endpoints de
+// catalogo + calculo. CRUD admin dos templates fica como follow-up.
+app.get('/api/aditivos-campo/configs', requireAuth, async (_req: Request, res: Response) => {
+  try {
+    const m = await import('./repositories/aditivoCampoRepo');
+    const items = await m.aditivoCampoConfigRepo.listarAtivos();
+    res.json({ items });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+app.get('/api/aditivos-campo/configs/:id', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id) || id <= 0) { res.status(404).json({ error: 'id invalido' }); return; }
+    const m = await import('./repositories/aditivoCampoRepo');
+    const c = await m.aditivoCampoConfigRepo.buscarPorId(id);
+    if (!c) { res.status(404).json({ error: 'config nao encontrada' }); return; }
+    res.json(c);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+app.post('/api/aditivos-campo/calcular', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const b = (req.body || {}) as Record<string, unknown>;
+    const tipo = String(b.tipo || '');
+    const grau = String(b.grau || '');
+    if (tipo !== 'insalubridade' && tipo !== 'periculosidade') {
+      res.status(422).json({ error: 'tipo invalido' }); return;
+    }
+    if (!['minimo', 'medio', 'maximo', 'unico'].includes(grau)) {
+      res.status(422).json({ error: 'grau invalido' }); return;
+    }
+    const bc = b.base_calculo as Record<string, unknown> | undefined;
+    // Aceita tanto { base_calculo: { diarias_tecnico_valor, diarias_equipamento_valor } }
+    // quanto shortcut { base_calculo_valor } (split 50/50 — uso so pra preview rapido)
+    let dtec = 0, deq = 0;
+    if (bc && typeof bc === 'object') {
+      dtec = Number(bc.diarias_tecnico_valor) || 0;
+      deq = Number(bc.diarias_equipamento_valor) || 0;
+    } else if (typeof b.base_calculo_valor === 'number') {
+      const tot = Number(b.base_calculo_valor) || 0;
+      dtec = tot / 2;
+      deq = tot / 2;
+    }
+    const fc = await import('./services/aditivoCampoCalculator');
+    const repo = await import('./repositories/aditivoCampoRepo');
+    const r = await fc.calcularAditivoCampo({
+      tipo: tipo as 'insalubridade' | 'periculosidade',
+      grau: grau as 'minimo' | 'medio' | 'maximo' | 'unico',
+      base_calculo: { diarias_tecnico_valor: dtec, diarias_equipamento_valor: deq },
+      observacao_tecnica: typeof b.observacao_tecnica === 'string' ? b.observacao_tecnica : undefined,
+    }, repo.aditivoCampoConfigRepo);
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
 // v3.28.0: Galeria Pos-Captura — compartilhamento multi-canal + download +
 // preferences. Reusa servicos existentes (whatsapp/telegram) via injecao.
 // Validacao manual (padrao do repo — Zod nao e' usado em nenhum outro lugar).
@@ -4378,6 +4440,17 @@ app.listen(PORT, () => {
       await m.runMigrationsUserPreferences();
     } catch (err) {
       console.error('[user-preferences-migrations] FALHA fatal:', err);
+    }
+  })();
+
+  // v3.29.0: aditivo de campo (insalubridade/periculosidade) — config + seed
+  // dos 4 templates + tabela polimorfica de vinculo com propostas.
+  void (async () => {
+    try {
+      const m = await import('./database/migrations-aditivo-campo');
+      await m.runMigrationsAditivoCampo();
+    } catch (err) {
+      console.error('[aditivo-campo-migrations] FALHA fatal:', err);
     }
   })();
 

--- a/src/services/aditivoCampoCalculator.test.ts
+++ b/src/services/aditivoCampoCalculator.test.ts
@@ -1,0 +1,162 @@
+// v3.29.0: testes do calculator de aditivo de campo (insalubridade/periculosidade).
+// Standalone — usa repo mock em memoria, sem deps de mysql/pdfkit.
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularAditivoCampo,
+  validarCombinacao,
+  type AditivoConfig,
+  type AditivoConfigRepoLike,
+  type AditivoTipo,
+  type AditivoGrau,
+} from './aditivoCampoCalculator';
+import { defaultParaSubtipo, ADITIVO_DEFAULTS } from './aditivoCampoDefaults';
+
+function fakeRepo(configs: AditivoConfig[]): AditivoConfigRepoLike {
+  return {
+    async findByTipoGrau(tipo, grau) {
+      return configs.find((c) => c.tipo === tipo && c.grau === grau) ?? null;
+    },
+  };
+}
+
+const TEMPLATES: AditivoConfig[] = [
+  { id: 1, tipo: 'insalubridade', grau: 'minimo',  percentual: 10, descricao_curta: 'Insal min',  fundamentacao_legal: 'CLT 192 NR-15', texto_explicativo_md: '## Insalubridade minimo\n\nTexto base.', ativo: true },
+  { id: 2, tipo: 'insalubridade', grau: 'medio',   percentual: 20, descricao_curta: 'Insal med',  fundamentacao_legal: 'CLT 192 NR-15', texto_explicativo_md: '## Insalubridade medio\n\nTexto base.', ativo: true },
+  { id: 3, tipo: 'insalubridade', grau: 'maximo',  percentual: 40, descricao_curta: 'Insal max',  fundamentacao_legal: 'CLT 192 NR-15', texto_explicativo_md: '## Insalubridade maximo\n\nTexto base.', ativo: true },
+  { id: 4, tipo: 'periculosidade', grau: 'unico',  percentual: 30, descricao_curta: 'Peric',      fundamentacao_legal: 'CLT 193 NR-16', texto_explicativo_md: '## Periculosidade\n\nTexto base.', ativo: true },
+];
+
+describe('aditivoCampoCalculator — validarCombinacao', () => {
+  it('1. periculosidade + grau != unico -> throw', () => {
+    expect(() => validarCombinacao('periculosidade', 'medio' as AditivoGrau)).toThrow(/Periculosidade so aceita grau "unico"/);
+  });
+  it('2. insalubridade + grau = unico -> throw', () => {
+    expect(() => validarCombinacao('insalubridade', 'unico')).toThrow(/Insalubridade so aceita/);
+  });
+  it('3. insalubridade + grau minimo/medio/maximo -> ok', () => {
+    for (const g of ['minimo', 'medio', 'maximo'] as AditivoGrau[]) {
+      expect(() => validarCombinacao('insalubridade', g)).not.toThrow();
+    }
+  });
+  it('4. periculosidade + unico -> ok', () => {
+    expect(() => validarCombinacao('periculosidade', 'unico')).not.toThrow();
+  });
+});
+
+describe('aditivoCampoCalculator — calculo', () => {
+  it('5. insalubridade grau medio (20%) sobre R$ 1.800 = R$ 360', async () => {
+    const r = await calcularAditivoCampo({
+      tipo: 'insalubridade', grau: 'medio',
+      base_calculo: { diarias_tecnico_valor: 1200, diarias_equipamento_valor: 600 },
+    }, fakeRepo(TEMPLATES));
+    expect(r.percentual).toBe(20);
+    expect(r.base_calculo_valor).toBe(1800);
+    expect(r.valor_aditivo).toBe(360);
+    expect(r.config_id).toBe(2);
+  });
+
+  it('6. periculosidade (30%) sobre R$ 1.800 = R$ 540', async () => {
+    const r = await calcularAditivoCampo({
+      tipo: 'periculosidade', grau: 'unico',
+      base_calculo: { diarias_tecnico_valor: 1200, diarias_equipamento_valor: 600 },
+    }, fakeRepo(TEMPLATES));
+    expect(r.valor_aditivo).toBe(540);
+  });
+
+  it('7. insalubridade grau minimo (10%) e maximo (40%) — arredondamento HALF_UP', async () => {
+    const repo = fakeRepo(TEMPLATES);
+    const min = await calcularAditivoCampo({
+      tipo: 'insalubridade', grau: 'minimo',
+      base_calculo: { diarias_tecnico_valor: 333.33, diarias_equipamento_valor: 166.67 },
+    }, repo);
+    // base = 500.00, 10% = 50.00
+    expect(min.valor_aditivo).toBeCloseTo(50, 2);
+    const max = await calcularAditivoCampo({
+      tipo: 'insalubridade', grau: 'maximo',
+      base_calculo: { diarias_tecnico_valor: 250, diarias_equipamento_valor: 250 },
+    }, repo);
+    expect(max.valor_aditivo).toBe(200);
+  });
+
+  it('8. config inativa -> throw', async () => {
+    const inativa = [{ ...TEMPLATES[1], ativo: false }];
+    await expect(
+      calcularAditivoCampo({
+        tipo: 'insalubridade', grau: 'medio',
+        base_calculo: { diarias_tecnico_valor: 100, diarias_equipamento_valor: 0 },
+      }, fakeRepo(inativa)),
+    ).rejects.toThrow(/desativada/);
+  });
+
+  it('9. config inexistente -> throw', async () => {
+    await expect(
+      calcularAditivoCampo({
+        tipo: 'insalubridade', grau: 'medio',
+        base_calculo: { diarias_tecnico_valor: 100, diarias_equipamento_valor: 0 },
+      }, fakeRepo([])),
+    ).rejects.toThrow(/nao encontrada/);
+  });
+
+  it('10. concatena observacao tecnica no texto_pdf_md', async () => {
+    const r = await calcularAditivoCampo({
+      tipo: 'insalubridade', grau: 'medio',
+      base_calculo: { diarias_tecnico_valor: 100, diarias_equipamento_valor: 100 },
+      observacao_tecnica: 'Imovel em mata fechada com presenca de jararaca',
+    }, fakeRepo(TEMPLATES));
+    expect(r.texto_pdf_md).toContain('Observacao tecnica especifica');
+    expect(r.texto_pdf_md).toContain('mata fechada com presenca de jararaca');
+  });
+
+  it('11. observacao tecnica vazia/somente espacos NAO concatena', async () => {
+    const r = await calcularAditivoCampo({
+      tipo: 'insalubridade', grau: 'medio',
+      base_calculo: { diarias_tecnico_valor: 100, diarias_equipamento_valor: 0 },
+      observacao_tecnica: '   ',
+    }, fakeRepo(TEMPLATES));
+    expect(r.texto_pdf_md).not.toContain('Observacao tecnica especifica');
+  });
+
+  it('12. base de calculo negativa -> throw', async () => {
+    await expect(
+      calcularAditivoCampo({
+        tipo: 'insalubridade', grau: 'medio',
+        base_calculo: { diarias_tecnico_valor: -10, diarias_equipamento_valor: 100 },
+      }, fakeRepo(TEMPLATES)),
+    ).rejects.toThrow(/negativos/);
+  });
+
+  it('13. rejeita periculosidade com grau medio (defesa em profundidade)', async () => {
+    await expect(
+      calcularAditivoCampo({
+        tipo: 'periculosidade', grau: 'medio' as AditivoGrau,
+        base_calculo: { diarias_tecnico_valor: 100, diarias_equipamento_valor: 100 },
+      }, fakeRepo(TEMPLATES)),
+    ).rejects.toThrow(/Periculosidade so aceita/);
+  });
+});
+
+describe('aditivoCampoDefaults — ADITIVO_DEFAULTS por subtipo', () => {
+  it('14. demarcacao_rural / georreferenciamento_rural -> grau medio habilitado', () => {
+    expect(ADITIVO_DEFAULTS.demarcacao_rural).toEqual({ habilitado: true, tipo: 'insalubridade', grau: 'medio' });
+    expect(ADITIVO_DEFAULTS.georreferenciamento_rural).toEqual({ habilitado: true, tipo: 'insalubridade', grau: 'medio' });
+  });
+
+  it('15. demarcacao_urbana / averbacoes / desm/rem/retif -> grau minimo habilitado', () => {
+    const subs = ['demarcacao_urbana', 'averbacao_residencial', 'averbacao_comercial', 'desmembramento', 'remembramento', 'retificacao_area'];
+    for (const s of subs) {
+      expect(ADITIVO_DEFAULTS[s]).toEqual({ habilitado: true, tipo: 'insalubridade', grau: 'minimo' });
+    }
+  });
+
+  it('16. avaliacao_ptam / projeto_executivo -> desabilitado por default', () => {
+    expect(ADITIVO_DEFAULTS.avaliacao_ptam.habilitado).toBe(false);
+    expect(ADITIVO_DEFAULTS.projeto_executivo.habilitado).toBe(false);
+  });
+
+  it('17. defaultParaSubtipo de subtipo desconhecido retorna minimo+desabilitado', () => {
+    expect(defaultParaSubtipo('subtipo_inventado')).toEqual({ habilitado: false, tipo: 'insalubridade', grau: 'minimo' });
+    expect(defaultParaSubtipo(null)).toEqual({ habilitado: false, tipo: 'insalubridade', grau: 'minimo' });
+    expect(defaultParaSubtipo(undefined)).toEqual({ habilitado: false, tipo: 'insalubridade', grau: 'minimo' });
+  });
+});

--- a/src/services/aditivoCampoCalculator.ts
+++ b/src/services/aditivoCampoCalculator.ts
@@ -1,0 +1,109 @@
+// v3.29.0: calculator standalone do aditivo de campo (insalubridade/periculosidade).
+//
+// Decisoes:
+//   - Base de calculo = diarias tecnico + diarias equipamento (decisao
+//     comercial defensavel, documentada no texto do PDF).
+//   - Insalubridade e Periculosidade sao excludentes (CLT art. 193 §2o).
+//   - Templates de texto vem do DB (tabela aditivo_campo_config seedada).
+//   - Observacao tecnica do tecnico e' concatenada ao texto do PDF.
+//   - Snapshot: o caller persiste em propostas_aditivos_campo o texto_pdf_md
+//     do MOMENTO da criacao — se admin editar template depois, propostas
+//     antigas mantem o texto original (auditoria).
+//
+// Modulo standalone — toma o repo via injecao pra ser testavel sem mysql.
+
+export type AditivoTipo = 'insalubridade' | 'periculosidade';
+export type AditivoGrau = 'minimo' | 'medio' | 'maximo' | 'unico';
+
+export interface AditivoConfig {
+  id: number;
+  tipo: AditivoTipo;
+  grau: AditivoGrau;
+  percentual: number;
+  descricao_curta: string;
+  fundamentacao_legal: string;
+  texto_explicativo_md: string;
+  ativo: boolean;
+}
+
+export interface AditivoCampoInput {
+  tipo: AditivoTipo;
+  grau: AditivoGrau;
+  base_calculo: {
+    diarias_tecnico_valor: number;
+    diarias_equipamento_valor: number;
+  };
+  observacao_tecnica?: string;
+}
+
+export interface AditivoCampoResultado {
+  config_id: number;
+  tipo: AditivoTipo;
+  grau: AditivoGrau;
+  percentual: number;
+  base_calculo_descricao: string;
+  base_calculo_valor: number;
+  valor_aditivo: number;
+  descricao_curta: string;
+  fundamentacao_legal: string;
+  texto_pdf_md: string;
+}
+
+export interface AditivoConfigRepoLike {
+  findByTipoGrau(tipo: AditivoTipo, grau: AditivoGrau): Promise<AditivoConfig | null>;
+}
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+export function validarCombinacao(tipo: AditivoTipo, grau: AditivoGrau): void {
+  if (tipo === 'periculosidade' && grau !== 'unico') {
+    throw new Error('Periculosidade so aceita grau "unico" (30%)');
+  }
+  if (tipo === 'insalubridade' && grau === 'unico') {
+    throw new Error('Insalubridade so aceita grau minimo, medio ou maximo');
+  }
+}
+
+export async function calcularAditivoCampo(
+  input: AditivoCampoInput,
+  repo: AditivoConfigRepoLike,
+): Promise<AditivoCampoResultado> {
+  validarCombinacao(input.tipo, input.grau);
+
+  const config = await repo.findByTipoGrau(input.tipo, input.grau);
+  if (!config) {
+    throw new Error(`Config nao encontrada para ${input.tipo}/${input.grau}`);
+  }
+  if (!config.ativo) {
+    throw new Error(`Config ${input.tipo}/${input.grau} esta desativada`);
+  }
+
+  const dtec = Number(input.base_calculo.diarias_tecnico_valor) || 0;
+  const deq = Number(input.base_calculo.diarias_equipamento_valor) || 0;
+  if (dtec < 0 || deq < 0) {
+    throw new Error('base_calculo: valores nao podem ser negativos');
+  }
+  const base = round2(dtec + deq);
+  const valor = round2((base * config.percentual) / 100);
+
+  let texto = config.texto_explicativo_md;
+  const obs = (input.observacao_tecnica ?? '').trim();
+  if (obs) {
+    texto += `\n\n**Observacao tecnica especifica desta proposta:**\n${obs}`;
+  }
+
+  return {
+    config_id: config.id,
+    tipo: input.tipo,
+    grau: input.grau,
+    percentual: config.percentual,
+    base_calculo_descricao: 'Diarias tecnico + Diarias equipamento',
+    base_calculo_valor: base,
+    valor_aditivo: valor,
+    descricao_curta: config.descricao_curta,
+    fundamentacao_legal: config.fundamentacao_legal,
+    texto_pdf_md: texto,
+  };
+}

--- a/src/services/aditivoCampoDefaults.ts
+++ b/src/services/aditivoCampoDefaults.ts
@@ -1,0 +1,36 @@
+// v3.29.0: defaults sugeridos de aditivo de campo por subtipo de proposta.
+// O default reflete a exposicao tipica do tecnico em cada cenario:
+//   - Mata fechada / cerrado / rural denso  -> insalubridade grau medio
+//   - Urbano com vegetacao rasa             -> insalubridade grau minimo
+//   - Avaliacao/projeto em escritorio       -> desligado por default
+
+import type { AditivoTipo, AditivoGrau } from './aditivoCampoCalculator';
+
+export interface AditivoDefault {
+  habilitado: boolean;
+  tipo: AditivoTipo;
+  grau: AditivoGrau;
+}
+
+export const ADITIVO_DEFAULTS: Record<string, AditivoDefault> = {
+  // Mata fechada / cerrado -> grau medio
+  demarcacao_rural:          { habilitado: true,  tipo: 'insalubridade', grau: 'medio' },
+  georreferenciamento_rural: { habilitado: true,  tipo: 'insalubridade', grau: 'medio' },
+
+  // Urbano / vegetacao rasa -> grau minimo
+  demarcacao_urbana:         { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  averbacao_residencial:     { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  averbacao_comercial:       { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  desmembramento:            { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  remembramento:             { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+  retificacao_area:          { habilitado: true,  tipo: 'insalubridade', grau: 'minimo' },
+
+  // Escritorio (avaliacao / projeto executivo) -> desligado
+  avaliacao_ptam:            { habilitado: false, tipo: 'insalubridade', grau: 'minimo' },
+  projeto_executivo:         { habilitado: false, tipo: 'insalubridade', grau: 'minimo' },
+};
+
+export function defaultParaSubtipo(subtipo: string | null | undefined): AditivoDefault {
+  if (!subtipo) return { habilitado: false, tipo: 'insalubridade', grau: 'minimo' };
+  return ADITIVO_DEFAULTS[subtipo] ?? { habilitado: false, tipo: 'insalubridade', grau: 'minimo' };
+}


### PR DESCRIPTION
…(v3.29.0)

Implementa Adicional de Insalubridade/Periculosidade aplicavel a TODOS os subtipos de Proposta de Consultoria que envolvem trabalho de campo, com:

1. Calculo automatico sobre diarias tecnico + equipamento (base comercial defensavel, documentada inline no PDF).
2. Bloco explicativo amber no PDF justificando com base em CLT art. 192-193
   + NR-15 + NR-16 (Portaria MTE 3.214/78).
3. 4 templates seedados (insal min/med/max + peric) em aditivo_campo_config.
4. Snapshot imutavel do texto_pdf_md em propostas_aditivos_campo no momento da emissao (admin pode editar template depois sem afetar PDFs antigos).
5. Defaults por subtipo: rural=medio, urbano=minimo, escritorio=desabilitado.

Backend:
- migrations-aditivo-campo.ts: 2 tabelas idempotentes + seed dos 4 templates com textos completos (CLT/NR-15/NR-16 referenciados).
- services/aditivoCampoCalculator.ts: engine standalone (repo injetado) com validarCombinacao() + calcularAditivoCampo(). Round HALF_UP 2 casas. Valida insal+unico/peric+!unico (CLT art. 193 §2o — excludentes).
- services/aditivoCampoDefaults.ts: mapa por subtipo + fallback p/ desconhecidos.
- repositories/aditivoCampoRepo.ts: repo dos templates + snapshot polimorfico com upsert idempotente por (proposta_tipo, proposta_id).
- propostasConsultoria.ts: aceita aditivo_campo em CriarPropostaConsultoria, aplicarAditivoCampo() apos INSERT (calcula, persiste, atualiza secao_5_total e injeta em custos_calculados), renderAditivoCampoBody() com parser markdown minimalista (##, **bold**, - bullet) renderiza bloco amber no fim do body de TODOS os subtipos.
- server.ts: 3 endpoints novos /api/aditivos-campo/{configs, configs/:id, calcular} + migration registrada no boot.

Frontend (obras.html):
- ADITIVO_DEFAULTS_FRONT espelho do backend.
- renderAditivoCampoForm(subtipo, baseCalculo, containerId, cache) componente reutilizavel: checkbox + radio Insal/Peric + select grau + previa em tempo real + textarea observacao tecnica + botao "Por que isso e' cobrado?" expandivel.
- lerAditivoCampoForm() leitor pro submit.
- POC wireado no form de Demarcacao: <div id="dmAditivoContainer">, base inicial = diarias x SM x 0.42, recalcula quando diarias mudam, submit envia aditivo_campo no body.

Testes: 17 novos cobrindo validacoes, calculo dos 4 graus, config inativa/inexistente, observacao tecnica, defaults por subtipo. Suite total: 734 passing, 1 skipped, 0 failures.

Follow-ups: wire-up nos outros forms (Georref/Averbacao/Desm/Rem/Retif/PTAM/ PE), linha discriminada na composicao visual da tabela, tela admin de templates, acumulacao de aditivos.