### PR TITLE
fix(memoriais): hotfix 401 em /hidraulico/calcular + UX fallback 401 …

### DIFF
--- a/06-Changelog/v3.37.0-hotfix-memoriais-401.md
+++ b/06-Changelog/v3.37.0-hotfix-memoriais-401.md
@@ -1,0 +1,104 @@
+# v3.37.0 — Hotfix Memoriais 401 + UX fallback
+
+**Data:** 2026-05-28
+**Branch:** `feature/hotfix-memoriais-401-v3.37.0`
+**Base:** `main` (v3.36.0 pendente PR + v3.35.0 mergeada)
+**Versão alvo:** v3.37.0
+
+## Bugs corrigidos
+
+### 1. "401 em POST /api/memoriais/hidraulico/calcular"
+
+**Sintoma:**
+```
+api/memoriais/hidraulico/calcular:1  Failed to load resource: status 401
+```
+
+**Diagnóstico:** mesmo padrão do v3.36.0 com `/adicional-campo/calcular`. O endpoint era autenticado por excesso de zelo, mas o cálculo NBR 5626 é **determinístico**:
+- Lê apenas tabelas hardcoded no engine (`hidraulicoCalc.ts`)
+- Não acessa DB
+- Não persiste nada
+- Não retorna dado sensível
+
+**Fix:** removido `requireAuth` do `POST /api/memoriais/hidraulico/calcular`.
+
+### 2. "401 em GET /api/memoriais?limite=50"
+
+**Sintoma:**
+```
+api/memoriais?limite=50:1  Failed to load resource: status 401
+```
+
+**Diagnóstico:** o endpoint **deve** ser autenticado (lista memoriais do user). O problema é que ao abrir a aba "📐 Memoriais & Quantitativos" sem login, o frontend mostrava "Nenhum memorial gerado ainda" (confundindo 401 com lista vazia).
+
+**Fix:** `renderMemoriaisQuantitativos()` agora detecta `hResp.status === 401` e mostra mensagem clara:
+
+```
+🔒 Sessão expirada ou não autenticada. Faça login pra ver seu histórico de memoriais.
+```
+
+### 3. RangeError: Maximum call stack size exceeded (obras:22912)
+
+**Sintoma reportado:**
+```
+obras:22912 Uncaught (in promise) RangeError: Maximum call stack size exceeded
+    at HTMLInputElement.<anonymous> (obras:22912:29)
+```
+
+**Diagnóstico:** linha 22912 do obras.html é `const disc = b.getAttribute('data-mem-disc')` em um handler de **button**, não **input**. O stack trace é inconsistente com o código atual. Hipóteses:
+- Cache antigo do navegador rodando código de versão anterior
+- Extensão Chrome (a mensagem `"A listener indicated an asynchronous response by returning true, but the message channel closed"` é típica de extensões) injetando código
+
+**Mitigação:** sem reprodução local, não pode-se fixar o código. Documentado como follow-up. Recomendação: usuário deve **forçar refresh** (Ctrl+Shift+R) e desabilitar extensões para validar.
+
+## Endpoints reorganizados (defesa em profundidade)
+
+| Endpoint | Tipo | Auth | Motivo |
+|---|---|---|---|
+| `GET /api/memoriais/disciplinas` | catálogo | ❌ público | já era em v3.35.0 |
+| `GET /api/memoriais/:disciplina/wizard` | catálogo | ❌ público | já era em v3.35.0 |
+| **`POST /api/memoriais/hidraulico/calcular`** | **cálculo determinístico** | **❌ público (NOVO)** | **HOTFIX v3.37.0** |
+| `POST /api/memoriais/upload-pdf` | extrai PDF do user | ✅ auth | mantido |
+| `POST /api/memoriais/:disciplina/criar` | persiste | ✅ auth | mantido |
+| `GET /api/memoriais/:id` | dado da proposta | ✅ auth | mantido |
+| `GET /api/memoriais` | lista do user | ✅ auth | mantido |
+
+## Mudanças por arquivo
+
+### Backend (1 linha)
+
+- `src/server.ts:2456` — removido `requireAuth` do `POST /api/memoriais/hidraulico/calcular` + comentário de hotfix.
+
+### Frontend (`src/public/obras.html`)
+
+- `renderMemoriaisQuantitativos()` — detecta 401 e mostra mensagem clara em vez de "Nenhum memorial gerado ainda".
+
+## Testes
+
+`src/test/hotfix-memoriais-401.test.ts` — **8 testes**:
+
+1. POST `/calcular` NÃO usa `requireAuth`
+2. Comentário de hotfix presente (rastreabilidade)
+3. `/disciplinas` continua público (regressão)
+4. `/:disciplina/wizard` continua público (regressão)
+5. Endpoints que persistem MANTÊM `requireAuth` (defesa em profundidade)
+6. UI detecta 401 do `/api/memoriais`
+7. Mensagem UX clara em PT-BR
+8. "Nenhum memorial" só aparece quando autorizado (não confunde 401 com lista vazia)
+
+**Suite total**: 881 passing, 1 skipped, 0 failures (baseline 873 + 8 novos).
+
+## Política preservada
+
+- ✅ Endpoints que persistem ou retornam dados sensíveis continuam autenticados
+- ✅ Apenas cálculos puros (engine NBR 5626 + textos jurídicos públicos) são públicos
+- ✅ Mesmo padrão aplicado em v3.36.0 (`/adicional-campo/calcular`)
+- ✅ Schema do banco intacto
+
+## Follow-up
+
+- **Stack overflow obras:22912** — sem reprodução local, requer testar com hard refresh + sem extensões. Se persistir, abrir issue com replay de console.
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.36.0",
+  "version": "3.37.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -22848,6 +22848,7 @@ async function renderMemoriaisQuantitativos() {
 
   let disciplinas = [];
   let historico = [];
+  let historicoUnauthorized = false;
   try {
     const [dResp, hResp] = await Promise.all([
       fetch('/api/memoriais/disciplinas', { credentials: 'include' }),
@@ -22855,6 +22856,7 @@ async function renderMemoriaisQuantitativos() {
     ]);
     if (dResp.ok) disciplinas = (await dResp.json()).disciplinas || [];
     if (hResp.ok) historico = (await hResp.json()).items || [];
+    else if (hResp.status === 401) historicoUnauthorized = true; // v3.37.0: UX clara
   } catch (err) {
     v.innerHTML = `<div class="card empty">Erro ao carregar: ${escape(err.message || err)}</div>`;
     return;
@@ -22880,7 +22882,9 @@ async function renderMemoriaisQuantitativos() {
     </button>`;
   }).join('');
 
-  const linhasHist = historico.length === 0
+  const linhasHist = historicoUnauthorized
+    ? '<div class="card empty">🔒 Sessão expirada ou não autenticada. Faça login pra ver seu histórico de memoriais.</div>'
+    : historico.length === 0
     ? '<div class="card empty">Nenhum memorial gerado ainda. Comece selecionando uma disciplina acima.</div>'
     : historico.map(h => `<div class="card">
         <p style="margin:0; font-weight:600;">${escapeHtml(h.codigo)} · ${escapeHtml(h.obra_titulo)}</p>

--- a/src/server.ts
+++ b/src/server.ts
@@ -2453,7 +2453,11 @@ app.post('/api/memoriais/upload-pdf', requireAuth, async (req: Request, res: Res
   }
 });
 
-app.post('/api/memoriais/hidraulico/calcular', requireAuth, async (req: Request, res: Response) => {
+// v3.37.0 HOTFIX: /calcular tornado PUBLICO (espelhando /adicional-campo/calcular
+// da v3.36.0). Calculo e' deterministico — le apenas tabelas NBR 5626 hardcoded
+// no engine, nao acessa DB, nao persiste, nao retorna dado sensivel.
+// Diagnostico: user reportou 401 em producao ao usar o wizard hidraulico.
+app.post('/api/memoriais/hidraulico/calcular', async (req: Request, res: Response) => {
   try {
     const m = await import('./services/memoriais/hidraulicoCalc');
     const r = m.calcularMemorialHidraulico(req.body as Parameters<typeof m.calcularMemorialHidraulico>[0]);

--- a/src/test/hotfix-memoriais-401.test.ts
+++ b/src/test/hotfix-memoriais-401.test.ts
@@ -1,0 +1,62 @@
+// v3.37.0: testes de regressao do hotfix do 401 em /api/memoriais/hidraulico/calcular
+// + fallback UI quando /api/memoriais?limite=50 retorna 401.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER_TS = fs.readFileSync(path.join(process.cwd(), 'src', 'server.ts'), 'utf-8');
+const OBRAS_HTML = fs.readFileSync(path.join(process.cwd(), 'src', 'public', 'obras.html'), 'utf-8');
+
+describe('HOTFIX v3.37.0 — memoriais /calcular publico', () => {
+  it('1. POST /api/memoriais/hidraulico/calcular NAO usa requireAuth (publico)', () => {
+    const m = SERVER_TS.match(/app\.post\('\/api\/memoriais\/hidraulico\/calcular',\s*(\w+|async)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe('async');
+    expect(m![1]).not.toBe('requireAuth');
+  });
+
+  it('2. Comentario de hotfix presente em server.ts (rastreabilidade)', () => {
+    expect(SERVER_TS).toMatch(/v3\.37\.0 HOTFIX: \/calcular tornado PUBLICO/);
+  });
+
+  it('3. GET /api/memoriais/disciplinas continua publico (regressao)', () => {
+    const m = SERVER_TS.match(/app\.get\('\/api\/memoriais\/disciplinas',\s*(\w+|async)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe('async');
+  });
+
+  it('4. GET /api/memoriais/:disciplina/wizard continua publico (regressao)', () => {
+    const m = SERVER_TS.match(/app\.get\('\/api\/memoriais\/:disciplina\/wizard',\s*(\w+|async)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe('async');
+  });
+
+  it('5. Endpoints que persistem MANTEM requireAuth (defesa em profundidade)', () => {
+    // POST /upload-pdf (auth — lida com arquivo do user)
+    expect(SERVER_TS).toMatch(/app\.post\('\/api\/memoriais\/upload-pdf',\s*requireAuth/);
+    // POST /:disciplina/criar (persiste)
+    expect(SERVER_TS).toMatch(/app\.post\('\/api\/memoriais\/:disciplina\/criar',\s*requireAuth/);
+    // GET /:id (dado da proposta)
+    expect(SERVER_TS).toMatch(/app\.get\('\/api\/memoriais\/:id\(\\\\d\+\)',\s*requireAuth/);
+    // GET / (listar do user)
+    expect(SERVER_TS).toMatch(/app\.get\('\/api\/memoriais',\s*requireAuth/);
+  });
+});
+
+describe('v3.37.0 UI — fallback amigavel quando /api/memoriais retorna 401', () => {
+  it('6. renderMemoriaisQuantitativos detecta 401 do /api/memoriais', () => {
+    expect(OBRAS_HTML).toMatch(/historicoUnauthorized\s*=\s*false/);
+    expect(OBRAS_HTML).toMatch(/hResp\.status === 401/);
+  });
+
+  it('7. UX clara: "Sessao expirada ou nao autenticada"', () => {
+    expect(OBRAS_HTML).toMatch(/Sess[ãa]o expirada ou n[ãa]o autenticada/i);
+    expect(OBRAS_HTML).toMatch(/Faça login pra ver|Faca login pra ver/i);
+  });
+
+  it('8. Mensagem "Nenhum memorial" so aparece quando autorizado (nao confunde 401 com lista vazia)', () => {
+    // Verifica que a mensagem "Nenhum memorial gerado ainda" e' o segundo branch do ternario
+    expect(OBRAS_HTML).toMatch(/historicoUnauthorized[\s\S]*?Sess[ãa]o expirada[\s\S]*?:\s*historico\.length === 0/);
+  });
+});


### PR DESCRIPTION
…(v3.37.0)

DOIS BUGS resolvidos + 1 follow-up documentado:

1) POST /api/memoriais/hidraulico/calcular -> 401
   Sintoma: "Failed to load resource: status 401" no console em producao
   ao usar o wizard hidraulico.

   Diagnostico: mesmo padrao do hotfix v3.36.0 com /adicional-campo/calcular.
   O calculo NBR 5626 e' DETERMINISTICO — le apenas tabelas hardcoded no
   engine (hidraulicoCalc.ts), nao acessa DB, nao persiste, nao retorna
   dado sensivel.

   Fix: removido requireAuth do endpoint. Endpoints que PERSISTEM
   (upload-pdf, criar, get, listar) MANTEM requireAuth.

2) GET /api/memoriais?limite=50 -> 401
   Sintoma: mesma mensagem 401 ao abrir a aba "📐 Memoriais &
   Quantitativos" sem login. O frontend mostrava confusamente "Nenhum
   memorial gerado ainda" (era 401, nao lista vazia).

   Fix: renderMemoriaisQuantitativos detecta hResp.status === 401 e
   exibe mensagem clara:
     "🔒 Sessao expirada ou nao autenticada. Faca login pra ver seu
      historico de memoriais."

3) RangeError: Maximum call stack size exceeded (obras:22912)
   Sintoma: stack overflow em HTMLInputElement.<anonymous>.

   Diagnostico: linha 22912 do codigo atual e' um handler de BUTTON
   (data-mem-disc), nao input. Stack trace inconsistente com o codigo
   atual. Hipoteses: cache antigo do navegador OU extensao Chrome
   injetando codigo (mensagem "A listener indicated an asynchronous
   response..." e' tipica de extensao).

   Mitigacao: documentado como follow-up. Recomendacao ao user: hard
   refresh (Ctrl+Shift+R) + desabilitar extensoes. Se persistir, abrir
   issue com replay de console.

Reorganizacao defesa em profundidade:
- /disciplinas, /:disciplina/wizard, /calcular  -> PUBLICO
- /upload-pdf, /:disciplina/criar, /:id, /     -> requireAuth (mantido)

Testes: 8 novos cobrindo:
- /calcular publico (sem requireAuth)
- Comentario de hotfix rastreavel
- /disciplinas + /wizard continuam publicos (regressao)
- Endpoints sensiveis MANTEM auth
- UI detecta 401 com mensagem PT-BR clara
- "Nenhum memorial" so aparece quando autorizado

Suite total: 881 passing, 1 skipped, 0 failures (baseline 873 + 8). Typecheck limpo.