### PR TITLE
feat(demarcacao): alinha engine + PDF + UI ao gold standard PROP-2026…

### DIFF
--- a/06-Changelog/v3.38.0-alinha-proposta-prop-2026-0028.md
+++ b/06-Changelog/v3.38.0-alinha-proposta-prop-2026-0028.md
@@ -1,0 +1,142 @@
+# v3.38.0 — Alinhamento da Proposta de Demarcação ao Gold Standard PROP-2026-0028-R1
+
+**Data:** 2026-05-28
+**Branch:** `feature/proposta-demarcacao-alinha-prop-2026-0028-v3.38.0`
+**Base:** `main` (v3.37.0)
+**Versão alvo:** v3.38.0
+
+## Contexto
+
+O CEO compartilhou a **proposta PROP-2026-0028-R1** (CONSTRUSUL CONSTRUÇÕES LTDA / Parte da Fazenda Glória) como **gold standard aprovado** para Demarcação Rural. Comparando o output gerado hoje com o aprovado, identifiquei 6 divergências na fórmula e na estrutura da tabela. Esta release alinha 1:1.
+
+**Resultado canônico esperado e validado em teste:** R$ 6.619,26 com 2 parcelas de R$ 3.309,63 (50% sinal + 50% entrega final do laudo).
+
+## Mudanças de fórmula
+
+### 1. Adicional de Insalubridade/Periculosidade — base de incidência
+
+**Antes (v3.33.0–v3.37.0):** o adicional era aplicado **APÓS** o cálculo, multiplicando o `secao_5_total` (todos os itens já com complexidade + assessoria). Resultado: o adicional saía inflado pelo multiplicador.
+
+**Agora (v3.38.0):** incide **APENAS sobre `tecnicos_campo`** e é integrado à **BASE antes da complexidade e da assessoria**, conforme CLT art. 192-193, NR-15 e NR-16. Comportamento espelha o entendimento jurídico padrão (adicional remunera exposição da mão de obra, não inflate todo o preço).
+
+**Para outros subtipos** (georref, projeto executivo, etc.), o comportamento legado é mantido — apenas demarcacao_urbana / demarcacao_rural adotam a nova fórmula.
+
+### 2. Parcelas 2× (50/50) — sinal + entrega do laudo
+
+**Antes:** sempre 3 parcelas (40/30/30 — assinatura, campo, entrega).
+
+**Agora:** input opcional `num_parcelas: 2 | 3`. Default **2** no front (gold standard), com 3 disponível. Para 2×:
+- 1ª — `Assinatura do contrato (sinal)` — 50%
+- 2ª — `Entrega final + TRT/CFT` — 50%
+
+### 3. Alinhamento de Cerca — R$ 0,42/m com auto-fill = perímetro
+
+**Antes:** R$ 4,50/m. Input de metros manual.
+
+**Agora:**
+- Valor unitário default em `pricing-params.json` reduzido a **R$ 0,42/m**.
+- No frontend, quando o usuário não informa metros explicitamente, o sistema **adota o perímetro total** da poligonal como default.
+- Memória de cálculo visível no PDF: `extensão × R$ 0,42 = valor`.
+
+### 4. Laudo Técnico de Demarcação — item direto (não mais opcional)
+
+**Antes:** ficava na seção "Serviços Adicionais Opcionais" como checkbox; quando contratado, valor = `1 SM × multiplicador_complexidade × (1 + assessoria)`. Output inconsistente.
+
+**Agora:** item **direto** em `honorarios_romatec.laudo_tecnico_direto`. Valor fechado **R$ 1.621,00** (1 SM 2026), **sem multiplicador de complexidade**, **sem assessoria**, **sem desconto**. Aparece na tabela principal da Seção 4.
+
+**Retrocompat:** propostas antigas com `opcionais.laudo_tecnico.contratado=true` migram automaticamente para o item direto (mesmo valor 1 SM).
+
+### 5. Locação Kit GNSS — item novo, direto
+
+**Novo item.** `honorarios_romatec.locacao_kit_gnss`:
+- Diária default editável: **R$ 250,00** (campo no frontend permite override).
+- Quantidade multiplicável: aceita **meia diária (0,5)**, 1, 2, 3+ diárias.
+- Soma direta ao total — **fora** da complexidade/assessoria/desconto.
+- Discriminação fixa no PDF: *Receptor ComNav S6 (base) · T30 Plus com laser (rover) · tripé · base niveladora · bastão/bipé · coletora R80*.
+
+### 6. Opcionais reduzidos para 4 linhas
+
+`secao_opcionais_demarcacao.linhas` agora tem **4** linhas (laudo saiu): alinhamento, croqui, acompanhamento, jurídica.
+
+## Verificação numérica — PROP-2026-0028-R1
+
+Cenário: 29,04 ha · 4 vértices · perímetro 2.190,78 m · 1 diária · 30 km · 4 marcos madeira · insalubridade Grau Médio (20%) · complexidade média · Kit GNSS 1 diária · Laudo Técnico · 2 parcelas.
+
+| Item | Valor (R$) | Fórmula |
+|---|---|---|
+| TRT/CFT | 93,40 | tabela CFT 2026 |
+| Técnicos de campo | 680,82 | 1 × 1.621 × 0,42 |
+| Adicional de Insalubridade (20%) | 136,16 | 20% × 680,82 |
+| Marcos — Madeira | 140,00 | 4 × 35 |
+| Deslocamento | 105,00 | 30 × 3,50 |
+| Área (29,04 ha) | 2.323,20 | 29,04 × 80 |
+| **Subtotal bruto** | **3.478,58** | — |
+| Multiplicador complexidade (média) | +1.043,57 | ×1,3 |
+| Subtotal após complexidade | 4.522,15 | — |
+| Assessoria (5%) | +226,11 | 5% × 4.522,15 |
+| Subtotal core | 4.748,26 | — |
+| Locação Kit GNSS | +250,00 | 1 × 250 (direto) |
+| Laudo Técnico | +1.621,00 | 1 SM (direto) |
+| **TOTAL** | **6.619,26** | ✓ |
+| Parcela 1 (50%) | 3.309,63 | sinal |
+| Parcela 2 (50%) | 3.309,63 | entrega + TRT/CFT |
+
+Todos validados em `demarcacaoLotes.test.ts` (testes 38–43).
+
+## Arquivos alterados
+
+### Engine + types
+
+- `src/services/pricing/types.ts` — `InputDemarcacaoLotes` ganha `adicional_campo_pct`, `laudo_tecnico_direto`, `locacao_kit_gnss`, `num_parcelas`. `DemarcacaoLotesOutput.honorarios_romatec` ganha `adicional_campo`, `laudo_tecnico_direto`, `locacao_kit_gnss`.
+- `src/services/pricing/params.ts` — tipo `demarcacao_lotes_2026` ganha `laudo_tecnico_direto`, `locacao_kit_gnss`, `parcelas_2x`.
+- `src/services/pricing/demarcacaoLotes.ts` — fórmula reescrita: adicional na base antes da complexidade; extras diretos (Kit + Laudo) somam depois; parcelas 2× ou 3×; retrocompat de laudo via `opcionais.laudo_tecnico`.
+- `src/services/pricing/demarcacaoLotes.test.ts` — 22 testes novos (#23–#44). Suite agora 44 testes, todos verdes.
+
+### Config
+
+- `config/pricing-params.json` — `alinhamento_cerca.valor_unitario`: 4,50 → **0,42**. Adicionado `laudo_tecnico_direto`, `locacao_kit_gnss`, `parcelas_2x`.
+
+### Backend
+
+- `src/integrations/propostasConsultoria.ts`:
+  - Em `criarPropostaConsultoria` (linha ~190): para demarcacao, deriva `pct` via `calcularAdicionalCampo` e injeta `adicional_campo_pct` em `dados_imovel` **antes** do engine.
+  - Em `previewCustoConsultoria` (linha ~611): mesmo padrão; assinatura agora aceita `adicional_campo` opcional.
+  - Bloco pós-cálculo (linha ~355) ajustado: para demarcacao, **não** multiplica o `secao_5_total` (engine já integrou); só persiste o snapshot.
+  - `renderDemarcacaoLotesBody` (linha ~1985): tabela inclui linha do adicional quando aplicável, linha do Kit GNSS com descritivo, linha do Laudo Técnico direto.
+
+### Frontend (`src/public/obras.html`)
+
+- Form de demarcação:
+  - Removido checkbox "Laudo Técnico" da seção opcional.
+  - Adicionada seção **🛰️ Itens Diretos** com checkbox Kit GNSS (qtd + R$/diária) e checkbox Laudo Técnico direto.
+  - Adicionada seção **💳 Parcelamento** com select 2× (default) / 3×.
+  - Alinhamento de cerca: label atualizado para "R$ 0,42/m"; campo "Metros" passa a aceitar default = perímetro quando vazio.
+- `montarDadosImovel()` passa `laudo_tecnico_direto`, `locacao_kit_gnss`, `num_parcelas` e usa valor_unitario `0.42` para alinhamento.
+- Preview POST agora envia `adicional_campo` no body (preview reflete fórmula nova).
+
+## Política preservada
+
+- ✅ Retrocompat: propostas v3.37.0 com `opcionais.laudo_tecnico.contratado=true` continuam renderizando (migra para item direto em runtime).
+- ✅ Retrocompat: input sem `num_parcelas` mantém 3× (40/30/30).
+- ✅ Retrocompat: input sem `adicional_campo_pct` calcula com 0 (sem adicional).
+- ✅ Retrocompat: outros subtipos (georref, projeto exec.) **não** mudam fórmula — adicional segue post-hoc.
+- ✅ Snapshot de blocos jurídicos do adicional continua persistido em `custos_calculados.adicional_campo` para renderização do PDF.
+- ✅ Mínimo garantido 2 SM aplicado sobre `core` (antes dos extras diretos), preservando margem.
+
+## Testes
+
+`src/services/pricing/demarcacaoLotes.test.ts` — **44 testes** (22 baseline + 22 novos):
+
+| # | Bloco | Cobertura |
+|---|---|---|
+| 23–26 | Adicional na base | pct=0 não muda total; 20% só sobre tec; entra antes da complexidade; validação 0–40 |
+| 27–29 | Laudo direto | contratado soma 1 SM fora da complexidade; retrocompat via opcionais legacy; default sem contratação |
+| 30–34 | Kit GNSS | qtd=0 zero valor; qtd=1 + diária default = 250; meia + 3 diárias; diária custom; descritivo no output |
+| 35–37 | Parcelas | default 3×; num_parcelas=2 ⇒ 50/50; residuo de arredondamento na última |
+| 38–44 | PROP-2026-0028-R1 | TODAS as linhas individuais + complexidade + assessoria + Kit/Laudo + TOTAL exato 6.619,26 + parcelas 3.309,63 + alinhamento de cerca 920,13 |
+
+**Suite total:** 903 passing, 1 skipped, 0 failures (baseline 881 + 22 novos).
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/config/pricing-params.json
+++ b/config/pricing-params.json
@@ -181,10 +181,16 @@
     },
     "opcionais": {
       "laudo_tecnico":        { "rotulo": "Laudo Tecnico de Demarcacao", "valor_unitario_sm_multiplicador": 1.0 },
-      "alinhamento_cerca":    { "rotulo": "Alinhamento de Cerca", "valor_unitario": 4.50, "unidade": "metro" },
+      "alinhamento_cerca":    { "rotulo": "Alinhamento de Cerca", "valor_unitario": 0.42, "unidade": "metro" },
       "croqui_assinado":      { "rotulo": "Croqui Assinado em Cartorio", "valor_unitario": 180.00 },
       "acompanhamento_obra":  { "rotulo": "Acompanhamento de Obra", "valor_unitario": 350.00, "unidade": "diaria" },
       "consultoria_juridica": { "rotulo": "Consultoria Juridica", "valor": "sob_orcamento" }
+    },
+    "laudo_tecnico_direto":   { "rotulo": "Laudo Tecnico de Demarcacao", "valor_unitario_sm_multiplicador": 1.0 },
+    "locacao_kit_gnss":       {
+      "rotulo": "Locacao de equipamentos — Kit GNSS",
+      "valor_unitario_diaria_default": 250.00,
+      "descritivo": "Receptor ComNav S6 (base); Receptor T30 Plus com laser (rover); tripe; base niveladora; bastao/bipe; coletora R80."
     },
     "minimo_garantido_sm": 2,
     "complexidade_multiplicadores": { "simples": 1.0, "media": 1.3, "alta": 1.6 },
@@ -194,6 +200,10 @@
       { "numero": 1, "rotulo": "Assinatura do contrato",      "percentual": 40 },
       { "numero": 2, "rotulo": "Entrega do trabalho de campo", "percentual": 30 },
       { "numero": 3, "rotulo": "Entrega final + TRT/CFT",      "percentual": 30 }
+    ],
+    "parcelas_2x": [
+      { "numero": 1, "rotulo": "Assinatura do contrato (sinal)", "percentual": 50 },
+      { "numero": 2, "rotulo": "Entrega final + TRT/CFT",        "percentual": 50 }
     ],
     "validade_dias_default": 15
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.37.0",
+  "version": "3.38.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -189,8 +189,26 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
     );
   } else if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
     // v3.27.0: Demarcacao de Lotes (Urbana e Rural)
+    // v3.38.0: se adicional_campo (insal/peric) foi solicitado, deriva o pct
+    // e INJETA em dados_imovel antes do engine — assim o adicional entra na
+    // BASE (antes da complexidade) conforme PROP-2026-0028-R1.
+    const dadosInjetados: Record<string, unknown> = { ...input.dados_imovel };
+    if (input.adicional_campo?.ativo && input.adicional_campo.cenario) {
+      try {
+        const modAd = await import('../services/pricing/adicionalCampo');
+        const r2 = modAd.calcularAdicionalCampo({
+          ativo: true,
+          cenario: input.adicional_campo.cenario,
+          tipo: input.adicional_campo.tipo,
+          grau: input.adicional_campo.grau,
+        });
+        dadosInjetados.adicional_campo_pct = r2.percentual;
+      } catch (err) {
+        console.warn(`[demarcacao+adicional v3.38.0] falha derivar pct: ${(err as Error).message}`);
+      }
+    }
     const m = await import('../services/pricing/demarcacaoLotes');
-    const out = m.calcularDemarcacaoLotes(input.dados_imovel as unknown as InputDemarcacaoLotes);
+    const out = m.calcularDemarcacaoLotes(dadosInjetados as unknown as InputDemarcacaoLotes);
     resultado = {
       custos: adaptarDemarcacaoParaCustosCalculados(out),
       fontes: {} as FontesConsulta,
@@ -355,6 +373,10 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
   // v3.33.0 (= v3.27.1 do prompt): adicional REFACTORED com wizard de cenario.
   // Se o caller envia `adicional_campo` (novo), usa o engine v3.33.0; senao,
   // cai no fallback aditivo_campo v3.29.0 (compat retro).
+  //
+  // v3.38.0: para demarcacao_urbana/demarcacao_rural o engine ja' integrou o
+  // adicional na BASE (antes da complexidade) — nao multiplicar o total
+  // novamente aqui. Persiste apenas o snapshot (blocos juridicos / dados pro PDF).
   if (input.adicional_campo?.ativo && input.adicional_campo.cenario) {
     try {
       const mod = await import('../services/pricing/adicionalCampo');
@@ -367,15 +389,28 @@ export async function criarPropostaConsultoria(input: CriarPropostaConsultoriaIn
         bloco_justificativa_cliente_editado: input.adicional_campo.bloco_justificativa_cliente_editado,
         observacao_adicional: input.adicional_campo.observacao_adicional,
       });
-      // Calcula o valor monetario: percentual sobre o secao_5_total ANTES de
-      // qualquer adicional/desconto extra (snapshot do subtotal de campo).
-      const subtotalBase = round2Lib(resultado.custos.secao_5_total);
-      const valorAdicional = round2Lib(subtotalBase * r2.percentual / 100);
-      const novoTotal = round2Lib(subtotalBase + valorAdicional);
-      const custosAtualizados = {
-        ...resultado.custos,
-        secao_5_total: novoTotal,
-      };
+      const isDemarcacao = subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural';
+      let novoTotal: number;
+      let custosAtualizados: typeof resultado.custos;
+      let subtotalBase: number;
+      let valorAdicional: number;
+      if (isDemarcacao) {
+        // v3.38.0: engine ja integrou. Snapshot reflete os valores ja calculados.
+        novoTotal = round2Lib(resultado.custos.secao_5_total);
+        const hr = (resultado.custos as unknown as { honorarios_romatec_demarcacao?: { tecnicos_campo: number; adicional_campo: { valor: number } } }).honorarios_romatec_demarcacao;
+        subtotalBase = hr ? round2Lib(hr.tecnicos_campo) : 0;
+        valorAdicional = hr ? round2Lib(hr.adicional_campo.valor) : 0;
+        custosAtualizados = { ...resultado.custos };
+      } else {
+        // Comportamento legado: multiplica secao_5_total pelo percentual.
+        subtotalBase = round2Lib(resultado.custos.secao_5_total);
+        valorAdicional = round2Lib(subtotalBase * r2.percentual / 100);
+        novoTotal = round2Lib(subtotalBase + valorAdicional);
+        custosAtualizados = {
+          ...resultado.custos,
+          secao_5_total: novoTotal,
+        };
+      }
       (custosAtualizados as unknown as { adicional_campo: typeof r2 & { valor_aplicado: number; subtotal_base: number } }).adicional_campo = {
         ...r2,
         valor_aplicado: valorAdicional,
@@ -520,6 +555,14 @@ async function aplicarAditivoCampo(args: {
 export async function previewCustoConsultoria(input: {
   subtipo: SubtipoConsultoria;
   dados_imovel: Record<string, unknown>;
+  // v3.38.0: preview de demarcacao aceita adicional_campo para refletir
+  // o gold standard (adicional integrado na base ANTES da complexidade).
+  adicional_campo?: {
+    ativo?: boolean;
+    cenario?: string;
+    tipo?: string;
+    grau?: string;
+  };
 }) {
   const { subtipo, dados_imovel } = input;
   if (subtipo === 'averbacao_residencial' || subtipo === 'averbacao_comercial') {
@@ -609,8 +652,24 @@ export async function previewCustoConsultoria(input: {
   }
   // v3.27.0: Demarcacao de Lotes (Urbana e Rural)
   if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+    // v3.38.0: derivar adicional_campo_pct se presente, antes do engine
+    const dadosInjetados: Record<string, unknown> = { ...dados_imovel };
+    if (input.adicional_campo?.ativo && input.adicional_campo.cenario) {
+      try {
+        const modAd = await import('../services/pricing/adicionalCampo');
+        const r2 = modAd.calcularAdicionalCampo({
+          ativo: true,
+          cenario: input.adicional_campo.cenario as Parameters<typeof modAd.calcularAdicionalCampo>[0]['cenario'],
+          tipo: input.adicional_campo.tipo as Parameters<typeof modAd.calcularAdicionalCampo>[0]['tipo'],
+          grau: input.adicional_campo.grau as Parameters<typeof modAd.calcularAdicionalCampo>[0]['grau'],
+        });
+        dadosInjetados.adicional_campo_pct = r2.percentual;
+      } catch (err) {
+        console.warn(`[preview demarcacao+adicional v3.38.0] falha: ${(err as Error).message}`);
+      }
+    }
     const m = await import('../services/pricing/demarcacaoLotes');
-    const out = m.calcularDemarcacaoLotes(dados_imovel as unknown as InputDemarcacaoLotes);
+    const out = m.calcularDemarcacaoLotes(dadosInjetados as unknown as InputDemarcacaoLotes);
     const custos = adaptarDemarcacaoParaCustosCalculados(out);
     return {
       ok: true as const,
@@ -1982,15 +2041,57 @@ function renderDemarcacaoLotesBody(
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.2);
 
+  // v3.38.0: alinhamento a PROP-2026-0028-R1 (gold standard)
+  //   - Adicional de insal/peric incide sobre tecnicos_campo, integrado na base
+  //   - Kit GNSS e Laudo Tecnico aparecem como itens DIRETOS (fora da complexidade)
   const linhasHon: Array<{ label: string; valor: number; obs?: string }> = hr
-    ? [
-        { label: 'TRT/CFT — Termo de Responsabilidade Tecnica (CFT/MA)', valor: hr.trt_cft, obs: 'Tec. em Agrimensura CFT/MA n. 01209185369' },
-        { label: 'Tecnicos de campo', valor: hr.tecnicos_campo, obs: `${di.diarias_equipe || 0} diaria(s) x SM x fator CFT-MA 0,42 (Res. 12/2025)` },
-        { label: `Area do servico (${isUrbana ? 'm²' : 'hectare'})`, valor: hr.area_servico, obs: isUrbana ? `${di.area_m2 || 0} m² x valor unitario` : `${di.area_hectares || 0} ha x valor unitario` },
-        { label: 'Deslocamento', valor: hr.deslocamento, obs: `${di.km_deslocamento || 0} km x R$ 3,50/km` },
-        { label: `Multiplicador de complexidade (${di.complexidade || 'media'})`, valor: hr.subtotal_apos_complexidade - (hr.trt_cft + hr.tecnicos_campo + hr.marcos_subtotal + hr.deslocamento + hr.area_servico), obs: `x ${hr.complexidade_multiplicador}` },
-        { label: 'Assessoria (5%)', valor: hr.assessoria },
-      ]
+    ? (() => {
+        const arr: Array<{ label: string; valor: number; obs?: string }> = [
+          { label: 'TRT/CFT — Termo de Responsabilidade Tecnica (CFT/MA)', valor: hr.trt_cft, obs: 'Tec. em Agrimensura CFT/MA n. 01209185369' },
+          { label: 'Tecnicos de campo', valor: hr.tecnicos_campo, obs: `${di.diarias_equipe || 0} diaria(s) x SM x fator CFT-MA 0,42 (Res. 12/2025)` },
+        ];
+        // v3.38.0: adicional de campo (se aplicavel)
+        if (hr.adicional_campo?.aplicavel && hr.adicional_campo.valor > 0) {
+          const tipoLabel = hr.adicional_campo.pct === 30 ? 'Periculosidade' : 'Insalubridade';
+          const grauLabel = hr.adicional_campo.pct === 10 ? ' (Grau Minimo)'
+            : hr.adicional_campo.pct === 20 ? ' (Grau Medio)'
+            : hr.adicional_campo.pct === 40 ? ' (Grau Maximo)'
+            : '';
+          const norma = hr.adicional_campo.pct === 30
+            ? 'CLT art. 193 / NR-16'
+            : 'CLT art. 192 / NR-15';
+          arr.push({
+            label: `Adicional de ${tipoLabel}${grauLabel}`,
+            valor: hr.adicional_campo.valor,
+            obs: `${hr.adicional_campo.pct}% x Tecnicos de campo (${norma})`,
+          });
+        }
+        arr.push(
+          { label: `Area do servico (${isUrbana ? 'm²' : 'hectare'})`, valor: hr.area_servico, obs: isUrbana ? `${di.area_m2 || 0} m² x valor unitario` : `${di.area_hectares || 0} ha x valor unitario` },
+          { label: 'Deslocamento', valor: hr.deslocamento, obs: `${di.km_deslocamento || 0} km x R$ 3,50/km` },
+          { label: `Multiplicador de complexidade (${di.complexidade || 'media'})`, valor: hr.subtotal_apos_complexidade - (hr.trt_cft + hr.tecnicos_campo + (hr.adicional_campo?.valor || 0) + hr.marcos_subtotal + hr.deslocamento + hr.area_servico), obs: `x ${hr.complexidade_multiplicador}` },
+          { label: 'Assessoria (5%)', valor: hr.assessoria },
+        );
+        // v3.38.0: Kit GNSS (item direto)
+        if (hr.locacao_kit_gnss?.contratado && hr.locacao_kit_gnss.valor > 0) {
+          const qtd = hr.locacao_kit_gnss.qtd_diarias;
+          const diaria = hr.locacao_kit_gnss.diaria;
+          arr.push({
+            label: 'Locacao de equipamentos — Kit GNSS',
+            valor: hr.locacao_kit_gnss.valor,
+            obs: `${qtd} diaria(s) x R$ ${diaria.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}${hr.locacao_kit_gnss.descritivo ? ' — ' + hr.locacao_kit_gnss.descritivo : ''}`,
+          });
+        }
+        // v3.38.0: Laudo Tecnico (item direto)
+        if (hr.laudo_tecnico_direto?.contratado && hr.laudo_tecnico_direto.valor > 0) {
+          arr.push({
+            label: 'Laudo Tecnico de Demarcacao',
+            valor: hr.laudo_tecnico_direto.valor,
+            obs: 'valor fechado (1 SM 2026)',
+          });
+        }
+        return arr;
+      })()
     : (custos.secao_3_honorarios || []).map((h) => ({ label: h.descricao, valor: Number(h.valor), obs: h.observacao }));
 
   linhasHon.forEach((h) => {
@@ -2084,7 +2185,7 @@ function renderDemarcacaoLotesBody(
   // ── 5. BOX VERDE — VALOR TOTAL ────────────────────────────────────────
   const totalRomatec = hr?.total ?? custos.honorarios_romatec?.total ?? custos.secao_5_total;
   if (doc.y > 700) doc.addPage();
-  const txtTotalNota = 'Soma de TRT/CFT + Tecnicos de campo + Marcos + Deslocamento + Area, com complexidade e assessoria. Eventuais custos de cartorio para averbacao da demarcacao NAO estao inclusos.';
+  const txtTotalNota = 'Soma de TRT/CFT + Tecnicos de campo (com adicional de insal/peric quando aplicavel) + Marcos + Deslocamento + Area, com complexidade e assessoria, mais Locacao de Kit GNSS e Laudo Tecnico de Demarcacao (itens diretos, quando contratados). Eventuais custos de cartorio para averbacao da demarcacao NAO estao inclusos.';
   const boxYT = doc.y;
   const boxAlturaT = doc.heightOfString(txtTotalNota, { width: COL_W - 24 }) + 38;
   doc.rect(COL_X_INI, boxYT, COL_W, boxAlturaT).fillAndStroke(COR_VERDE_BG, COR_VERDE_BORDA);

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -9256,11 +9256,33 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
         </div>
         <label>Validade (dias) <input id="dmValidade" type="number" min="1" step="1" value="${cache?.validade_dias ?? 15}" style="width:100%;"></label>
 
-        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">➕ Opcionais (não somam ao total)</p>
-        <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcLaudo" type="checkbox"> Laudo Técnico (1 SM)</label>
+        <!-- v3.38.0: itens diretos (Kit GNSS + Laudo) — alinhamento a PROP-2026-0028-R1 -->
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">🛰️ Itens Diretos (somam ao total)</p>
         <div class="lp-grid-2">
-          <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcAlinh" type="checkbox"> Alinhamento de Cerca</label>
-          <label>Metros <input id="dmOpcAlinhM" type="number" min="0" step="1" value="0" style="width:100%;"></label>
+          <label style="display:flex; gap:6px; align-items:center;"><input id="dmKitGnss" type="checkbox" ${cache?.locacao_kit_gnss_contratado ? 'checked' : ''}> Locação Kit GNSS</label>
+          <div></div>
+        </div>
+        <div class="lp-grid-2">
+          <label>Diárias (admite 0,5) <input id="dmKitGnssQtd" type="number" min="0" step="0.5" value="${cache?.locacao_kit_gnss_qtd ?? 1}" style="width:100%;"></label>
+          <label>R$/diária <input id="dmKitGnssDiaria" type="number" min="0" step="0.01" value="${cache?.locacao_kit_gnss_diaria ?? 250}" style="width:100%;"></label>
+        </div>
+        <div style="font-size:11px; color:var(--text-muted); margin:-4px 0 6px 4px;">
+          ComNav S6 (base) · T30 Plus c/ laser (rover) · tripé · base niveladora · bastão/bipé · coletora R80
+        </div>
+        <label style="display:flex; gap:6px; align-items:center;"><input id="dmLaudoDireto" type="checkbox" ${cache?.laudo_tecnico_direto_contratado ? 'checked' : ''}> Laudo Técnico de Demarcação (R$ 1.621 — 1 SM 2026)</label>
+
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">💳 Parcelamento</p>
+        <label>Nº de parcelas
+          <select id="dmNumParcelas" style="width:100%;">
+            <option value="2"${(cache?.num_parcelas ?? 2) === 2 ? ' selected' : ''}>2× (50% sinal · 50% entrega do laudo)</option>
+            <option value="3"${(cache?.num_parcelas ?? 2) === 3 ? ' selected' : ''}>3× (40/30/30 — assinatura · campo · entrega final)</option>
+          </select>
+        </label>
+
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">➕ Opcionais (não somam ao total)</p>
+        <div class="lp-grid-2">
+          <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcAlinh" type="checkbox"> Alinhamento de Cerca (R$ 0,42/m)</label>
+          <label>Metros (default = perímetro) <input id="dmOpcAlinhM" type="number" min="0" step="0.01" value="${cache?.alinhamento_metros ?? ''}" style="width:100%;"></label>
         </div>
         <label style="display:flex; gap:6px; align-items:center;"><input id="dmOpcCroqui" type="checkbox"> Croqui Assinado em Cartório (R$ 180)</label>
         <div class="lp-grid-2">
@@ -9367,10 +9389,13 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     if (m > 0) marcos.push({ tipo: 'madeira',          quantidade: m, valor_unitario_congelado: VU.madeira });
 
     const opcionais = {};
-    if (document.getElementById('dmOpcLaudo').checked)
-      opcionais.laudo_tecnico = { contratado: true, valor_unitario_sm_multiplicador: 1.0 };
-    if (document.getElementById('dmOpcAlinh').checked)
-      opcionais.alinhamento_cerca = { contratado: true, metros: parseFloat(document.getElementById('dmOpcAlinhM').value) || 0, valor_unitario: 4.5 };
+    // v3.38.0: alinhamento de cerca — default = perimetro_m; R$ 0,42/m (gold standard)
+    const perimetroM = parseFloat(document.getElementById('dmPerimetro').value) || 0;
+    if (document.getElementById('dmOpcAlinh').checked) {
+      const metrosInput = parseFloat(document.getElementById('dmOpcAlinhM').value);
+      const metros = Number.isFinite(metrosInput) && metrosInput > 0 ? metrosInput : perimetroM;
+      opcionais.alinhamento_cerca = { contratado: true, metros, valor_unitario: 0.42 };
+    }
     if (document.getElementById('dmOpcCroqui').checked)
       opcionais.croqui_assinado = { contratado: true, valor_unitario: 180 };
     if (document.getElementById('dmOpcAcomp').checked)
@@ -9378,13 +9403,18 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     if (document.getElementById('dmOpcJurid').checked)
       opcionais.consultoria_juridica = { contratado: true, valor: 'sob_orcamento' };
 
+    // v3.38.0: itens diretos (Kit GNSS + Laudo Tecnico)
+    const kitContratado = document.getElementById('dmKitGnss').checked;
+    const laudoContratado = document.getElementById('dmLaudoDireto').checked;
+    const numParcelas = parseInt(document.getElementById('dmNumParcelas').value, 10) === 3 ? 3 : 2;
+
     const dados = {
       subtipo, finalidade,
       municipio: document.getElementById('dmMunicipio').value.trim(),
       uf: document.getElementById('dmUf').value.trim(),
       matricula: document.getElementById('dmMatricula').value.trim() || undefined,
       cri: document.getElementById('dmCri').value.trim() || undefined,
-      perimetro_m: parseFloat(document.getElementById('dmPerimetro').value) || undefined,
+      perimetro_m: perimetroM || undefined,
       num_vertices,
       servico_piqueteamento: piquet,
       marcos,
@@ -9395,6 +9425,13 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
       desconto_pct: parseFloat(document.getElementById('dmDesc').value) || 0,
       validade_dias: parseInt(document.getElementById('dmValidade').value, 10) || 15,
       opcionais,
+      // v3.38.0
+      laudo_tecnico_direto: laudoContratado ? { contratado: true, valor_unitario_sm_multiplicador: 1.0 } : undefined,
+      locacao_kit_gnss: kitContratado ? {
+        qtd_diarias: parseFloat(document.getElementById('dmKitGnssQtd').value) || 1,
+        diaria: parseFloat(document.getElementById('dmKitGnssDiaria').value) || 250,
+      } : undefined,
+      num_parcelas: numParcelas,
     };
     if (isUrbana) {
       dados.loteamento_nome = document.getElementById('dmLoteamento').value.trim() || undefined;
@@ -9438,7 +9475,9 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
       const r = await api('/api/propostas-consultoria/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ subtipo, dados_imovel: dados }),
+        // v3.38.0: envia adicional_campo no preview pra refletir gold standard
+        // (adicional integrado na base, antes da complexidade) ja na pre-visualizacao.
+        body: JSON.stringify({ subtipo, dados_imovel: dados, adicional_campo: adicionalCampo || undefined }),
       });
       // v3.30.0 HOTFIX: shape do ctx alinhado com os outros 6 forms (cliId,
       // nao cliente_id) — o submit handler comum em cnsSalvar.onclick le

--- a/src/services/pricing/demarcacaoLotes.test.ts
+++ b/src/services/pricing/demarcacaoLotes.test.ts
@@ -195,13 +195,19 @@ describe('calcularDemarcacaoLotes — calculo principal', () => {
 });
 
 describe('calcularDemarcacaoLotes — opcionais', () => {
-  it('18. Opcionais: 5 linhas sempre, mesmo com nenhum contratado', () => {
+  it('18. Opcionais: 4 linhas sempre (v3.38.0 — laudo virou item direto)', () => {
     const r = calcularDemarcacaoLotes(baseUrbana);
-    expect(r.secao_opcionais_demarcacao.linhas).toHaveLength(5);
+    expect(r.secao_opcionais_demarcacao.linhas).toHaveLength(4);
     expect(r.secao_opcionais_demarcacao.subtotal).toBe(0);
+    const rotulos = r.secao_opcionais_demarcacao.linhas.map((l) => l.rotulo).join(' | ');
+    expect(rotulos).not.toMatch(/Laudo/i);
+    expect(rotulos).toMatch(/Alinhamento/i);
+    expect(rotulos).toMatch(/Croqui/i);
+    expect(rotulos).toMatch(/Acompanhamento/i);
+    expect(rotulos).toMatch(/Juridica/i);
   });
 
-  it('19. alinhamento_cerca com metros=120 -> subtotal = 120 × 4.50', () => {
+  it('19. alinhamento_cerca com metros=120 -> subtotal = 120 × valor_unitario (override)', () => {
     const r = calcularDemarcacaoLotes({
       ...baseUrbana,
       opcionais: { alinhamento_cerca: { contratado: true, metros: 120, valor_unitario: 4.5 } },
@@ -221,13 +227,12 @@ describe('calcularDemarcacaoLotes — opcionais', () => {
     expect(linha?.contratado).toBe(true);
   });
 
-  it('21. Opcionais NAO somam ao total Romatec', () => {
+  it('21. Opcionais (sem laudo) NAO somam ao total Romatec', () => {
     const semOpc = calcularDemarcacaoLotes(baseUrbana);
     const comOpc = calcularDemarcacaoLotes({
       ...baseUrbana,
       opcionais: {
-        laudo_tecnico: { contratado: true, valor_unitario_sm_multiplicador: 1.0 },
-        alinhamento_cerca: { contratado: true, metros: 100, valor_unitario: 4.5 },
+        alinhamento_cerca: { contratado: true, metros: 100, valor_unitario: 0.42 },
         croqui_assinado: { contratado: true, valor_unitario: 180 },
       },
     });
@@ -243,5 +248,229 @@ describe('calcularDemarcacaoLotes — opcionais', () => {
     expect(r2.honorarios_romatec.tecnicos_campo).toBeGreaterThan(r1.honorarios_romatec.tecnicos_campo);
     expect(r1.salario_minimo_usado).toBe(1500);
     expect(r2.salario_minimo_usado).toBe(2000);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// v3.38.0 — alinhamento a PROP-2026-0028-R1 (gold standard aprovado pelo CEO)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('v3.38.0 — adicional de campo (insal/peric) na base', () => {
+  it('23. adicional_campo_pct=0 (default) — output zerado, total nao muda', () => {
+    const semAd = calcularDemarcacaoLotes(baseUrbana);
+    const comAd = calcularDemarcacaoLotes({ ...baseUrbana, adicional_campo_pct: 0 });
+    expect(comAd.honorarios_romatec.adicional_campo.aplicavel).toBe(false);
+    expect(comAd.honorarios_romatec.adicional_campo.valor).toBe(0);
+    expect(comAd.honorarios_romatec.total).toBe(semAd.honorarios_romatec.total);
+  });
+
+  it('24. adicional=20% incide SOMENTE sobre tecnicos_campo (CLT 192/II)', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, adicional_campo_pct: 20 });
+    const ad = r.honorarios_romatec.adicional_campo;
+    const expectado = r.honorarios_romatec.tecnicos_campo * 0.20;
+    expect(ad.aplicavel).toBe(true);
+    expect(ad.pct).toBe(20);
+    expect(ad.valor).toBeCloseTo(expectado, 2);
+  });
+
+  it('25. adicional entra na base ANTES da complexidade (multiplicado por x1.3 etc)', () => {
+    const r0 = calcularDemarcacaoLotes({ ...baseUrbana, adicional_campo_pct: 0 });
+    const r20 = calcularDemarcacaoLotes({ ...baseUrbana, adicional_campo_pct: 20 });
+    const delta = r20.honorarios_romatec.subtotal_apos_complexidade - r0.honorarios_romatec.subtotal_apos_complexidade;
+    const tec = r20.honorarios_romatec.tecnicos_campo;
+    // delta = adicional × complexidade (= 20% × tec × 1.3 para 'media')
+    expect(delta).toBeCloseTo(tec * 0.20 * 1.3, 1);
+  });
+
+  it('26. adicional_campo_pct invalido (-1 ou 41) -> throw', () => {
+    expect(() => calcularDemarcacaoLotes({ ...baseUrbana, adicional_campo_pct: -1 }))
+      .toThrow(/adicional_campo_pct/);
+    expect(() => calcularDemarcacaoLotes({ ...baseUrbana, adicional_campo_pct: 41 }))
+      .toThrow(/adicional_campo_pct/);
+  });
+});
+
+describe('v3.38.0 — Laudo Tecnico de Demarcacao (item direto)', () => {
+  it('27. laudo_tecnico_direto.contratado=true -> soma 1 SM ao total, fora da complexidade', () => {
+    const sem = calcularDemarcacaoLotes(baseUrbana);
+    const com = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      laudo_tecnico_direto: { contratado: true },
+    });
+    expect(com.honorarios_romatec.laudo_tecnico_direto.contratado).toBe(true);
+    expect(com.honorarios_romatec.laudo_tecnico_direto.valor).toBeCloseTo(SM_2026 * 1.0, 2);
+    // Diferenca exata = laudo (sem complexidade nem assessoria nem desconto)
+    expect(com.honorarios_romatec.total - sem.honorarios_romatec.total).toBeCloseTo(SM_2026, 2);
+  });
+
+  it('28. Retrocompat: opcionais.laudo_tecnico.contratado=true migra pra item direto', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      opcionais: { laudo_tecnico: { contratado: true, valor_unitario_sm_multiplicador: 1.0 } },
+    });
+    expect(r.honorarios_romatec.laudo_tecnico_direto.contratado).toBe(true);
+    expect(r.honorarios_romatec.laudo_tecnico_direto.valor).toBeCloseTo(SM_2026, 2);
+  });
+
+  it('29. Sem contratacao -> laudo_tecnico_direto.contratado=false, valor=0', () => {
+    const r = calcularDemarcacaoLotes(baseUrbana);
+    expect(r.honorarios_romatec.laudo_tecnico_direto.contratado).toBe(false);
+    expect(r.honorarios_romatec.laudo_tecnico_direto.valor).toBe(0);
+  });
+});
+
+describe('v3.38.0 — Locacao Kit GNSS (item direto)', () => {
+  it('30. qtd_diarias=0 (default) -> contratado=false, valor=0', () => {
+    const r = calcularDemarcacaoLotes(baseUrbana);
+    expect(r.honorarios_romatec.locacao_kit_gnss.contratado).toBe(false);
+    expect(r.honorarios_romatec.locacao_kit_gnss.valor).toBe(0);
+  });
+
+  it('31. qtd_diarias=1, diaria default (250) -> valor=250 somado ao total', () => {
+    const sem = calcularDemarcacaoLotes(baseUrbana);
+    const com = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 1 } });
+    expect(com.honorarios_romatec.locacao_kit_gnss.contratado).toBe(true);
+    expect(com.honorarios_romatec.locacao_kit_gnss.qtd_diarias).toBe(1);
+    expect(com.honorarios_romatec.locacao_kit_gnss.diaria).toBeCloseTo(250, 2);
+    expect(com.honorarios_romatec.locacao_kit_gnss.valor).toBeCloseTo(250, 2);
+    expect(com.honorarios_romatec.total - sem.honorarios_romatec.total).toBeCloseTo(250, 2);
+  });
+
+  it('32. Meia diaria (0.5) e multiplas (3) aceitas — fora da complexidade', () => {
+    const meia = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 0.5 } });
+    expect(meia.honorarios_romatec.locacao_kit_gnss.valor).toBeCloseTo(125, 2);
+    const tres = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 3 } });
+    expect(tres.honorarios_romatec.locacao_kit_gnss.valor).toBeCloseTo(750, 2);
+  });
+
+  it('33. Diaria custom override (R$ 300) preserva qtd × diaria', () => {
+    const r = calcularDemarcacaoLotes({
+      ...baseUrbana,
+      locacao_kit_gnss: { qtd_diarias: 2, diaria: 300 },
+    });
+    expect(r.honorarios_romatec.locacao_kit_gnss.diaria).toBe(300);
+    expect(r.honorarios_romatec.locacao_kit_gnss.valor).toBeCloseTo(600, 2);
+  });
+
+  it('34. Descritivo do kit (equipamentos discriminados) presente no output', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 1 } });
+    expect(r.honorarios_romatec.locacao_kit_gnss.descritivo).toMatch(/ComNav S6/);
+    expect(r.honorarios_romatec.locacao_kit_gnss.descritivo).toMatch(/T30 Plus/);
+    expect(r.honorarios_romatec.locacao_kit_gnss.descritivo).toMatch(/R80/);
+  });
+});
+
+describe('v3.38.0 — Parcelas 2x (50/50) vs 3x (40/30/30)', () => {
+  it('35. num_parcelas omitido -> 3 parcelas (retrocompat)', () => {
+    const r = calcularDemarcacaoLotes(baseUrbana);
+    expect(r.parcelas).toHaveLength(3);
+    expect(r.parcelas[0].percentual).toBe(40);
+  });
+
+  it('36. num_parcelas=2 -> 2 parcelas (50/50: sinal + entrega final)', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, num_parcelas: 2 });
+    expect(r.parcelas).toHaveLength(2);
+    expect(r.parcelas[0].percentual).toBe(50);
+    expect(r.parcelas[1].percentual).toBe(50);
+    expect(r.parcelas[0].rotulo).toMatch(/[Aa]ssinatura|[Ss]inal/);
+    expect(r.parcelas[1].rotulo).toMatch(/[Ee]ntrega/);
+    // Soma exata
+    const soma = r.parcelas.reduce((s, p) => s + p.valor, 0);
+    expect(Math.abs(soma - r.honorarios_romatec.total)).toBeLessThan(0.02);
+  });
+
+  it('37. num_parcelas=2 com total impar -> ultima parcela absorve residuo', () => {
+    // total propositalmente impar via diarias estranho
+    const r = calcularDemarcacaoLotes({ ...baseRural, num_parcelas: 2 });
+    const t = r.honorarios_romatec.total;
+    const p1 = r.parcelas[0].valor;
+    const p2 = r.parcelas[1].valor;
+    expect(Math.abs(p1 + p2 - t)).toBeLessThan(0.02);
+  });
+});
+
+describe('v3.38.0 — Cenario canonico PROP-2026-0028-R1 (gold standard)', () => {
+  // CONSTRUSUL CONSTRUCOES LTDA — Parte da Fazenda Gloria, Acailandia/MA
+  // Matricula 29.689, CCIR 110.027.001.708-6
+  // 29,04 ha · 4 vertices · perimetro 2.190,78 m
+  // 1 diaria · 30 km · 4 marcos madeira · insal 20% · complexidade media · 2 parcelas
+  // Kit GNSS 1 diaria (R$ 250) + Laudo Tecnico (R$ 1.621) = R$ 6.619,26 esperado
+  const propInput: InputDemarcacaoLotes = {
+    subtipo: 'demarcacao_rural',
+    finalidade: 'demarcacao_inicial',
+    municipio: 'Acailandia',
+    uf: 'MA',
+    matricula: '29.689',
+    cri: 'Cartorio 03.018-9',
+    denominacao_imovel: 'Parte da Fazenda Gloria',
+    ccir: '110.027.001.708-6',
+    area_hectares: 29.04,
+    perimetro_m: 2190.78,
+    num_vertices: 4,
+    servico_piqueteamento: true,
+    marcos: [marcoMadeira(4)],
+    diarias_equipe: 1,
+    km_deslocamento: 30,
+    complexidade: 'media',
+    adicional_campo_pct: 20,
+    laudo_tecnico_direto: { contratado: true },
+    locacao_kit_gnss: { qtd_diarias: 1, diaria: 250 },
+    num_parcelas: 2,
+  };
+
+  it('38. Linhas individuais: TRT 93,40 · Tec 680,82 · Insal 136,16 · Marcos 140 · Desloc 105 · Area 2323,20', () => {
+    const r = calcularDemarcacaoLotes(propInput);
+    const h = r.honorarios_romatec;
+    expect(h.trt_cft).toBeCloseTo(93.40, 2);
+    expect(h.tecnicos_campo).toBeCloseTo(680.82, 2);
+    expect(h.adicional_campo.valor).toBeCloseTo(136.16, 2);
+    expect(h.marcos_subtotal).toBeCloseTo(140.00, 2);
+    expect(h.deslocamento).toBeCloseTo(105.00, 2);
+    expect(h.area_servico).toBeCloseTo(2323.20, 2);
+  });
+
+  it('39. Complexidade (×1,3): subtotal_apos = 4.522,15', () => {
+    const r = calcularDemarcacaoLotes(propInput);
+    const h = r.honorarios_romatec;
+    expect(h.complexidade_multiplicador).toBe(1.3);
+    expect(h.subtotal_apos_complexidade).toBeCloseTo(4522.15, 1);
+  });
+
+  it('40. Assessoria 5%: 226,11', () => {
+    const r = calcularDemarcacaoLotes(propInput);
+    expect(r.honorarios_romatec.assessoria).toBeCloseTo(226.11, 1);
+  });
+
+  it('41. Kit GNSS 1× R$ 250 + Laudo R$ 1.621 (itens diretos)', () => {
+    const r = calcularDemarcacaoLotes(propInput);
+    const h = r.honorarios_romatec;
+    expect(h.locacao_kit_gnss.valor).toBeCloseTo(250.00, 2);
+    expect(h.laudo_tecnico_direto.valor).toBeCloseTo(1621.00, 2);
+  });
+
+  it('42. VALOR TOTAL DA PROPOSTA = R$ 6.619,26', () => {
+    const r = calcularDemarcacaoLotes(propInput);
+    expect(r.honorarios_romatec.total).toBeCloseTo(6619.26, 1);
+  });
+
+  it('43. Parcelas 2× = R$ 3.309,63 cada (50/50)', () => {
+    const r = calcularDemarcacaoLotes(propInput);
+    expect(r.parcelas).toHaveLength(2);
+    expect(r.parcelas[0].valor).toBeCloseTo(3309.63, 1);
+    expect(r.parcelas[1].valor).toBeCloseTo(3309.63, 1);
+  });
+
+  it('44. Alinhamento de cerca default R$ 0,42/m × perimetro 2.190,78 m = R$ 920,13 (opcional)', () => {
+    const r = calcularDemarcacaoLotes({
+      ...propInput,
+      opcionais: {
+        alinhamento_cerca: { contratado: true, metros: 2190.78, valor_unitario: 0.42 },
+      },
+    });
+    const linha = r.secao_opcionais_demarcacao.linhas.find((l) => /Alinhamento/i.test(l.rotulo));
+    expect(linha?.valor).toBeCloseTo(920.13, 1);
+    // Alinhamento e' opcional — NAO soma ao total Romatec
+    const r0 = calcularDemarcacaoLotes(propInput);
+    expect(r.honorarios_romatec.total).toBe(r0.honorarios_romatec.total);
   });
 });

--- a/src/services/pricing/demarcacaoLotes.ts
+++ b/src/services/pricing/demarcacaoLotes.ts
@@ -1,4 +1,14 @@
 // v3.27.0: motor de calculo de Demarcacao de Lotes (Urbana e Rural).
+// v3.38.0: alinha a PROP-2026-0028-R1 (gold standard aprovado pelo CEO em 2026-05-28).
+//   - Adicional de campo (insal/peric) incide APENAS sobre tecnicos_campo,
+//     integrado a base ANTES da complexidade e da assessoria (CLT 192-193/NR-15/16).
+//   - Laudo Tecnico de Demarcacao promovido a item DIRETO em honorarios
+//     (fora da complexidade/assessoria/desconto). Default 1 SM.
+//   - Locacao de Kit GNSS NOVO item direto (diaria editavel × qtd_diarias).
+//   - Suporte a 2 parcelas (50/50 — sinal + entrega final) alem do 3x (40/30/30).
+//   - Alinhamento de cerca: valor unitario default reduzido para R$ 0,42/m
+//     (config) — auto-fill = perimetro_m no frontend.
+//
 // Espelha 1:1 o padrao da v3.23.5 (Georref Rural PROP-2026-0011-R1):
 //   - TRT/CFT em linha propria (R$ 93,40 tabela CFT 2026)
 //   - Tecnicos de campo: diarias * SM * fator_diaria_tecnico (CFT-MA Res. 12/2025)
@@ -8,8 +18,7 @@
 //   - Multiplicador de complexidade (simples 1.0 / media 1.3 / alta 1.6)
 //   - Assessoria 5% sobre subtotal apos complexidade
 //   - Desconto sobre (subtotal + assessoria)
-//   - Minimo garantido 2 SM
-//   - 3 parcelas 40/30/30
+//   - Minimo garantido 2 SM (sobre core, antes dos extras diretos)
 //   - Opcionais NAO somam (secao informativa propria)
 //
 // Modulo standalone (zero deps de mysql/pdfkit/voyageai) — testavel sem arrastar
@@ -21,6 +30,7 @@
 //   - NTGIR 3a Edicao (INCRA) — codificacao de marcos com credencial do tecnico
 //   - Lei 6.766/79 (parcelamento de solo urbano) + Lei 5.868/72 (CNIR rural)
 //   - Tabela CFT 2026 — Tec. em Agrimensura CFT/MA no 01209185369
+//   - CLT (Decreto-Lei 5.452/43) art. 192 e 193 + NR-15/NR-16 do MTE
 
 import type {
   InputDemarcacaoLotes,
@@ -111,6 +121,20 @@ export function calcularDemarcacaoLotes(
   // ── 2. Tecnicos de campo ─────────────────────────────────────────────
   const tecnicos_campo = round2(input.diarias_equipe * SM * cfg.fator_diaria_tecnico);
 
+  // ── 2-bis. Adicional de campo (insal/peric) — v3.38.0 ────────────────
+  // Incide APENAS sobre tecnicos_campo, integrado a base ANTES da complexidade.
+  // CLT art. 192 (insal 10/20/40) e 193 (peric 30) — valor obrigatorio.
+  const adicional_pct = Number(input.adicional_campo_pct ?? 0);
+  if (!Number.isFinite(adicional_pct) || adicional_pct < 0 || adicional_pct > 40) {
+    throw new Error(`adicional_campo_pct invalido: ${adicional_pct} (esperado [0, 40])`);
+  }
+  const adicional_valor = round2((tecnicos_campo * adicional_pct) / 100);
+  const adicional_campo = {
+    aplicavel: adicional_pct > 0,
+    pct: adicional_pct,
+    valor: adicional_valor,
+  };
+
   // ── 3. Marcos discriminados ──────────────────────────────────────────
   const marcosOrdem: MaterialMarco[] = ['concreto', 'tubo_galvanizado', 'madeira'];
   const marcos_discriminados: { tipo: MaterialMarco; qtd: number; subtotal: number }[] = [];
@@ -144,8 +168,8 @@ export function calcularDemarcacaoLotes(
     area_servico = round2((input.area_hectares as number) * vUnit);
   }
 
-  // ── 6. Subtotal bruto ────────────────────────────────────────────────
-  const subtotal_bruto = round2(trt_cft + tecnicos_campo + marcos_subtotal + deslocamento + area_servico);
+  // ── 6. Subtotal bruto (com adicional integrado na base) ──────────────
+  const subtotal_bruto = round2(trt_cft + tecnicos_campo + adicional_valor + marcos_subtotal + deslocamento + area_servico);
 
   // ── 7. Complexidade ──────────────────────────────────────────────────
   const complexidade_multiplicador = cfg.complexidade_multiplicadores[input.complexidade];
@@ -158,42 +182,90 @@ export function calcularDemarcacaoLotes(
   const base_desconto = round2(subtotal_apos_complexidade + assessoria);
   const desconto_valor = round2((base_desconto * desconto_pct) / 100);
 
-  // ── 10. Total Romatec ────────────────────────────────────────────────
-  let total = round2(base_desconto - desconto_valor);
-
-  // ── 11. Minimo garantido ─────────────────────────────────────────────
+  // ── 10. Core Romatec (sujeito a minimo garantido) ────────────────────
+  let core = round2(base_desconto - desconto_valor);
   const minimo = round2(cfg.minimo_garantido_sm * SM);
-  const aplicouMinimo = total < minimo;
+  const aplicouMinimo = core < minimo;
   if (aplicouMinimo) {
-    total = minimo;
+    core = minimo;
   }
 
-  // Guard de fechamento (defensivo — catch bug cedo)
-  const guardSubBruto = round2(trt_cft + tecnicos_campo + marcos_subtotal + deslocamento + area_servico);
+  // ── 11. Itens diretos (fora da complexidade/assessoria/desconto) ─────
+  // v3.38.0 — laudo tecnico + locacao kit GNSS.
+  // Retrocompat: se opcionais.laudo_tecnico.contratado=true (propostas antigas)
+  // E input.laudo_tecnico_direto NAO foi passado, migra automaticamente.
+  const opcionaisRaw = input.opcionais ?? {};
+  const laudoDireto = (() => {
+    const direto = input.laudo_tecnico_direto;
+    const optLegacy = opcionaisRaw.laudo_tecnico;
+    if (direto?.contratado) {
+      const mult = direto.valor_unitario_sm_multiplicador
+        ?? cfg.laudo_tecnico_direto?.valor_unitario_sm_multiplicador
+        ?? 1.0;
+      return { contratado: true, valor: round2(mult * SM) };
+    }
+    if (optLegacy?.contratado) {
+      const mult = optLegacy.valor_unitario_sm_multiplicador
+        ?? cfg.laudo_tecnico_direto?.valor_unitario_sm_multiplicador
+        ?? 1.0;
+      return { contratado: true, valor: round2(mult * SM) };
+    }
+    return { contratado: false, valor: 0 };
+  })();
+
+  const kitGnss = (() => {
+    const kit = input.locacao_kit_gnss;
+    const cfgKit = cfg.locacao_kit_gnss;
+    const diariaDefault = cfgKit?.valor_unitario_diaria_default ?? 250.00;
+    const descritivo = cfgKit?.descritivo ?? '';
+    const qtd = Number(kit?.qtd_diarias ?? 0);
+    if (!Number.isFinite(qtd) || qtd < 0) {
+      throw new Error(`locacao_kit_gnss.qtd_diarias invalido: ${qtd} (esperado >= 0)`);
+    }
+    const diaria = Number(kit?.diaria ?? diariaDefault);
+    if (!Number.isFinite(diaria) || diaria < 0) {
+      throw new Error(`locacao_kit_gnss.diaria invalido: ${diaria} (esperado >= 0)`);
+    }
+    const contratado = qtd > 0;
+    return {
+      contratado,
+      qtd_diarias: qtd,
+      diaria: round2(diaria),
+      valor: contratado ? round2(qtd * diaria) : 0,
+      descritivo,
+    };
+  })();
+
+  // ── 12. Total = core + extras diretos ────────────────────────────────
+  const extrasDiretos = round2(laudoDireto.valor + kitGnss.valor);
+  const total = round2(core + extrasDiretos);
+
+  // Guard de fechamento
+  const guardSubBruto = round2(trt_cft + tecnicos_campo + adicional_valor + marcos_subtotal + deslocamento + area_servico);
   const guardApos = round2(guardSubBruto * complexidade_multiplicador);
   const guardComAssess = round2(guardApos + assessoria);
-  const guardFinal = round2(guardComAssess - desconto_valor);
-  if (aplicouMinimo) {
-    if (round2(total) !== round2(minimo)) {
-      throw new Error(`Guard minimo: esperado ${minimo}, obtido ${total}`);
-    }
-  } else {
-    if (round2(guardFinal) !== round2(total)) {
-      throw new Error(`Guard fechamento: esperado ${guardFinal}, obtido ${total}`);
-    }
+  const guardCore = aplicouMinimo ? minimo : round2(guardComAssess - desconto_valor);
+  const guardTotal = round2(guardCore + extrasDiretos);
+  if (round2(total) !== round2(guardTotal)) {
+    throw new Error(`Guard fechamento: esperado ${guardTotal}, obtido ${total}`);
   }
 
-  // ── Opcionais (5 linhas sempre, NAO somam ao total) ──────────────────
-  const opcionais = input.opcionais ?? {};
-  const linhasOpcionais = montarLinhasOpcionais(opcionais, SM, cfg.opcionais);
+  // ── Opcionais (4 linhas — laudo foi promovido a direto) ──────────────
+  const linhasOpcionais = montarLinhasOpcionais(opcionaisRaw, cfg.opcionais);
   const subtotalOpcionais = round2(
     linhasOpcionais
       .filter((l) => l.contratado && typeof l.valor === 'number')
       .reduce((s, l) => s + (l.valor as number), 0),
   );
 
-  // ── Parcelas 40/30/30 ────────────────────────────────────────────────
-  const parcelasCfg = cfg.parcelas;
+  // ── Parcelas (3x default ou 2x se input.num_parcelas === 2) ──────────
+  const numParcelas = input.num_parcelas === 2 ? 2 : 3;
+  const parcelasCfg = numParcelas === 2
+    ? (cfg.parcelas_2x ?? [
+        { numero: 1, rotulo: 'Assinatura do contrato (sinal)', percentual: 50 },
+        { numero: 2, rotulo: 'Entrega final + TRT/CFT',        percentual: 50 },
+      ])
+    : cfg.parcelas;
   const parcelasOut: { numero: 1 | 2 | 3; rotulo: string; valor: number; percentual: number }[] = parcelasCfg.map(
     (p, i, arr) => {
       const numero = (i + 1) as 1 | 2 | 3;
@@ -219,6 +291,7 @@ export function calcularDemarcacaoLotes(
     honorarios_romatec: {
       trt_cft,
       tecnicos_campo,
+      adicional_campo,
       marcos_discriminados,
       marcos_subtotal,
       deslocamento,
@@ -227,6 +300,8 @@ export function calcularDemarcacaoLotes(
       subtotal_apos_complexidade,
       assessoria,
       desconto_valor,
+      laudo_tecnico_direto: laudoDireto,
+      locacao_kit_gnss: kitGnss,
       total,
     },
     secao_opcionais_demarcacao: {
@@ -241,24 +316,13 @@ export function calcularDemarcacaoLotes(
 
 function montarLinhasOpcionais(
   opcionais: OpcionaisDemarcacao,
-  SM: number,
   cfgOpc: NonNullable<ReturnType<typeof getParams>['demarcacao_lotes_2026']>['opcionais'],
 ): { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[] {
-  // 5 linhas SEMPRE renderizadas, na ordem fixa abaixo.
+  // v3.38.0: 4 linhas SEMPRE renderizadas (laudo_tecnico foi promovido a item
+  // direto em honorarios_romatec).
   const linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[] = [];
 
-  // 1. Laudo Tecnico
-  {
-    const it = opcionais.laudo_tecnico;
-    const contratado = !!it?.contratado;
-    const mult = it?.valor_unitario_sm_multiplicador ?? cfgOpc.laudo_tecnico.valor_unitario_sm_multiplicador;
-    linhas.push({
-      rotulo: cfgOpc.laudo_tecnico.rotulo,
-      contratado,
-      valor: contratado ? round2(mult * SM) : 0,
-    });
-  }
-  // 2. Alinhamento de cerca
+  // 1. Alinhamento de cerca
   {
     const it = opcionais.alinhamento_cerca;
     const contratado = !!it?.contratado;
@@ -270,7 +334,7 @@ function montarLinhasOpcionais(
       valor: contratado ? round2(metros * vUnit) : 0,
     });
   }
-  // 3. Croqui assinado
+  // 2. Croqui assinado
   {
     const it = opcionais.croqui_assinado;
     const contratado = !!it?.contratado;
@@ -281,7 +345,7 @@ function montarLinhasOpcionais(
       valor: contratado ? round2(vUnit) : 0,
     });
   }
-  // 4. Acompanhamento de obra
+  // 3. Acompanhamento de obra
   {
     const it = opcionais.acompanhamento_obra;
     const contratado = !!it?.contratado;
@@ -293,7 +357,7 @@ function montarLinhasOpcionais(
       valor: contratado ? round2(diarias * vUnit) : 0,
     });
   }
-  // 5. Consultoria juridica (literal 'sob_orcamento' — NUNCA numero)
+  // 4. Consultoria juridica (literal 'sob_orcamento' — NUNCA numero)
   {
     const it = opcionais.consultoria_juridica;
     const contratado = !!it?.contratado;

--- a/src/services/pricing/params.ts
+++ b/src/services/pricing/params.ts
@@ -116,11 +116,19 @@ interface PricingParams {
       acompanhamento_obra:  { rotulo: string; valor_unitario: number; unidade?: string };
       consultoria_juridica: { rotulo: string; valor: 'sob_orcamento' };
     };
+    // v3.38.0 — itens diretos (fora da complexidade/assessoria)
+    laudo_tecnico_direto?: { rotulo: string; valor_unitario_sm_multiplicador: number };
+    locacao_kit_gnss?: {
+      rotulo: string;
+      valor_unitario_diaria_default: number;
+      descritivo: string;
+    };
     minimo_garantido_sm: number;
     complexidade_multiplicadores: { simples: number; media: number; alta: number };
     assessoria_pct: number;
     desconto_max_pct: number;
     parcelas: Array<{ numero: number; rotulo: string; percentual: number }>;
+    parcelas_2x?: Array<{ numero: number; rotulo: string; percentual: number }>;
     validade_dias_default: number;
   };
   _meta?: { ultima_atualizacao: string; atualizado_por: string; versao: string };

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -466,6 +466,9 @@ export interface MarcoDiscriminado {
 }
 
 export interface OpcionaisDemarcacao {
+  // v3.38.0: laudo_tecnico foi promovido a item direto em honorarios_romatec
+  // (laudo_tecnico_direto). Permanece aqui apenas por retrocompat — propostas
+  // antigas com opcionais.laudo_tecnico.contratado=true sao migradas em runtime.
   laudo_tecnico?: { contratado: boolean; valor_unitario_sm_multiplicador: number };
   alinhamento_cerca?: { contratado: boolean; metros: number; valor_unitario: number };
   croqui_assinado?: { contratado: boolean; valor_unitario: number };
@@ -506,6 +509,19 @@ export interface InputDemarcacaoLotes {
   validade_dias?: number;
 
   opcionais?: OpcionaisDemarcacao;
+
+  // v3.38.0 — alinhamento a PROP-2026-0028-R1 (gold standard)
+  // Adicional de insalubridade/periculosidade. Incide APENAS sobre tecnicos_campo,
+  // integrado a base ANTES da complexidade e da assessoria (CLT art. 192-193 / NR-15/NR-16).
+  adicional_campo_pct?: number; // 0..40 — default 0
+  // Laudo Tecnico de Demarcacao — item direto, fora da complexidade/assessoria.
+  // valor = mult × SM (default 1.0 SM = R$ 1.621,00 em 2026).
+  laudo_tecnico_direto?: { contratado: boolean; valor_unitario_sm_multiplicador?: number };
+  // Locacao de Kit GNSS — item direto, fora da complexidade/assessoria.
+  // valor = diaria × qtd_diarias. Default diaria de pricing-params (R$ 250,00).
+  locacao_kit_gnss?: { qtd_diarias: number; diaria?: number };
+  // Parcelamento — default 3x (40/30/30, retrocompat). 2x = 50/50 (sinal + entrega final).
+  num_parcelas?: 2 | 3;
 }
 
 export interface CodigosMintadosFQNS {
@@ -523,6 +539,8 @@ export interface DemarcacaoLotesOutput {
   honorarios_romatec: {
     trt_cft: number;
     tecnicos_campo: number;
+    // v3.38.0 — adicional de insal/peric sobre tecnicos_campo, integrado a base.
+    adicional_campo: { aplicavel: boolean; pct: number; valor: number };
     marcos_discriminados: { tipo: MaterialMarco; qtd: number; subtotal: number }[];
     marcos_subtotal: number;
     deslocamento: number;
@@ -531,6 +549,9 @@ export interface DemarcacaoLotesOutput {
     subtotal_apos_complexidade: number;
     assessoria: number;
     desconto_valor: number;
+    // v3.38.0 — itens diretos (fora da complexidade/assessoria/desconto).
+    laudo_tecnico_direto: { contratado: boolean; valor: number };
+    locacao_kit_gnss: { contratado: boolean; qtd_diarias: number; diaria: number; valor: number; descritivo: string };
     total: number;
   };
   secao_opcionais_demarcacao: {


### PR DESCRIPTION
…-0028-R1 (v3.38.0)

Refatora a fórmula de Demarcacao de Lotes para bater 1:1 com a proposta PROP-2026-0028-R1 (CONSTRUSUL / Fazenda Glória) aprovada pelo CEO. O total canônico passa a fechar exatamente em R$ 6.619,26 com 2 parcelas de 3.309,63.

Mudanças de fórmula:
- Adicional de insal/peric incide APENAS sobre tecnicos_campo e entra na base ANTES da complexidade (CLT 192-193 / NR-15/16). Outros subtipos mantêm comportamento legado.
- Laudo Técnico de Demarcação promovido a item DIRETO (fora da complexidade).
- Locação Kit GNSS adicionada como item direto (diária × qtd, com discriminação ComNav S6 + T30 Plus + tripé + base + bastão + R80).
- Parcelas 2× (50/50: sinal + entrega) com input num_parcelas opcional; 3× segue como retrocompat.
- Alinhamento de cerca: R$ 0,42/m (era R$ 4,50/m); UI auto-fill = perímetro.

Tests: 22 novos (44 total no arquivo), incluindo cenário canônico PROP-2026-0028-R1 com todas as linhas + total + parcelas validadas. Suite global 903 passing.

Retrocompat preservada: propostas antigas com opcionais.laudo_tecnico.contratado=true migram automaticamente para laudo_tecnico_direto; input sem num_parcelas usa 3×; input sem adicional_campo_pct calcula com 0.