### PR TITLE
fix(adicional)+feat(clientes): hotfix 401 + CRUD UI de clientes (v3.3…

### DIFF
--- a/06-Changelog/v3.36.0-hotfix-adicional-publico-e-clientes-crud.md
+++ b/06-Changelog/v3.36.0-hotfix-adicional-publico-e-clientes-crud.md
@@ -1,0 +1,115 @@
+# v3.36.0 — Hotfix Adicional 401 + UI CRUD de Clientes
+
+**Data:** 2026-05-28
+**Branch:** `feature/hotfix-adicional-publico-e-clientes-crud-v3.36.0`
+**Base:** `main` (v3.34.0)
+**Versão alvo:** v3.36.0
+
+> **Nota:** v3.35.0 (Memoriais Fase 1) ainda está em PR pendente. Esta release é independente — pode ser mergeada antes ou depois.
+
+## Bugs corrigidos
+
+### 1. "Erro ao carregar cenário" no Adicional de Insalubridade/Periculosidade (produção)
+
+**Sintoma reportado:**
+```
+Erro ao carregar cenário
+Não é possível GET /api/adicional-campo/calcular
+https://romatecvoiceagent-production.up.railway.app/api/adicional-campo/calcular
+Failed to load resource: the server responded with a status of 401
+```
+
+**Diagnóstico:**
+- O endpoint `POST /api/adicional-campo/calcular` (v3.33.0) usava `requireAuth`
+- A UI da página `obras.html` é chamada antes de qualquer autenticação completar OU em sessões com cookie httpOnly não chegando
+- Resultado: 401 → frontend exibe "Erro ao carregar cenário"
+
+**Causa raiz:**
+Decisão original de proteger o endpoint era conservadora. Mas o cálculo é **determinístico**:
+- Lê apenas `pricing-params.json` (arquivo público)
+- Não acessa o banco de dados
+- Não persiste nada
+- Não retorna dado sensível (são apenas os textos jurídicos públicos da CLT/NR-15/NR-16)
+- Apenas calcula `percentual × 1` e retorna o texto correspondente
+
+**Fix:** removido `requireAuth` do endpoint `/calcular`. Endpoint `/cenarios` já era público.
+
+```ts
+// Antes (v3.33.0):
+app.post('/api/adicional-campo/calcular', requireAuth, async (req, res) => { ... });
+
+// Depois (v3.36.0):
+app.post('/api/adicional-campo/calcular', async (req, res) => { ... });
+```
+
+Endpoints que **persistem** (`/api/propostas-consultoria` POST/PUT) continuam protegidos. Apenas o cálculo público foi liberado.
+
+## Feature nova
+
+### 2. CRUD completo de Clientes (UI)
+
+**Backend já tinha**:
+- `PUT /api/propostas-clientes/:id` (linha 1143, `atualizarClienteProposta` em `propostas.ts:197`)
+- `DELETE /api/propostas-clientes/:id` (linha 1144, `apagarClienteProposta` em `propostas.ts:256`, soft-delete via `deleted_at`)
+
+**O que faltava**: UI. Implementado:
+
+1. **`abrirCadastroClienteModal(subtipoParaVoltar, clienteExistente?)`** — modal agora aceita 2º parâmetro opcional:
+   - `null` → modo cadastro (POST, comportamento original)
+   - cliente object → modo edição (PUT, preenche campos automaticamente)
+   - Título do modal muda dinamicamente (`+ Novo Cliente` / `✏️ Editar Cliente`)
+
+2. **`abrirGerenciarClientes()`** — novo modal de listagem com:
+   - Cards por cliente (nome, CPF, telefone, cidade/UF)
+   - Botão `✏️ Editar` → abre modal de edição
+   - Botão `🗑️ Excluir` → `confirm()` PT-BR + DELETE + reload
+   - Botão `+ Novo cliente` no topo
+   - Mensagem amigável explicando soft-delete: *"Propostas existentes desse cliente continuam visíveis"*
+
+3. **Botão `📇 Gerenciar Clientes`** adicionado no toggle da aba Proposta (ao lado do toggle Mão de Obra/Consultoria).
+
+4. **Event delegation global** no `DOMContentLoaded` — uma única função handler para o botão, evita duplicar wire-up nos 10+ pontos onde o toggle é renderizado.
+
+## Mudanças por arquivo
+
+### Backend (1 linha)
+
+- `src/server.ts:2591` — removido `requireAuth` do `POST /api/adicional-campo/calcular` + comentário de hotfix explicando diagnóstico.
+
+### Frontend (`src/public/obras.html`)
+
+- `abrirCadastroClienteModal()` — refatorado para aceitar `clienteExistente` (modo edição) e `subtipoParaVoltar = '__gerenciar__'` (volta para modal de gerenciamento em vez do form de proposta).
+- `abrirGerenciarClientes()` — função nova (modal grande com listagem + ações).
+- Botão `[data-gerenciar-clientes]` adicionado ao toggle da aba Proposta (linha ~6113).
+- Event delegate `document.body.addEventListener('click', ...)` no `DOMContentLoaded` (linha ~1255).
+
+## Testes
+
+`src/test/hotfix-adicional-publico-e-clientes-crud.test.ts` — **12 testes**:
+
+1. POST `/api/adicional-campo/calcular` NÃO usa `requireAuth` (regex no server.ts)
+2. Comentário de hotfix presente em server.ts (rastreabilidade)
+3. GET `/api/adicional-campo/cenarios` continua público (regressão)
+4. `abrirCadastroClienteModal` aceita `clienteExistente`
+5. Modo edição usa PUT em vez de POST
+6. `abrirGerenciarClientes` existe e renderiza lista
+7. Cada cliente tem botões `data-cli-edit` + `data-cli-del`
+8. Excluir pede `confirm()` PT-BR com nome
+9. Excluir chama DELETE `/api/propostas-clientes/:id`
+10. Toggle da aba Proposta tem botão `[data-gerenciar-clientes]`
+11. Handler global delegate no `DOMContentLoaded`
+12. Mensagem amigável de exclusão menciona soft-delete
+
+**Suite total**: 845 passing, 1 skipped, 0 failures (baseline 833 + 12 novos).
+
+## Política preservada
+
+- ✅ Schema do banco intacto (soft-delete já existia em `propostas_clientes.deleted_at`)
+- ✅ Sem endpoint novo de cliente (reuso de PUT/DELETE pré-existentes desde v3.24.11)
+- ✅ Endpoints que persistem continuam autenticados — apenas o `/calcular` (puro cálculo) foi liberado
+- ✅ Textos jurídicos VERBATIM permanecem (texto vai pra PDF que cliente recebe)
+- ✅ Padrão `confirm()` PT-BR antes de ação destrutiva (já usado em outros locais do app)
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.34.0",
+  "version": "3.36.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -1250,6 +1250,16 @@ function atualizarBotaoCeo() {
   btn.style.color = tem ? 'var(--neon)' : 'var(--text-muted)';
 }
 document.addEventListener('DOMContentLoaded', () => {
+  // v3.36.0: delegate global pra botao "📇 Gerenciar Clientes" que aparece
+  // no toggle da aba Proposta. Evita duplicar handler em 10+ renderers.
+  document.body.addEventListener('click', (ev) => {
+    const target = ev.target;
+    if (target instanceof HTMLElement && target.closest('[data-gerenciar-clientes]')) {
+      ev.preventDefault();
+      if (typeof abrirGerenciarClientes === 'function') abrirGerenciarClientes();
+    }
+  });
+
   atualizarBotaoCeo();
   const btn = document.getElementById('btnCeoToken');
   if (!btn) return;
@@ -6100,14 +6110,17 @@ function renderPropostasLista() {
   const ativoMo = state.tipoPropostaAtivo === 'mao_de_obra';
   const ativoCons = state.tipoPropostaAtivo === 'consultoria';
   const toggleHTML = `
-    <div class="card" role="tablist" aria-label="Tipo de proposta" style="display:flex; gap:8px; padding:8px; align-items:center;">
+    <div class="card" role="tablist" aria-label="Tipo de proposta" style="display:flex; gap:8px; padding:8px; align-items:center; flex-wrap:wrap;">
       <span style="font-size:12px; color:var(--text-muted);">Tipo:</span>
       <button class="${ativoMo ? '' : 'btn-secondary'}"
               role="tab" aria-current="${ativoMo ? 'page' : 'false'}" aria-selected="${ativoMo}"
-              data-toggle-tipo="mao_de_obra" style="flex:1;">🔨 Mão de Obra</button>
+              data-toggle-tipo="mao_de_obra" style="flex:1; min-width:140px;">🔨 Mão de Obra</button>
       <button class="${ativoCons ? '' : 'btn-secondary'}"
               role="tab" aria-current="${ativoCons ? 'page' : 'false'}" aria-selected="${ativoCons}"
-              data-toggle-tipo="consultoria" style="flex:1;">📋 Consultoria</button>
+              data-toggle-tipo="consultoria" style="flex:1; min-width:140px;">📋 Consultoria</button>
+      <button class="btn-secondary" data-gerenciar-clientes
+              title="Editar ou excluir clientes cadastrados"
+              style="white-space:nowrap;">📇 Gerenciar Clientes</button>
     </div>`;
 
   if (state.tipoPropostaAtivo === 'consultoria') {
@@ -10722,84 +10735,174 @@ function abrirHelpPadraoConstrutivo() {
 // v1.66.0: cadastro inline de cliente (chamado pelo botao "+ Novo cliente"
 // dentro do form de Nova Consultoria). Apos salvar, retorna pro form com
 // o novo cliente ja selecionado.
-async function abrirCadastroClienteModal(subtipoParaVoltar) {
+// v3.36.0: cadastro/edicao de cliente. Quando `clienteExistente` e' passado,
+// abre em modo EDICAO (PUT em vez de POST) + preenche os campos.
+async function abrirCadastroClienteModal(subtipoParaVoltar, clienteExistente = null) {
+  const isEdit = !!clienteExistente;
+  const c = clienteExistente || {};
+  const esc = (s) => String(s == null ? '' : s).replace(/"/g, '&quot;');
   const html = `
     <div style="display:grid; gap:8px; font-size:13px;">
       <label>Nome completo / Razão Social *
-        <input id="novCliNome" placeholder="Maria Ester R. Sampaio" style="width:100%;" autofocus>
+        <input id="novCliNome" placeholder="Maria Ester R. Sampaio" style="width:100%;" value="${esc(c.nome)}" autofocus>
       </label>
       <div class="lp-grid-2">
         <label>CPF / CNPJ
-          <input id="novCliCpf" placeholder="000.000.000-00" style="width:100%;">
+          <input id="novCliCpf" placeholder="000.000.000-00" style="width:100%;" value="${esc(c.cpf_cnpj)}">
         </label>
         <label>Telefone (WhatsApp)
-          <input id="novCliTel" placeholder="55 98 99168-2644" style="width:100%;">
+          <input id="novCliTel" placeholder="55 98 99168-2644" style="width:100%;" value="${esc(c.telefone)}">
         </label>
       </div>
       <label>E-mail
-        <input id="novCliEmail" type="email" placeholder="cliente@email.com" style="width:100%;">
+        <input id="novCliEmail" type="email" placeholder="cliente@email.com" style="width:100%;" value="${esc(c.email)}">
       </label>
       <label>Endereço completo
-        <input id="novCliEnd" placeholder="Rua Bom Jesus, 236, Centro" style="width:100%;">
+        <input id="novCliEnd" placeholder="Rua Bom Jesus, 236, Centro" style="width:100%;" value="${esc(c.endereco)}">
       </label>
       <div class="lp-grid-auto">
         <label>Cidade
-          <input id="novCliCidade" placeholder="Açailândia" style="width:100%;" value="Açailândia">
+          <input id="novCliCidade" placeholder="Açailândia" style="width:100%;" value="${esc(c.cidade || 'Açailândia')}">
         </label>
         <label>UF
-          <input id="novCliEstado" placeholder="MA" maxlength="2" style="width:100%; text-transform:uppercase;" value="MA">
+          <input id="novCliEstado" placeholder="MA" maxlength="2" style="width:100%; text-transform:uppercase;" value="${esc(c.estado || 'MA')}">
         </label>
         <label>CEP
-          <input id="novCliCep" placeholder="65930-000" style="width:100%;">
+          <input id="novCliCep" placeholder="65930-000" style="width:100%;" value="${esc(c.cep)}">
         </label>
       </div>
       <label>Observações
-        <textarea id="novCliObs" rows="2" placeholder="Notas internas (opcional)" style="width:100%; resize:vertical;"></textarea>
+        <textarea id="novCliObs" rows="2" placeholder="Notas internas (opcional)" style="width:100%; resize:vertical;">${esc(c.observacoes)}</textarea>
       </label>
       <div style="display:flex; gap:6px; margin-top:8px;">
-        <button id="novCliSalvar" style="flex:1; background:var(--success); color:#fff; border-color:var(--success);">💾 Salvar e voltar</button>
+        <button id="novCliSalvar" style="flex:1; background:var(--success); color:#fff; border-color:var(--success);">${isEdit ? '💾 Salvar alterações' : '💾 Salvar e voltar'}</button>
         <button class="btn-secondary" id="novCliCancelar">Cancelar</button>
       </div>
     </div>`;
-  const body = abrirModal(html, { width: '640px', title: '+ Novo Cliente', subtitle: 'Cadastro completo' });
+  abrirModal(html, {
+    width: '640px',
+    title: isEdit ? '✏️ Editar Cliente' : '+ Novo Cliente',
+    subtitle: isEdit ? `ID ${c.id}` : 'Cadastro completo',
+  });
 
-  document.getElementById('novCliCancelar').onclick = () => {
+  const voltarOuFechar = () => {
     fecharModal();
-    abrirNovaConsultoriaPasso2(subtipoParaVoltar);
+    if (subtipoParaVoltar === '__gerenciar__') {
+      abrirGerenciarClientes();
+    } else if (subtipoParaVoltar) {
+      abrirNovaConsultoriaPasso2(subtipoParaVoltar);
+    }
   };
+
+  document.getElementById('novCliCancelar').onclick = voltarOuFechar;
 
   document.getElementById('novCliSalvar').onclick = async () => {
     const nome = document.getElementById('novCliNome').value.trim();
     if (!nome) return alert('Nome é obrigatório.');
     const btn = document.getElementById('novCliSalvar');
     btn.disabled = true; btn.textContent = 'Salvando...';
+    const payload = {
+      nome,
+      cpf_cnpj: document.getElementById('novCliCpf').value.trim() || null,
+      telefone: document.getElementById('novCliTel').value.trim() || null,
+      email: document.getElementById('novCliEmail').value.trim() || null,
+      endereco: document.getElementById('novCliEnd').value.trim() || null,
+      cidade: document.getElementById('novCliCidade').value.trim() || null,
+      estado: (document.getElementById('novCliEstado').value.trim() || null)?.toUpperCase(),
+      cep: document.getElementById('novCliCep').value.trim() || null,
+      observacoes: document.getElementById('novCliObs').value.trim() || null,
+    };
     try {
-      const r = await api('/api/propostas-clientes', {
-        method: 'POST',
-        body: JSON.stringify({
-          nome,
-          cpf_cnpj: document.getElementById('novCliCpf').value.trim() || null,
-          telefone: document.getElementById('novCliTel').value.trim() || null,
-          email: document.getElementById('novCliEmail').value.trim() || null,
-          endereco: document.getElementById('novCliEnd').value.trim() || null,
-          cidade: document.getElementById('novCliCidade').value.trim() || null,
-          estado: (document.getElementById('novCliEstado').value.trim() || null)?.toUpperCase(),
-          cep: document.getElementById('novCliCep').value.trim() || null,
-          observacoes: document.getElementById('novCliObs').value.trim() || null,
-        }),
-      });
-      // Recarrega lista e volta pro form, ja selecionando o novo cliente
+      let r;
+      if (isEdit) {
+        r = await api(`/api/propostas-clientes/${c.id}`, { method: 'PUT', body: JSON.stringify(payload) });
+      } else {
+        r = await api('/api/propostas-clientes', { method: 'POST', body: JSON.stringify(payload) });
+      }
       await loadPropostasClientes();
       fecharModal();
-      await abrirNovaConsultoriaPasso2(subtipoParaVoltar);
-      const sel = document.getElementById('cnsCliente');
-      if (sel && r.insertId) sel.value = String(r.insertId);
+      if (subtipoParaVoltar === '__gerenciar__') {
+        abrirGerenciarClientes();
+      } else if (subtipoParaVoltar) {
+        await abrirNovaConsultoriaPasso2(subtipoParaVoltar);
+        const sel = document.getElementById('cnsCliente');
+        if (sel && r?.insertId) sel.value = String(r.insertId);
+      }
     } catch (e) {
-      alert('Erro: ' + e.message);
+      alert('Erro: ' + (e?.message || e));
       btn.disabled = false;
-      btn.textContent = '💾 Salvar e voltar';
+      btn.textContent = isEdit ? '💾 Salvar alterações' : '💾 Salvar e voltar';
     }
   };
+}
+
+// v3.36.0: modal de gerenciamento de clientes — listar + editar + excluir.
+// Reusa os endpoints PUT/DELETE ja existentes em propostas.ts (linhas 197/256).
+async function abrirGerenciarClientes() {
+  await loadPropostasClientes();
+  const clientes = state.propostasClientes || [];
+  const esc = (s) => String(s == null ? '' : s).replace(/[<>&"']/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
+
+  const linhas = clientes.length === 0
+    ? '<div class="card empty">Nenhum cliente cadastrado.</div>'
+    : clientes.map(c => `
+      <div class="card" style="display:flex; gap:8px; justify-content:space-between; align-items:flex-start; flex-wrap:wrap;">
+        <div style="flex:1; min-width:200px;">
+          <p style="margin:0; font-weight:600;">${esc(c.nome)}</p>
+          <p style="margin:4px 0 0; font-size:11px; color:var(--text-muted);">
+            ${c.cpf_cnpj ? '📄 ' + esc(c.cpf_cnpj) : ''}${c.telefone ? ' · 📱 ' + esc(c.telefone) : ''}${c.cidade ? ' · ' + esc(c.cidade) + (c.estado ? '/' + esc(c.estado) : '') : ''}
+          </p>
+        </div>
+        <div style="display:flex; gap:4px;">
+          <button data-cli-edit="${c.id}" style="font-size:11px; padding:6px 12px; background:#0ea5e922; color:#0ea5e9; border:1px solid #0ea5e955;">✏️ Editar</button>
+          <button data-cli-del="${c.id}" data-cli-nome="${esc(c.nome)}" class="btn-danger" style="font-size:11px; padding:6px 12px;">🗑️ Excluir</button>
+        </div>
+      </div>`).join('');
+
+  const html = `
+    <div style="display:grid; gap:8px;">
+      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:6px;">
+        <p style="margin:0; font-size:12px; color:var(--text-muted);">${clientes.length} cliente(s) cadastrado(s)</p>
+        <button id="gerCliNovo" style="background:var(--success); color:#fff; border-color:var(--success); font-size:12px;">+ Novo cliente</button>
+      </div>
+      <div id="gerCliLista" style="max-height:60vh; overflow-y:auto; display:grid; gap:6px;">
+        ${linhas}
+      </div>
+      <div style="display:flex; justify-content:flex-end; margin-top:8px;">
+        <button class="btn-secondary" id="gerCliFechar">Fechar</button>
+      </div>
+    </div>`;
+  abrirModal(html, { width: '720px', title: '📇 Gerenciar Clientes', subtitle: 'Editar ou excluir cadastros existentes' });
+
+  document.getElementById('gerCliFechar').onclick = fecharModal;
+  document.getElementById('gerCliNovo').onclick = () => {
+    fecharModal();
+    abrirCadastroClienteModal('__gerenciar__', null);
+  };
+
+  document.querySelectorAll('[data-cli-edit]').forEach(b => b.onclick = async () => {
+    const id = Number(b.dataset.cliEdit);
+    const cli = clientes.find(c => Number(c.id) === id);
+    if (!cli) return;
+    fecharModal();
+    abrirCadastroClienteModal('__gerenciar__', cli);
+  });
+
+  document.querySelectorAll('[data-cli-del]').forEach(b => b.onclick = async () => {
+    const id = Number(b.dataset.cliDel);
+    const nome = b.dataset.cliNome || 'este cliente';
+    if (!confirm(`Excluir "${nome}"?\n\nO cliente será removido da lista (soft-delete). Propostas existentes desse cliente continuam visíveis.`)) return;
+    b.disabled = true; b.textContent = 'Excluindo...';
+    try {
+      await api(`/api/propostas-clientes/${id}`, { method: 'DELETE' });
+      await loadPropostasClientes();
+      abrirGerenciarClientes(); // re-render
+    } catch (err) {
+      alert('Erro: ' + (err.message || err));
+      b.disabled = false;
+      b.textContent = '🗑️ Excluir';
+    }
+  });
 }
 
 async function abrirNovaConsultoriaPasso2(subtipo) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2588,7 +2588,14 @@ app.get('/api/adicional-campo/cenarios', async (_req: Request, res: Response) =>
   }
 });
 
-app.post('/api/adicional-campo/calcular', requireAuth, async (req: Request, res: Response) => {
+// v3.36.0 HOTFIX: endpoint /calcular tornado PUBLICO (sem requireAuth).
+// Diagnostico do 401 em producao: cookie httpOnly de sessao nao chegava ao
+// endpoint quando o user marcava o checkbox do adicional sem estar logado.
+// O calculo e' determinist​ico (consulta apenas pricing-params.json — sem DB,
+// sem side-effect, sem dado sensivel). Endpoint /cenarios ja era publico —
+// agora /calcular tambem. Endpoints que PERSISTEM (criar/atualizar proposta)
+// continuam protegidos.
+app.post('/api/adicional-campo/calcular', async (req: Request, res: Response) => {
   try {
     const b = (req.body || {}) as Record<string, unknown>;
     const ativo = !!b.ativo;

--- a/src/test/hotfix-adicional-publico-e-clientes-crud.test.ts
+++ b/src/test/hotfix-adicional-publico-e-clientes-crud.test.ts
@@ -1,0 +1,73 @@
+// v3.36.0: testes de regressao do hotfix do 401 + UI CRUD de clientes.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER_TS = fs.readFileSync(path.join(process.cwd(), 'src', 'server.ts'), 'utf-8');
+const OBRAS_HTML = fs.readFileSync(path.join(process.cwd(), 'src', 'public', 'obras.html'), 'utf-8');
+
+describe('HOTFIX v3.36.0 — adicional-campo/calcular publico', () => {
+  it('1. POST /api/adicional-campo/calcular NAO usa requireAuth (publico)', () => {
+    // Pattern especifico do registro do endpoint
+    const m = SERVER_TS.match(/app\.post\('\/api\/adicional-campo\/calcular',\s*(\w+|async)/);
+    expect(m).not.toBeNull();
+    // O 2o argumento deve ser `async` direto (sem requireAuth)
+    expect(m![1]).toBe('async');
+    expect(m![1]).not.toBe('requireAuth');
+  });
+
+  it('2. Comentario de hotfix presente em server.ts (rastreabilidade)', () => {
+    expect(SERVER_TS).toMatch(/v3\.36\.0 HOTFIX: endpoint \/calcular tornado PUBLICO/);
+  });
+
+  it('3. GET /api/adicional-campo/cenarios continua publico (regressao)', () => {
+    const m = SERVER_TS.match(/app\.get\('\/api\/adicional-campo\/cenarios',\s*(\w+|async)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe('async');
+  });
+});
+
+describe('v3.36.0 UI — CRUD de clientes em obras.html', () => {
+  it('4. abrirCadastroClienteModal aceita clienteExistente (modo edicao)', () => {
+    expect(OBRAS_HTML).toMatch(/function abrirCadastroClienteModal\(subtipoParaVoltar,\s*clienteExistente/);
+    expect(OBRAS_HTML).toMatch(/isEdit\s*=\s*!!clienteExistente/);
+  });
+
+  it('5. Modo edicao usa PUT em vez de POST', () => {
+    expect(OBRAS_HTML).toMatch(/api\(`\/api\/propostas-clientes\/\$\{c\.id\}`,\s*\{ method: 'PUT'/);
+  });
+
+  it('6. Funcao abrirGerenciarClientes existe e renderiza lista', () => {
+    expect(OBRAS_HTML).toMatch(/async function abrirGerenciarClientes\(\)/);
+    expect(OBRAS_HTML).toMatch(/state\.propostasClientes \|\| \[\]/);
+  });
+
+  it('7. Cada cliente tem botoes Editar e Excluir com data-cli-edit/data-cli-del', () => {
+    expect(OBRAS_HTML).toMatch(/data-cli-edit="\$\{c\.id\}"/);
+    expect(OBRAS_HTML).toMatch(/data-cli-del="\$\{c\.id\}"/);
+  });
+
+  it('8. Excluir pede confirm() PT-BR com nome do cliente', () => {
+    expect(OBRAS_HTML).toMatch(/confirm\(`Excluir "\$\{nome\}"\?/);
+  });
+
+  it('9. Excluir chama DELETE /api/propostas-clientes/:id', () => {
+    expect(OBRAS_HTML).toMatch(/api\(`\/api\/propostas-clientes\/\$\{id\}`,\s*\{ method: 'DELETE'/);
+  });
+
+  it('10. Toggle da aba Proposta tem botao [data-gerenciar-clientes]', () => {
+    expect(OBRAS_HTML).toMatch(/data-gerenciar-clientes/);
+    expect(OBRAS_HTML).toMatch(/📇 Gerenciar Clientes/);
+  });
+
+  it('11. Handler global delegate no DOMContentLoaded (evita duplicar em 10+ renders)', () => {
+    expect(OBRAS_HTML).toMatch(/document\.body\.addEventListener\('click'.*data-gerenciar-clientes/s);
+    expect(OBRAS_HTML).toMatch(/abrirGerenciarClientes\(\)/);
+  });
+
+  it('12. Mensagem amigavel ao excluir explica soft-delete', () => {
+    expect(OBRAS_HTML).toMatch(/soft-delete/);
+    expect(OBRAS_HTML).toMatch(/Propostas existentes desse cliente continuam visiveis|Propostas existentes desse cliente continuam vis[íi]veis/i);
+  });
+});


### PR DESCRIPTION
…6.0)

DOIS PROBLEMAS resolvidos:

1) HOTFIX: "Erro ao carregar cenario" em producao
   Reportado pelo CEO em https://romatecvoiceagent-production.up.railway.app
   ao tentar marcar checkbox de adicional Insal/Peric:
     POST /api/adicional-campo/calcular -> 401 Unauthorized
   Frontend exibia: "Erro ao carregar cenario"

   Diagnostico: endpoint /calcular usava requireAuth desde v3.33.0. Em
   producao, o cookie httpOnly de sessao nao chegava (sessao expirada ou
   user navegando sem login completo) → 401.

   Causa raiz: o calculo e' DETERMINISTICO — le apenas pricing-params.json
   (publico), nao acessa DB, nao persiste, nao retorna dado sensivel (sao
   textos juridicos publicos da CLT/NR-15/NR-16). Decisao original de
   proteger era conservadora demais.

   Fix: removido requireAuth de POST /api/adicional-campo/calcular.
   Endpoints que PERSISTEM (proposta POST/PUT) continuam protegidos.

2) FEATURE: CRUD UI de Clientes
   Backend ja tinha (desde v3.24.11):
   - PUT /api/propostas-clientes/:id (atualizarClienteProposta)
   - DELETE /api/propostas-clientes/:id (apagarClienteProposta, soft-delete) Mas faltava UI no frontend.

   Implementado em obras.html:
   - abrirCadastroClienteModal(subtipoParaVoltar, clienteExistente?) agora aceita 2o parametro opcional. clienteExistente → modo edicao (PUT + pre-preenche campos). null → cadastro original (POST).
   - abrirGerenciarClientes() funcao nova: modal grande lista todos os clientes com botoes Editar/Excluir. Excluir pede confirm() PT-BR com nome + mensagem amigavel sobre soft-delete preservando propostas existentes.
   - Botao "📇 Gerenciar Clientes" adicionado ao toggle da aba Proposta.
   - Event delegate GLOBAL no DOMContentLoaded — uma unica funcao handler evita duplicar wire-up nos 10+ pontos onde o toggle e' renderizado.

Testes: 12 novos (3 hotfix + 9 CRUD UI) cobrindo:
- Endpoint /calcular publico (sem requireAuth)
- /cenarios continua publico (regressao)
- Modal aceita clienteExistente
- PUT em modo edicao
- abrirGerenciarClientes existe + lista + acoes
- DELETE com confirm() PT-BR
- Handler global delegate

Suite total: 845 passing, 1 skipped, 0 failures (baseline 833 + 12). Typecheck limpo. Zero alteracao em schema do banco — reuso completo de endpoints PUT/DELETE pre-existentes.