### PR TITLE
fix(demarcacao-pdf): 5 BUGs do PROP-2026-0029 vs gold standard 0028-R…

### DIFF
--- a/06-Changelog/v3.40.0-hotfix-proposta-demarcacao-canonica.md
+++ b/06-Changelog/v3.40.0-hotfix-proposta-demarcacao-canonica.md
@@ -1,0 +1,135 @@
+# v3.40.0 — Hotfix: Proposta de Demarcação alinhada ao gold standard (5 BUGs)
+
+**Data:** 2026-05-28
+**Branch:** `fix/proposta-demarcacao-itens-canonicos-v3.40.0`
+**Base:** `main` (v3.39.0)
+**Versão alvo:** v3.40.0
+
+## Contexto
+
+A proposta PROP-2026-0029-R1 gerada com o engine v3.38.0 saiu **divergente em 5 pontos** do gold standard aprovado (PROP-2026-0028-R1). A divergência foi de **conteúdo/composição do PDF**, não de cálculo (os valores unitários estão corretos). Esta release alinha o template e a ordem dos itens 1:1.
+
+Importante: o 0029 saiu assinado digitalmente (PAdES) com hash já registrado. **Reemitir a proposta com este patch gera novo hash e exige nova assinatura** — o sistema já invalida a assinatura anterior por mudança de conteúdo (SHA-256 muda).
+
+## Bugs corrigidos
+
+### BUG 1 — Texto da FINALIDADE voltou para rascunho antigo
+
+**Antes (v3.38.0–v3.39.0):** texto hardcoded em `FINALIDADE_DEMARCACAO_TEXTOS` (Record genérico):
+> "Levantamento topográfico de campo para implantação física dos vértices definidos em projeto e materialização da poligonal do imóvel no terreno."
+
+**Agora:** função `montarFinalidadeDemarcacao(finalidade, subtipo, dados)` que escolhe o texto:
+- **Rural + demarcacao_inicial**: cita denominação do imóvel + "parcela de gleba rural" + NTGIR 3ª Ed. (INCRA) + NBR 13133 (ABNT) + SIRGAS2000.
+- **Urbana + demarcacao_inicial**: cita Loteamento/Quadra/Lote (quando disponíveis) + NBR 13133 (ABNT). Sem NTGIR/SIRGAS, irrelevantes pra lote urbano.
+- **Outras finalidades** (redemarcação, subdivisão, piqueteamento): texto legado preservado.
+
+Função extraída para **`src/services/pdf/demarcacaoFinalidade.ts`** (standalone, sem deps de mysql/voyageai/pdfkit — facilita teste unitário).
+
+### BUG 2 — Linha "Locação Kit GNSS" sumia do PDF (era condicional)
+
+**Antes:** Kit GNSS era item opcional. Quando o user não preenchia (ou desmarcava a checkbox), a linha não aparecia — mas o texto do bloco verde citava "mais Locação de Kit GNSS", causando **contradição interna do documento**.
+
+**Agora:** Kit GNSS é **item FIXO dos honorários**. O engine retorna `qtd_diarias = 1` por default quando o input não passa o campo. Para projetos sem campo (edge case raro — ex.: piqueteamento puro de escritório), o user passa explicitamente `qtd_diarias = 0`.
+
+**Reorganização da Seção 4 do PDF (ordem travada):**
+- **4. Honorários** (linhas inline): TRT/CFT, Técnicos de campo, Adicional insal/peric, Área, Deslocamento, Complexidade, Assessoria.
+- **4.2 Marcos Discriminados** (subseção dedicada, tabela).
+- **4.3 Locação de Equipamentos — Kit GNSS** (subseção dedicada, sempre presente). Inclui discriminação dos equipamentos abaixo.
+- **4.4 Laudo Técnico de Demarcação** (subseção dedicada, condicional ao contratado).
+- **4.5 Identificação dos Marcos (FQNS)** (renumerada de 4.3 → 4.5).
+
+**Frontend:** removida a checkbox `dmKitGnss`. Inputs de Diárias e R$/diária sempre visíveis com defaults 1 / 250. User pode ajustar diárias para 0 se necessário.
+
+### BUG 3 — Alinhamento de Cerca sem regra de cálculo
+
+**Antes:** linha "Alinhamento de Cerca ... R$ 920,13" sem nenhuma memória de cálculo.
+
+**Agora:** linha exibe o `detalhe` abaixo do rótulo:
+
+> Alinhamento de Cerca · R$ 920,13
+> *Extensão × R$ 0,42/m · default perímetro 2.190,78 m (editável p/ alinhamento parcial)*
+
+A engine agora popula `secao_opcionais_demarcacao.linhas[].detalhe` com a regra. O PDF render exibe se presente. Tipo `OpcionaisLinha` ganhou `detalhe?: string` opcional (retrocompat preservada).
+
+### BUG 4 — Discriminação do Kit GNSS abaixo da linha
+
+A subseção 4.3 (Kit GNSS) agora renderiza, em ordem:
+1. Linha principal: `Kit GNSS — 1 diária x R$ 250,00 ............... R$ 250,00`
+2. Linha clarificadora (oblique): *"Diária editável; admite meia ou múltiplas diárias."*
+3. Linha de discriminação (oblique): *"Receptor ComNav S6 (base); Receptor T30 Plus com laser (rover); tripé; base niveladora; bastão/bipé; coletora R80."*
+
+Cada linha é um `doc.text()` separado — não há mais risco de `\n` ser interpretado como caractere literal.
+
+### BUG 5 — Perímetro 2.190,78 vs 2.190,79
+
+**Causa:** o perímetro era formatado com `toLocaleString('pt-BR', { minimumFractionDigits: 2 })` em vários pontos. Como `maximumFractionDigits` defaulta para 3, valores como `2190.789` saíam como `"2.190,789"`, e arredondamentos diferentes em pontos diferentes do PDF causavam divergência.
+
+**Agora:** helper `formatarPerimetroBr()` em `src/services/pdf/demarcacaoFinalidade.ts` — fonte única, sempre `minimumFractionDigits: 2, maximumFractionDigits: 2`. Aplicado na seção 1 (Identificação). Área m² e hectares também ganham `maximumFractionDigits` explícito (2 e 4 respectivamente).
+
+### Bônus — Texto do total coerente com a soma
+
+Antes (v3.38.0):
+> "...acrescida de Locação de Kit GNSS e Laudo Técnico de Demarcação (itens diretos, quando contratados)."
+
+Agora:
+> "...acrescida de **Locação de Kit GNSS (item fixo)** e Laudo Técnico de Demarcação (quando contratado)."
+
+## Arquivos alterados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/services/pdf/demarcacaoFinalidade.ts` | **NOVO** — helpers `montarFinalidadeDemarcacao()` + `formatarPerimetroBr()` (standalone, testável) |
+| `src/services/pricing/types.ts` | `secao_opcionais_demarcacao.linhas` ganha campo `detalhe?: string` |
+| `src/services/pricing/demarcacaoLotes.ts` | Kit GNSS default `qtd_diarias=1` (era 0). `montarLinhasOpcionais` recebe `perimetro_m` para gerar regra do alinhamento de cerca |
+| `src/services/pricing/demarcacaoLotes.test.ts` | 2 testes ajustados (kit fixo) + 1 novo (#13b — mínimo + kit) |
+| `src/integrations/propostasConsultoria.ts` | Importa helpers do novo módulo. Seção 4 reorganizada (4.2 Marcos → 4.3 Locação → 4.4 Laudo → 4.5 FQNS). Texto do total atualizado. Linha de opcional com `detalhe` |
+| `src/public/obras.html` | Removida checkbox `dmKitGnss` — Kit é fixo, inputs sempre visíveis |
+| `src/test/hotfix-proposta-demarcacao-canonica-v3.40.0.test.ts` | **NOVO** — 24 testes (5 BUGs + reordem + texto total) |
+| `package.json` | 3.39.0 → 3.40.0 |
+
+## Arquivos NÃO alterados (regra do prompt)
+
+- ✅ `src/agent/tools.ts` — intocado
+- ✅ `src/agent/think.ts` — intocado
+- ✅ `src/services/aiCascade.ts` — intocado
+
+## Testes
+
+`src/test/hotfix-proposta-demarcacao-canonica-v3.40.0.test.ts` — **24 testes**:
+
+| # | Bloco | Cobertura |
+|---|---|---|
+| 1–4 | BUG 1 Finalidade | rural cita Fazenda Glória + parcela gleba + NTGIR + NBR 13133 + SIRGAS2000; urbana cita loteamento; fallback sem denominação; outras finalidades preservam texto legado |
+| 5–12 | BUG 2 Kit fixo | engine default qtd=1; total 6.619,26 sem precisar passar Kit; qtd=0 explícito desativa; descritivo presente; PDF tem subsection 4.3 dedicada; ordem 4.2 → 4.3 → 4.4 → 4.5; Kit/Laudo NÃO mais no array inline |
+| 13–15 | BUG 3 Alinhamento detalhe | engine popula `detalhe` com R$ 0,42/m + perímetro default; sem perímetro só com a regra; PDF renderiza detalhe em Helvetica-Oblique #555 |
+| 16–17 | BUG 4 Discriminação | descritivo do kit renderiza em linha própria; frase clarificadora visível |
+| 18–20 | BUG 5 Perímetro | helper `formatarPerimetroBr` com max=2; runtime check 2190.78 → "2.190,78"; pontos do PDF usam `maximumFractionDigits` explícito |
+| 21–23 | Texto total | bloco verde cita "Locação de Kit GNSS (item fixo)"; Laudo continua condicional; não contém mais "itens diretos, quando contratados" |
+
+`src/services/pricing/demarcacaoLotes.test.ts` — **46 testes** (44 baseline + 2 novos: #13b cobre mínimo + kit fixo; #30 reescrito + #30b para qtd=0 edge case).
+
+**Suite total:** 945 passing, 1 skipped, 0 failures (baseline 919 + 26 novos).
+**Typecheck:** ✅ limpo.
+
+## Política preservada
+
+- ✅ Retrocompat: propostas v3.38.0–v3.39.0 com `locacao_kit_gnss.contratado=false` continuam abrindo (rendering omite a subseção 4.3 quando `valor <= 0`).
+- ✅ Retrocompat: linhas opcionais sem `detalhe` continuam renderizando sem o trecho extra.
+- ✅ Retrocompat: input sem `locacao_kit_gnss` agora gera Kit por default — propostas novas seguem o gold standard.
+- ✅ Cálculo determinístico preservado (engine puro, sem side-effects).
+- ✅ Mínimo garantido 2 SM aplicado sobre core (extras somam por cima — comportamento v3.38.0 mantido).
+
+## Observação operacional sobre o hash/assinatura
+
+Conforme nota do prompt: o 0029 saiu assinado (PAdES) com hash `ab4545a0...`. Ao **reemitir a proposta com este patch**:
+
+1. O conteúdo muda → SHA-256 muda → hash de validação muda.
+2. Nova assinatura é gerada automaticamente no signing flow.
+3. A versão anterior fica orfã (hash antigo aponta para um documento que não bate com o conteúdo atual).
+4. **Recomenda-se versionar como R2** (nova revisão) ou invalidar a R1 antes de gerar a R2.
+
+O sistema atual já bloqueia tentativa de validação com hash antigo (não há colisão possível — SHA-256 ≠ entre conteúdos diferentes).
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.39.0",
+  "version": "3.40.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -1871,12 +1871,10 @@ function renderAditivoCampoBody(
 //   - 4-bis: Marcos Discriminados (tabela tipo x qtd x valor unit x subtotal)
 //   - 4-ter: Identificacao dos Marcos FQNS (codigos vitalicios INCRA)
 // Total: 11 secoes. Invocada SO para subtipo ∈ {demarcacao_urbana, demarcacao_rural}.
-const FINALIDADE_DEMARCACAO_TEXTOS: Record<FinalidadeDemarcacao, string> = {
-  demarcacao_inicial: 'Levantamento topografico de campo para implantacao fisica dos vertices definidos em projeto e materializacao da poligonal do imovel no terreno.',
-  redemarcacao: 'Repiqueteamento de vertices perdidos/deteriorados, restabelecendo a poligonal original conforme matricula e levantamento anterior.',
-  subdivisao_lote: 'Demarcacao fisica das fracoes resultantes de desmembramento/remembramento aprovado, com implantacao de marcos nas novas divisas.',
-  piqueteamento_apenas: 'Implantacao de marcos fisicos em vertices previamente calculados em escritorio (sem novo levantamento de campo).',
-};
+// v3.40.0: finalidade dinamica + formatador de perimetro extraidos para
+// src/services/pdf/demarcacaoFinalidade.ts (testavel standalone, sem
+// arrastar voyageai/mysql/pdfkit nos imports do test runner).
+import { montarFinalidadeDemarcacao, formatarPerimetroBr } from '../services/pdf/demarcacaoFinalidade';
 
 const ESCOPO_DEMARCACAO = [
   'Levantamento topografico georreferenciado com GNSS RTK / Estacao Total nas divisas existentes',
@@ -1993,6 +1991,7 @@ function renderDemarcacaoLotesBody(
 
   doc.text(`Municipio/UF:  ${municipio}${uf ? '/' + uf : ''}`);
   doc.text(`Matricula:  ${matricula}    ·    Cartorio:  ${cri}`);
+  // v3.40.0: perimetro com formatacao unica via formatarPerimetroBr (fixed 2 dec)
   if (isUrbana) {
     const lot = di.loteamento_nome ? `Loteamento ${di.loteamento_nome}` : '';
     const qd = di.quadra ? `Quadra ${di.quadra}` : '';
@@ -2000,18 +1999,25 @@ function renderDemarcacaoLotesBody(
     const linha = [lot, qd, lt].filter(Boolean).join('    ·    ');
     if (linha) doc.text(linha);
     if (di.area_m2) {
-      doc.text(`Area:  ${Number(di.area_m2).toLocaleString('pt-BR', { minimumFractionDigits: 2 })} m²    ·    Vertices:  ${vertices}${perimetro > 0 ? '    ·    Perimetro:  ' + perimetro.toLocaleString('pt-BR', { minimumFractionDigits: 2 }) + ' m' : ''}`);
+      doc.text(`Area:  ${Number(di.area_m2).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} m²    ·    Vertices:  ${vertices}${perimetro > 0 ? '    ·    Perimetro:  ' + formatarPerimetroBr(perimetro) + ' m' : ''}`);
     }
   } else {
     if (di.denominacao_imovel) doc.text(`Denominacao:  ${di.denominacao_imovel}${di.ccir ? '    ·    CCIR:  ' + di.ccir : ''}`);
     if (di.area_hectares) {
-      doc.text(`Area:  ${Number(di.area_hectares).toLocaleString('pt-BR', { minimumFractionDigits: 4 })} ha    ·    Vertices:  ${vertices}${perimetro > 0 ? '    ·    Perimetro:  ' + perimetro.toLocaleString('pt-BR', { minimumFractionDigits: 2 }) + ' m' : ''}`);
+      doc.text(`Area:  ${Number(di.area_hectares).toLocaleString('pt-BR', { minimumFractionDigits: 4, maximumFractionDigits: 4 })} ha    ·    Vertices:  ${vertices}${perimetro > 0 ? '    ·    Perimetro:  ' + formatarPerimetroBr(perimetro) + ' m' : ''}`);
     }
   }
   doc.moveDown(0.6);
 
   // ── 2. BOX DOURADO — FINALIDADE ───────────────────────────────────────
-  const textoFinal = FINALIDADE_DEMARCACAO_TEXTOS[finalidade];
+  // v3.40.0: texto dinamico (rural/urbana) com denominacao/loteamento — alinha
+  // a PROP-2026-0028-R1. Antes usava Record hardcoded de rascunho.
+  const textoFinal = montarFinalidadeDemarcacao(finalidade, subtipo, {
+    denominacao_imovel: di.denominacao_imovel,
+    loteamento_nome: di.loteamento_nome,
+    quadra: di.quadra,
+    lote: di.lote,
+  });
   const boxAltFin = doc.heightOfString(textoFinal, { width: COL_W - 28 }) + 28;
   const boxYFin = doc.y;
   doc.rect(COL_X_INI, boxYFin, COL_W, boxAltFin).fillAndStroke(COR_DOURADO_BG, COR_DOURADO_BORDA);
@@ -2041,9 +2047,11 @@ function renderDemarcacaoLotesBody(
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.2);
 
-  // v3.38.0: alinhamento a PROP-2026-0028-R1 (gold standard)
+  // v3.38.0–v3.40.0: alinhamento a PROP-2026-0028-R1 (gold standard).
   //   - Adicional de insal/peric incide sobre tecnicos_campo, integrado na base
-  //   - Kit GNSS e Laudo Tecnico aparecem como itens DIRETOS (fora da complexidade)
+  //   - Section 4 lista APENAS os itens BASE (TRT, Tec, Adicional, Area, Desloc, Complex, Assessoria).
+  //   - Marcos viram subsection 4.2; Kit GNSS subsection 4.3; Laudo 4.4; FQNS 4.5.
+  //   - Kit GNSS e' item FIXO (sempre renderizado quando output tem); Laudo e' condicional.
   const linhasHon: Array<{ label: string; valor: number; obs?: string }> = hr
     ? (() => {
         const arr: Array<{ label: string; valor: number; obs?: string }> = [
@@ -2072,24 +2080,7 @@ function renderDemarcacaoLotesBody(
           { label: `Multiplicador de complexidade (${di.complexidade || 'media'})`, valor: hr.subtotal_apos_complexidade - (hr.trt_cft + hr.tecnicos_campo + (hr.adicional_campo?.valor || 0) + hr.marcos_subtotal + hr.deslocamento + hr.area_servico), obs: `x ${hr.complexidade_multiplicador}` },
           { label: 'Assessoria (5%)', valor: hr.assessoria },
         );
-        // v3.38.0: Kit GNSS (item direto)
-        if (hr.locacao_kit_gnss?.contratado && hr.locacao_kit_gnss.valor > 0) {
-          const qtd = hr.locacao_kit_gnss.qtd_diarias;
-          const diaria = hr.locacao_kit_gnss.diaria;
-          arr.push({
-            label: 'Locacao de equipamentos — Kit GNSS',
-            valor: hr.locacao_kit_gnss.valor,
-            obs: `${qtd} diaria(s) x R$ ${diaria.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}${hr.locacao_kit_gnss.descritivo ? ' — ' + hr.locacao_kit_gnss.descritivo : ''}`,
-          });
-        }
-        // v3.38.0: Laudo Tecnico (item direto)
-        if (hr.laudo_tecnico_direto?.contratado && hr.laudo_tecnico_direto.valor > 0) {
-          arr.push({
-            label: 'Laudo Tecnico de Demarcacao',
-            valor: hr.laudo_tecnico_direto.valor,
-            obs: 'valor fechado (1 SM 2026)',
-          });
-        }
+        // Kit GNSS e Laudo Tecnico foram MOVIDOS para subseccoes proprias (v3.40.0).
         return arr;
       })()
     : (custos.secao_3_honorarios || []).map((h) => ({ label: h.descricao, valor: Number(h.valor), obs: h.observacao }));
@@ -2142,9 +2133,62 @@ function renderDemarcacaoLotesBody(
     doc.moveDown(0.4);
   }
 
-  // ── 4-ter. IDENTIFICACAO DOS MARCOS (FQNS) ───────────────────────────
+  // ── 4.3. LOCACAO DE EQUIPAMENTOS — KIT GNSS (v3.40.0 — item FIXO) ────
+  // Sempre renderiza quando o output tem o campo (propostas pre-v3.38.0
+  // sem o campo continuam funcionando — fallback silencioso). Inclui
+  // discriminacao dos equipamentos abaixo da linha.
+  if (hr && hr.locacao_kit_gnss && hr.locacao_kit_gnss.valor > 0) {
+    if (doc.y > 660) doc.addPage();
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4.3 Locacao de Equipamentos — Kit GNSS');
+    doc.font('Helvetica');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+
+    const kg = hr.locacao_kit_gnss;
+    const qtdTxt = kg.qtd_diarias === 1
+      ? '1 diaria'
+      : `${kg.qtd_diarias.toLocaleString('pt-BR', { minimumFractionDigits: kg.qtd_diarias % 1 === 0 ? 0 : 1, maximumFractionDigits: 2 })} diaria(s)`;
+    const diariaTxt = kg.diaria.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+    const y0 = doc.y;
+    doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+      .text(`Kit GNSS — ${qtdTxt} x R$ ${diariaTxt}`, COL_X_INI + 8, y0, { width: COL_W - 100 });
+    doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+      .text(formatBRL(kg.valor), COL_X_FIM - 80, y0, { width: 80, align: 'right' });
+    doc.font('Helvetica').fillColor('#111');
+    // v3.40.0 BUG 4: detalhe MULTILINHA renderiza como bloco (regra de calculo + discriminacao).
+    doc.fontSize(8).fillColor('#555').font('Helvetica-Oblique')
+      .text('Diaria editavel; admite meia ou multiplas diarias.', COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+    if (kg.descritivo) {
+      doc.fontSize(8).fillColor('#555').font('Helvetica')
+        .text(kg.descritivo, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+    }
+    doc.font('Helvetica').fillColor('#111');
+    doc.moveDown(0.4);
+  }
+
+  // ── 4.4. LAUDO TECNICO DE DEMARCACAO (item DIRETO, condicional) ──────
+  if (hr && hr.laudo_tecnico_direto && hr.laudo_tecnico_direto.contratado && hr.laudo_tecnico_direto.valor > 0) {
+    if (doc.y > 680) doc.addPage();
+    doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4.4 Laudo Tecnico de Demarcacao');
+    doc.font('Helvetica');
+    doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
+    doc.moveDown(0.2);
+    const y0 = doc.y;
+    doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
+      .text('Laudo Tecnico de Demarcacao', COL_X_INI + 8, y0, { width: COL_W - 100 });
+    doc.fontSize(10).fillColor(corHex).font('Helvetica-Bold')
+      .text(formatBRL(hr.laudo_tecnico_direto.valor), COL_X_FIM - 80, y0, { width: 80, align: 'right' });
+    doc.font('Helvetica').fillColor('#111');
+    doc.fontSize(8).fillColor('#555').font('Helvetica-Oblique')
+      .text('valor fechado (1 SM 2026)', COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+    doc.font('Helvetica').fillColor('#111');
+    doc.moveDown(0.4);
+  }
+
+  // ── 4.5. IDENTIFICACAO DOS MARCOS (FQNS) ─────────────────────────────
   if (doc.y > 600) doc.addPage();
-  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4.3 Identificacao dos Marcos (Codificacao INCRA)');
+  doc.fontSize(11).fillColor(corHex).font('Helvetica-Bold').text('4.5 Identificacao dos Marcos (Codificacao INCRA)');
   doc.font('Helvetica');
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.2);
@@ -2185,7 +2229,8 @@ function renderDemarcacaoLotesBody(
   // ── 5. BOX VERDE — VALOR TOTAL ────────────────────────────────────────
   const totalRomatec = hr?.total ?? custos.honorarios_romatec?.total ?? custos.secao_5_total;
   if (doc.y > 700) doc.addPage();
-  const txtTotalNota = 'Soma de TRT/CFT + Tecnicos de campo (com adicional de insal/peric quando aplicavel) + Marcos + Deslocamento + Area, com complexidade e assessoria, mais Locacao de Kit GNSS e Laudo Tecnico de Demarcacao (itens diretos, quando contratados). Eventuais custos de cartorio para averbacao da demarcacao NAO estao inclusos.';
+  // v3.40.0: texto coerente — locacao Kit GNSS e' FIXA (sempre soma), Laudo e' condicional.
+  const txtTotalNota = 'Soma de TRT/CFT + Tecnicos de campo (com adicional de insal/peric quando aplicavel) + Marcos + Deslocamento + Area, com complexidade (x1,3 padrao media) e assessoria (5%), acrescida de Locacao de Kit GNSS (item fixo) e Laudo Tecnico de Demarcacao (quando contratado). Eventuais custos de cartorio para averbacao da demarcacao NAO estao inclusos.';
   const boxYT = doc.y;
   const boxAlturaT = doc.heightOfString(txtTotalNota, { width: COL_W - 24 }) + 38;
   doc.rect(COL_X_INI, boxYT, COL_W, boxAlturaT).fillAndStroke(COR_VERDE_BG, COR_VERDE_BORDA);
@@ -2273,6 +2318,13 @@ function renderDemarcacaoLotesBody(
       doc.fontSize(9.5).fillColor(l.contratado ? corHex : '#666').font(l.contratado ? 'Helvetica-Bold' : 'Helvetica')
         .text(valorTxt, COL_X_FIM - 100, y0, { width: 100, align: 'right' });
       doc.font('Helvetica').fillColor('#111');
+      // v3.40.0: detalhe (regra de calculo / memoria descritiva) abaixo do rotulo
+      const det = (l as { detalhe?: string }).detalhe;
+      if (det) {
+        doc.fontSize(8).fillColor('#555').font('Helvetica-Oblique')
+          .text(det, COL_X_INI + 16, doc.y, { width: COL_W - 24 });
+        doc.font('Helvetica').fillColor('#111');
+      }
       doc.moveDown(0.1);
     });
     if (opcSec.subtotal > 0) {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -9256,18 +9256,15 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
         </div>
         <label>Validade (dias) <input id="dmValidade" type="number" min="1" step="1" value="${cache?.validade_dias ?? 15}" style="width:100%;"></label>
 
-        <!-- v3.38.0: itens diretos (Kit GNSS + Laudo) — alinhamento a PROP-2026-0028-R1 -->
-        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">🛰️ Itens Diretos (somam ao total)</p>
-        <div class="lp-grid-2">
-          <label style="display:flex; gap:6px; align-items:center;"><input id="dmKitGnss" type="checkbox" ${cache?.locacao_kit_gnss_contratado ? 'checked' : ''}> Locação Kit GNSS</label>
-          <div></div>
-        </div>
+        <!-- v3.38.0–v3.40.0: itens diretos (Kit GNSS é FIXO; Laudo condicional) — gold standard PROP-2026-0028-R1 -->
+        <p style="margin:12px 0 4px; font-weight:600; color:var(--neon); font-size:13px;">🛰️ Locação Kit GNSS (item fixo — sempre soma)</p>
         <div class="lp-grid-2">
           <label>Diárias (admite 0,5) <input id="dmKitGnssQtd" type="number" min="0" step="0.5" value="${cache?.locacao_kit_gnss_qtd ?? 1}" style="width:100%;"></label>
           <label>R$/diária <input id="dmKitGnssDiaria" type="number" min="0" step="0.01" value="${cache?.locacao_kit_gnss_diaria ?? 250}" style="width:100%;"></label>
         </div>
-        <div style="font-size:11px; color:var(--text-muted); margin:-4px 0 6px 4px;">
-          ComNav S6 (base) · T30 Plus c/ laser (rover) · tripé · base niveladora · bastão/bipé · coletora R80
+        <div style="font-size:11px; color:var(--text-muted); margin:-4px 0 8px 4px;">
+          Discriminação: ComNav S6 (base) · T30 Plus c/ laser (rover) · tripé · base niveladora · bastão/bipé · coletora R80.
+          Para projetos sem campo, ajuste diárias a 0.
         </div>
         <label style="display:flex; gap:6px; align-items:center;"><input id="dmLaudoDireto" type="checkbox" ${cache?.laudo_tecnico_direto_contratado ? 'checked' : ''}> Laudo Técnico de Demarcação (R$ 1.621 — 1 SM 2026)</label>
 
@@ -9403,8 +9400,8 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     if (document.getElementById('dmOpcJurid').checked)
       opcionais.consultoria_juridica = { contratado: true, valor: 'sob_orcamento' };
 
-    // v3.38.0: itens diretos (Kit GNSS + Laudo Tecnico)
-    const kitContratado = document.getElementById('dmKitGnss').checked;
+    // v3.38.0–v3.40.0: itens diretos. Kit GNSS e' FIXO (sempre passa qtd/diaria),
+    // Laudo Tecnico continua condicional ao checkbox.
     const laudoContratado = document.getElementById('dmLaudoDireto').checked;
     const numParcelas = parseInt(document.getElementById('dmNumParcelas').value, 10) === 3 ? 3 : 2;
 
@@ -9425,12 +9422,12 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
       desconto_pct: parseFloat(document.getElementById('dmDesc').value) || 0,
       validade_dias: parseInt(document.getElementById('dmValidade').value, 10) || 15,
       opcionais,
-      // v3.38.0
+      // v3.38.0–v3.40.0: laudo opcional (checkbox); Kit GNSS sempre passa qtd/diaria
       laudo_tecnico_direto: laudoContratado ? { contratado: true, valor_unitario_sm_multiplicador: 1.0 } : undefined,
-      locacao_kit_gnss: kitContratado ? {
-        qtd_diarias: parseFloat(document.getElementById('dmKitGnssQtd').value) || 1,
+      locacao_kit_gnss: {
+        qtd_diarias: parseFloat(document.getElementById('dmKitGnssQtd').value) || 0,
         diaria: parseFloat(document.getElementById('dmKitGnssDiaria').value) || 250,
-      } : undefined,
+      },
       num_parcelas: numParcelas,
     };
     if (isUrbana) {

--- a/src/services/pdf/demarcacaoFinalidade.ts
+++ b/src/services/pdf/demarcacaoFinalidade.ts
@@ -1,0 +1,58 @@
+// v3.40.0: helper standalone (sem deps de mysql/voyageai/pdfkit) pra gerar o
+// texto da FINALIDADE da proposta de Demarcacao conforme PROP-2026-0028-R1.
+// Extraido de propostasConsultoria.ts pra ser testavel sem arrastar voyageai.
+
+import type { FinalidadeDemarcacao } from '../pricing/types';
+
+// Textos legados (fallback retrocompat). v3.40.0 promoveu finalidade
+// demarcacao_inicial para um texto dinamico (rural com NBR 13133 + SIRGAS2000,
+// urbano com NBR 13133).
+const FINALIDADE_DEMARCACAO_TEXTOS_LEGADO: Record<FinalidadeDemarcacao, string> = {
+  demarcacao_inicial: 'Levantamento topografico de campo para implantacao fisica dos vertices definidos em projeto e materializacao da poligonal do imovel no terreno.',
+  redemarcacao: 'Repiqueteamento de vertices perdidos/deteriorados, restabelecendo a poligonal original conforme matricula e levantamento anterior.',
+  subdivisao_lote: 'Demarcacao fisica das fracoes resultantes de desmembramento/remembramento aprovado, com implantacao de marcos nas novas divisas.',
+  piqueteamento_apenas: 'Implantacao de marcos fisicos em vertices previamente calculados em escritorio (sem novo levantamento de campo).',
+};
+
+/**
+ * Gera o texto da FINALIDADE da proposta de Demarcacao.
+ *
+ * - Rural + demarcacao_inicial: cita denominacao do imovel + "parcela de gleba rural"
+ *   + NTGIR 3a Ed. (INCRA) + NBR 13133 (ABNT) + SIRGAS2000.
+ * - Urbana + demarcacao_inicial: cita loteamento/quadra/lote se disponivel + NBR 13133.
+ * - Outras finalidades: usa texto legado (retrocompat).
+ */
+export function montarFinalidadeDemarcacao(
+  finalidade: FinalidadeDemarcacao,
+  subtipo: 'demarcacao_urbana' | 'demarcacao_rural',
+  dadosImovel: { denominacao_imovel?: string; loteamento_nome?: string; quadra?: string; lote?: string },
+): string {
+  const isRural = subtipo === 'demarcacao_rural';
+  if (finalidade === 'demarcacao_inicial') {
+    if (isRural) {
+      const denom = (dadosImovel.denominacao_imovel || '').trim() || 'parte de gleba rural';
+      return `Levantamento topografico georreferenciado e implantacao fisica dos vertices `
+        + `da poligonal de ${denom} (parcela de gleba rural), com materializacao dos marcos no terreno `
+        + `conforme NTGIR 3a Ed. (INCRA) e NBR 13133 (ABNT), em coordenadas SIRGAS2000.`;
+    }
+    const parts: string[] = [];
+    if (dadosImovel.loteamento_nome) parts.push(`Loteamento ${dadosImovel.loteamento_nome.trim()}`);
+    if (dadosImovel.quadra) parts.push(`Quadra ${dadosImovel.quadra.trim()}`);
+    if (dadosImovel.lote) parts.push(`Lote ${dadosImovel.lote.trim()}`);
+    const ref = parts.length > 0 ? `do lote (${parts.join(', ')})` : 'do lote';
+    return `Levantamento topografico de campo para implantacao fisica dos vertices definidos `
+      + `em projeto e materializacao da poligonal ${ref} no terreno, conforme NBR 13133 (ABNT).`;
+  }
+  return FINALIDADE_DEMARCACAO_TEXTOS_LEGADO[finalidade];
+}
+
+/** v3.40.0: formatador uniforme do perimetro — sempre 2 casas decimais (fixed).
+ *  Evita o bug 2.190,78 vs 2.190,79 (renderizacoes inconsistentes em pontos
+ *  diferentes do PDF / front).
+ */
+export function formatarPerimetroBr(perimetroM: number): string {
+  return Number(perimetroM).toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}

--- a/src/services/pricing/demarcacaoLotes.test.ts
+++ b/src/services/pricing/demarcacaoLotes.test.ts
@@ -152,7 +152,28 @@ describe('calcularDemarcacaoLotes — calculo principal', () => {
     }
   });
 
-  it('13. Minimo garantido (2 SM) aplicado quando calculo fica abaixo', () => {
+  it('13. Minimo garantido (2 SM) aplicado sobre CORE quando calculo fica abaixo (extras somam por cima)', () => {
+    // v3.40.0: kit GNSS e' fixo (default 1 diaria=250). Minimo aplica sobre core,
+    // depois kit (e laudo se contratado) somam.
+    const r = calcularDemarcacaoLotes({
+      subtipo: 'demarcacao_urbana',
+      finalidade: 'piqueteamento_apenas',
+      municipio: 'X',
+      uf: 'MA',
+      area_m2: 0.01,
+      num_vertices: 3,
+      servico_piqueteamento: false,
+      marcos: [],
+      diarias_equipe: 1,
+      km_deslocamento: 0,
+      complexidade: 'simples',
+      locacao_kit_gnss: { qtd_diarias: 0 }, // edge: sem kit pra reproduzir comportamento original
+    });
+    const minimo = 2 * SM_2026;
+    expect(r.honorarios_romatec.total).toBe(Math.round(minimo * 100) / 100);
+  });
+
+  it('13b. Minimo + kit fixo (default qtd=1): total = minimo + 250', () => {
     const r = calcularDemarcacaoLotes({
       subtipo: 'demarcacao_urbana',
       finalidade: 'piqueteamento_apenas',
@@ -167,7 +188,7 @@ describe('calcularDemarcacaoLotes — calculo principal', () => {
       complexidade: 'simples',
     });
     const minimo = 2 * SM_2026;
-    expect(r.honorarios_romatec.total).toBe(Math.round(minimo * 100) / 100);
+    expect(r.honorarios_romatec.total).toBe(Math.round((minimo + 250) * 100) / 100);
   });
 
   it('14. Desconto 0% nao altera valor', () => {
@@ -319,15 +340,25 @@ describe('v3.38.0 — Laudo Tecnico de Demarcacao (item direto)', () => {
   });
 });
 
-describe('v3.38.0 — Locacao Kit GNSS (item direto)', () => {
-  it('30. qtd_diarias=0 (default) -> contratado=false, valor=0', () => {
+describe('v3.40.0 — Locacao Kit GNSS (item FIXO — sempre presente)', () => {
+  // v3.40.0: kit deixa de ser opcional. Default qtd_diarias=1, diaria=250.
+  // User pode passar qtd_diarias=0 explicitamente pra desativar (edge case).
+  it('30. input sem locacao_kit_gnss -> default qtd=1, contratado=true, valor=250 (gold standard)', () => {
     const r = calcularDemarcacaoLotes(baseUrbana);
+    expect(r.honorarios_romatec.locacao_kit_gnss.contratado).toBe(true);
+    expect(r.honorarios_romatec.locacao_kit_gnss.qtd_diarias).toBe(1);
+    expect(r.honorarios_romatec.locacao_kit_gnss.diaria).toBeCloseTo(250, 2);
+    expect(r.honorarios_romatec.locacao_kit_gnss.valor).toBeCloseTo(250, 2);
+  });
+
+  it('30b. qtd_diarias=0 explicito -> contratado=false, valor=0 (edge case: projeto sem campo)', () => {
+    const r = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 0 } });
     expect(r.honorarios_romatec.locacao_kit_gnss.contratado).toBe(false);
     expect(r.honorarios_romatec.locacao_kit_gnss.valor).toBe(0);
   });
 
-  it('31. qtd_diarias=1, diaria default (250) -> valor=250 somado ao total', () => {
-    const sem = calcularDemarcacaoLotes(baseUrbana);
+  it('31. qtd_diarias=1, diaria default (250) -> valor=250 (diferenca vs qtd=0)', () => {
+    const sem = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 0 } });
     const com = calcularDemarcacaoLotes({ ...baseUrbana, locacao_kit_gnss: { qtd_diarias: 1 } });
     expect(com.honorarios_romatec.locacao_kit_gnss.contratado).toBe(true);
     expect(com.honorarios_romatec.locacao_kit_gnss.qtd_diarias).toBe(1);

--- a/src/services/pricing/demarcacaoLotes.ts
+++ b/src/services/pricing/demarcacaoLotes.ts
@@ -213,12 +213,16 @@ export function calcularDemarcacaoLotes(
     return { contratado: false, valor: 0 };
   })();
 
+  // v3.40.0: Kit GNSS e' ITEM FIXO dos honorarios (nao opcional) — gold standard
+  // PROP-2026-0028-R1. Default qtd=1 (1 diaria), diaria R$ 250,00. User pode
+  // explicitamente passar qtd=0 pra desativar (edge case — projeto sem campo).
   const kitGnss = (() => {
     const kit = input.locacao_kit_gnss;
     const cfgKit = cfg.locacao_kit_gnss;
     const diariaDefault = cfgKit?.valor_unitario_diaria_default ?? 250.00;
     const descritivo = cfgKit?.descritivo ?? '';
-    const qtd = Number(kit?.qtd_diarias ?? 0);
+    // qtd default = 1 (v3.40.0); antes era 0
+    const qtd = Number(kit?.qtd_diarias ?? 1);
     if (!Number.isFinite(qtd) || qtd < 0) {
       throw new Error(`locacao_kit_gnss.qtd_diarias invalido: ${qtd} (esperado >= 0)`);
     }
@@ -251,7 +255,8 @@ export function calcularDemarcacaoLotes(
   }
 
   // ── Opcionais (4 linhas — laudo foi promovido a direto) ──────────────
-  const linhasOpcionais = montarLinhasOpcionais(opcionaisRaw, cfg.opcionais);
+  // v3.40.0: passa perimetro_m pra gerar a regra de calculo do alinhamento.
+  const linhasOpcionais = montarLinhasOpcionais(opcionaisRaw, cfg.opcionais, Number(input.perimetro_m ?? 0));
   const subtotalOpcionais = round2(
     linhasOpcionais
       .filter((l) => l.contratado && typeof l.valor === 'number')
@@ -317,21 +322,30 @@ export function calcularDemarcacaoLotes(
 function montarLinhasOpcionais(
   opcionais: OpcionaisDemarcacao,
   cfgOpc: NonNullable<ReturnType<typeof getParams>['demarcacao_lotes_2026']>['opcionais'],
-): { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[] {
-  // v3.38.0: 4 linhas SEMPRE renderizadas (laudo_tecnico foi promovido a item
-  // direto em honorarios_romatec).
-  const linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[] = [];
+  perimetroM: number,
+): { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string }[] {
+  // v3.38.0: 4 linhas SEMPRE renderizadas (laudo_tecnico foi promovido a item direto).
+  // v3.40.0: linhas ganham campo `detalhe` opcional — regra de calculo visivel no PDF.
+  const linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string }[] = [];
 
-  // 1. Alinhamento de cerca
+  // 1. Alinhamento de cerca — detalhe com a regra (Extensao × R$/m · default perimetro)
   {
     const it = opcionais.alinhamento_cerca;
     const contratado = !!it?.contratado;
     const metros = Number(it?.metros ?? 0);
     const vUnit = Number(it?.valor_unitario ?? cfgOpc.alinhamento_cerca.valor_unitario);
+    const vUnitTxt = vUnit.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const perimTxt = perimetroM > 0
+      ? perimetroM.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+      : null;
+    const detalhe = perimTxt
+      ? `Extensao × R$ ${vUnitTxt}/m · default perimetro ${perimTxt} m (editavel p/ alinhamento parcial)`
+      : `Extensao × R$ ${vUnitTxt}/m (editavel p/ alinhamento parcial)`;
     linhas.push({
       rotulo: cfgOpc.alinhamento_cerca.rotulo,
       contratado,
       valor: contratado ? round2(metros * vUnit) : 0,
+      detalhe,
     });
   }
   // 2. Croqui assinado

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -555,7 +555,9 @@ export interface DemarcacaoLotesOutput {
     total: number;
   };
   secao_opcionais_demarcacao: {
-    linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean }[];
+    // v3.40.0: linhas ganham `detalhe` opcional — regra de calculo / memoria descritiva
+    // exibida abaixo do rotulo no PDF (ex.: alinhamento de cerca: "Extensao X m × R$ 0,42/m · default perimetro 2.190,78 m (editavel)").
+    linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string }[];
     subtotal: number;
   };
   parcelas: { numero: 1 | 2 | 3; rotulo: string; valor: number; percentual: number }[];

--- a/src/test/hotfix-proposta-demarcacao-canonica-v3.40.0.test.ts
+++ b/src/test/hotfix-proposta-demarcacao-canonica-v3.40.0.test.ts
@@ -1,0 +1,276 @@
+// v3.40.0: testes do hotfix dos 5 bugs identificados na proposta PROP-2026-0029-R1
+// (regressao do PROP-2026-0028-R1, gold standard).
+//
+// BUG 1 — Finalidade voltava ao texto de rascunho hardcoded.
+// BUG 2 — Linha "Locação Kit GNSS" sumia (era opcional). Agora e' FIXA.
+// BUG 3 — Alinhamento de cerca sem memoria de calculo. Agora tem.
+// BUG 4 — Discriminacao do kit precisa renderizar abaixo da linha (multilinha).
+// BUG 5 — Perimetro 2.190,78 vs 2.190,79 (formatacao inconsistente).
+//
+// Tudo testavel por unit testing do engine + regex no propostasConsultoria.ts
+// (PDF render). PDF visual e' difamado e' fora do escopo do CI.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  calcularDemarcacaoLotes,
+} from '../services/pricing/demarcacaoLotes';
+import {
+  montarFinalidadeDemarcacao,
+} from '../services/pdf/demarcacaoFinalidade';
+import type { InputDemarcacaoLotes } from '../services/pricing/types';
+
+const PROPOSTAS_CONS_TS = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'integrations', 'propostasConsultoria.ts'),
+  'utf-8',
+);
+
+// ──────────────────────────────────────────────────────────────────────
+// BUG 1 — Finalidade rural com denominacao + NBR 13133 + SIRGAS2000
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3.40.0 — BUG 1: Finalidade rural alinhada a PROP-2026-0028-R1', () => {
+  it('1. Rural com denominacao -> cita denominacao + parcela de gleba + NBR 13133 + SIRGAS2000', () => {
+    const f = montarFinalidadeDemarcacao('demarcacao_inicial', 'demarcacao_rural', {
+      denominacao_imovel: 'Parte da Fazenda Gloria',
+    });
+    expect(f).toContain('Parte da Fazenda Gloria');
+    expect(f).toContain('parcela de gleba rural');
+    expect(f).toContain('NTGIR 3a Ed. (INCRA)');
+    expect(f).toContain('NBR 13133');
+    expect(f).toContain('SIRGAS2000');
+    // NAO contem o texto de rascunho antigo:
+    expect(f).not.toContain('definidos em projeto');
+  });
+
+  it('2. Rural sem denominacao -> usa fallback "parte de gleba rural"', () => {
+    const f = montarFinalidadeDemarcacao('demarcacao_inicial', 'demarcacao_rural', {});
+    expect(f).toContain('parte de gleba rural');
+  });
+
+  it('3. Urbana -> cita loteamento/quadra/lote + NBR 13133 (sem NTGIR/SIRGAS)', () => {
+    const f = montarFinalidadeDemarcacao('demarcacao_inicial', 'demarcacao_urbana', {
+      loteamento_nome: 'Vila Boa',
+      quadra: 'A',
+      lote: '10',
+    });
+    expect(f).toContain('Loteamento Vila Boa');
+    expect(f).toContain('Quadra A');
+    expect(f).toContain('Lote 10');
+    expect(f).toContain('NBR 13133');
+    expect(f).not.toContain('NTGIR');
+    expect(f).not.toContain('SIRGAS2000');
+  });
+
+  it('4. Outras finalidades (redemarcacao, subdivisao, piqueteamento) usam o texto legado', () => {
+    const fr = montarFinalidadeDemarcacao('redemarcacao', 'demarcacao_rural', {});
+    expect(fr).toMatch(/[Rr]epiqueteamento/);
+    const fs2 = montarFinalidadeDemarcacao('subdivisao_lote', 'demarcacao_urbana', {});
+    expect(fs2).toMatch(/desmembramento|remembramento/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// BUG 2 — Locacao Kit GNSS e' item FIXO (sempre presente)
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3.40.0 — BUG 2: Kit GNSS sempre presente nos honorarios', () => {
+  const baseInput: InputDemarcacaoLotes = {
+    subtipo: 'demarcacao_rural',
+    finalidade: 'demarcacao_inicial',
+    municipio: 'Acailandia',
+    uf: 'MA',
+    area_hectares: 29.04,
+    perimetro_m: 2190.78,
+    num_vertices: 4,
+    servico_piqueteamento: true,
+    marcos: [{ tipo: 'madeira', quantidade: 4, valor_unitario_congelado: 35 }],
+    diarias_equipe: 1,
+    km_deslocamento: 30,
+    complexidade: 'media',
+    adicional_campo_pct: 20,
+    laudo_tecnico_direto: { contratado: true },
+    num_parcelas: 2,
+  };
+
+  it('5. Input sem locacao_kit_gnss -> engine retorna kit com qtd=1, valor=250 (gold standard)', () => {
+    const r = calcularDemarcacaoLotes(baseInput);
+    expect(r.honorarios_romatec.locacao_kit_gnss.contratado).toBe(true);
+    expect(r.honorarios_romatec.locacao_kit_gnss.qtd_diarias).toBe(1);
+    expect(r.honorarios_romatec.locacao_kit_gnss.valor).toBe(250);
+  });
+
+  it('6. Total ja inclui Kit GNSS por default (PROP-2026-0028-R1 R$ 6.619,26)', () => {
+    const r = calcularDemarcacaoLotes(baseInput);
+    expect(r.honorarios_romatec.total).toBeCloseTo(6619.26, 1);
+  });
+
+  it('7. Engine NAO inclui Kit GNSS se user passa qtd_diarias=0 explicito (edge case)', () => {
+    const r = calcularDemarcacaoLotes({ ...baseInput, locacao_kit_gnss: { qtd_diarias: 0 } });
+    expect(r.honorarios_romatec.locacao_kit_gnss.contratado).toBe(false);
+    expect(r.honorarios_romatec.total).toBeCloseTo(6619.26 - 250, 1);
+  });
+
+  it('8. Descritivo do Kit (equipamentos) presente no output', () => {
+    const r = calcularDemarcacaoLotes(baseInput);
+    const desc = r.honorarios_romatec.locacao_kit_gnss.descritivo;
+    expect(desc).toMatch(/ComNav S6/);
+    expect(desc).toMatch(/T30 Plus/);
+    expect(desc).toMatch(/R80/);
+    expect(desc).toMatch(/tripe/i);
+  });
+
+  it('9. PDF render tem subsecao 4.3 Locacao Kit GNSS (NAO inline na 4. Honorarios)', () => {
+    // Kit foi promovido a subsecao propria (4.3)
+    expect(PROPOSTAS_CONS_TS).toMatch(/4\.3 Locacao de Equipamentos — Kit GNSS/);
+    // E' renderizado quando o output tem o campo e valor > 0
+    expect(PROPOSTAS_CONS_TS).toMatch(/hr\.locacao_kit_gnss && hr\.locacao_kit_gnss\.valor > 0/);
+  });
+
+  it('10. PDF render tem subsecao 4.4 Laudo (condicional ao contratado)', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/4\.4 Laudo Tecnico de Demarcacao/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/hr\.laudo_tecnico_direto\.contratado/);
+  });
+
+  it('11. Ordem travada: 4.2 Marcos antes de 4.3 Locacao antes de 4.4 Laudo antes de 4.5 FQNS', () => {
+    const i42 = PROPOSTAS_CONS_TS.indexOf('4.2 Marcos Discriminados');
+    const i43 = PROPOSTAS_CONS_TS.indexOf('4.3 Locacao de Equipamentos');
+    const i44 = PROPOSTAS_CONS_TS.indexOf('4.4 Laudo Tecnico de Demarcacao');
+    const i45 = PROPOSTAS_CONS_TS.indexOf('4.5 Identificacao dos Marcos');
+    expect(i42).toBeGreaterThan(0);
+    expect(i43).toBeGreaterThan(i42);
+    expect(i44).toBeGreaterThan(i43);
+    expect(i45).toBeGreaterThan(i44);
+  });
+
+  it('12. Linhas inline da secao 4 NAO contem mais Kit/Laudo (foram movidos pra subsecoes)', () => {
+    // O array linhasHon nao deve mais ter "Kit GNSS" como label inline.
+    // Aceita-se comentario citando — mas nao push() com esse label.
+    const matchKitInlinePush = PROPOSTAS_CONS_TS.match(
+      /arr\.push\(\{[\s\S]{0,200}?label:[\s\S]{0,80}?Locacao de equipamentos — Kit GNSS/,
+    );
+    expect(matchKitInlinePush).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// BUG 3 — Alinhamento cerca exibe regra completa
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3.40.0 — BUG 3: Alinhamento cerca com regra de calculo', () => {
+  it('13. Engine inclui `detalhe` na linha de alinhamento com vUnit + perimetro default', () => {
+    const r = calcularDemarcacaoLotes({
+      subtipo: 'demarcacao_rural',
+      finalidade: 'demarcacao_inicial',
+      municipio: 'X', uf: 'MA',
+      area_hectares: 29.04,
+      perimetro_m: 2190.78,
+      num_vertices: 4,
+      servico_piqueteamento: false,
+      marcos: [],
+      diarias_equipe: 1, km_deslocamento: 0,
+      complexidade: 'media',
+      opcionais: { alinhamento_cerca: { contratado: true, metros: 2190.78, valor_unitario: 0.42 } },
+    });
+    const linha = r.secao_opcionais_demarcacao.linhas.find(l => /Alinhamento/i.test(l.rotulo));
+    expect(linha?.detalhe).toBeDefined();
+    expect(linha!.detalhe).toMatch(/R\$ 0,42\/m/);
+    expect(linha!.detalhe).toMatch(/2\.190,78 m/);
+    expect(linha!.detalhe).toMatch(/editavel p\/ alinhamento parcial/i);
+  });
+
+  it('14. Engine sem perimetro_m -> detalhe ainda renderiza (sem citar default)', () => {
+    const r = calcularDemarcacaoLotes({
+      subtipo: 'demarcacao_urbana',
+      finalidade: 'demarcacao_inicial',
+      municipio: 'X', uf: 'MA',
+      area_m2: 500,
+      num_vertices: 4,
+      servico_piqueteamento: false,
+      marcos: [],
+      diarias_equipe: 1, km_deslocamento: 0,
+      complexidade: 'simples',
+      opcionais: { alinhamento_cerca: { contratado: true, metros: 100, valor_unitario: 0.42 } },
+    });
+    const linha = r.secao_opcionais_demarcacao.linhas.find(l => /Alinhamento/i.test(l.rotulo));
+    expect(linha?.detalhe).toMatch(/R\$ 0,42\/m/);
+    expect(linha?.detalhe).not.toMatch(/default perimetro/);
+  });
+
+  it('15. PDF render exibe `detalhe` abaixo do rotulo (Helvetica-Oblique, cor #555)', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/const det = \(l as \{ detalhe\?: string \}\)\.detalhe/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/if \(det\)\s*\{[\s\S]{0,200}?fontSize\(8\)[\s\S]{0,100}?Helvetica-Oblique/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// BUG 4 — Discriminacao do Kit renderiza como bloco multilinha
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3.40.0 — BUG 4: Discriminacao Kit em bloco abaixo da linha', () => {
+  it('16. PDF render da subsecao 4.3 inclui descritivo do kit como linha proprias', () => {
+    // Apos o valor R$ X, renderiza descritivo (ComNav S6, T30 Plus, etc.) em uma linha propria
+    expect(PROPOSTAS_CONS_TS).toMatch(/kg\.descritivo[\s\S]{0,300}?fontSize\(8\)[\s\S]{0,80}?text\(kg\.descritivo/);
+  });
+
+  it('17. Diaria editavel — frase clarificadora visivel no PDF', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/Diaria editavel; admite meia ou multiplas diarias/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// BUG 5 — Perimetro com fonte unica + toFixed(2) consistente
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3.40.0 — BUG 5: Perimetro com formatacao consistente (2.190,78 sempre)', () => {
+  const HELPER_TS = fs.readFileSync(
+    path.join(process.cwd(), 'src', 'services', 'pdf', 'demarcacaoFinalidade.ts'),
+    'utf-8',
+  );
+
+  it('18. Helper formatarPerimetroBr fixa 2 casas decimais (min + max)', () => {
+    expect(HELPER_TS).toMatch(/export function formatarPerimetroBr\(perimetroM: number\)/);
+    expect(HELPER_TS).toMatch(/minimumFractionDigits: 2,\s*\n?\s*maximumFractionDigits: 2/);
+  });
+
+  it('18b. Funcao em runtime: 2190.78 -> "2.190,78" (formato BR)', async () => {
+    const { formatarPerimetroBr } = await import('../services/pdf/demarcacaoFinalidade');
+    expect(formatarPerimetroBr(2190.78)).toBe('2.190,78');
+    // 2190.789 deve truncar pra 2 casas (era exatamente o bug 78 vs 79)
+    expect(formatarPerimetroBr(2190.789)).toMatch(/^2\.190,7(8|9)$/);
+    // 2190.785 -> banker rounding produz 2,79 em alguns engines; teste so' verifica 2 casas
+    expect(formatarPerimetroBr(2190).split(',')[1]).toBe('00');
+  });
+
+  it('19. Secao 1 (Identificacao) usa formatarPerimetroBr (nao toLocaleString inline)', () => {
+    // Garante que perimetro nao e' formatado inline com toLocaleString sem maximumFractionDigits
+    const m = PROPOSTAS_CONS_TS.match(/Perimetro:\s*' \+ formatarPerimetroBr\(perimetro\)/);
+    expect(m).not.toBeNull();
+  });
+
+  it('20. Area_m2 e area_hectares tambem usam maximumFractionDigits explicito', () => {
+    // Tres ocorrencias: m2 (2 dec), hectares (4 dec) e perimetro (2 dec via helper)
+    const matches = PROPOSTAS_CONS_TS.match(/maximumFractionDigits:\s*\d+/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Texto do total bate com a soma — locacao nao e' mais "quando contratado"
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3.40.0 — Texto do total coerente com soma real', () => {
+  it('21. Nota do bloco verde cita "Locacao de Kit GNSS (item fixo)" — nao mais condicional', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/Locacao de Kit GNSS \(item fixo\)/);
+  });
+
+  it('22. Laudo continua marcado como "(quando contratado)"', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/Laudo Tecnico de Demarcacao \(quando contratado\)/);
+  });
+
+  it('23. NAO contem mais o texto antigo "Kit GNSS e Laudo ... (itens diretos, quando contratados)"', () => {
+    expect(PROPOSTAS_CONS_TS).not.toMatch(/itens diretos, quando contratados/);
+  });
+});


### PR DESCRIPTION
…1 (v3.40.0)

BUG 1 — Finalidade voltava ao rascunho. Promove a funcao montarFinalidadeDemarcacao(finalidade, subtipo, dados): rural cita denominacao
+ parcela gleba + NTGIR 3a Ed. + NBR 13133 + SIRGAS2000; urbana cita loteamento + NBR 13133. Funcao extraida pra src/services/pdf/demarcacaoFinalidade.ts (standalone testavel).

BUG 2 — Linha Kit GNSS sumia (era condicional). Agora item FIXO: engine default qtd_diarias=1 (era 0). Seção 4 reorganizada: linhas inline (TRT..Assessoria) + 4.2 Marcos + 4.3 Locacao Kit GNSS + 4.4 Laudo + 4.5 FQNS. Frontend remove checkbox dmKitGnss.

BUG 3 — Alinhamento de cerca ganha campo `detalhe` no engine + PDF render exibe regra "Extensao × R$ 0,42/m · default perimetro 2.190,78 m (editavel)".

BUG 4 — Discriminacao do kit (ComNav S6 + T30 Plus + R80 etc) renderiza em linha propria do PDF, abaixo da linha de locacao.

BUG 5 — Perimetro consistente. Helper formatarPerimetroBr fixa {min: 2, max: 2} digits. Area m2/hectares ganham maximumFractionDigits explicito. Fonte unica via helper exportado.

Bonus: texto do total no bloco verde reflete que Locacao e' FIXA e so' Laudo e' condicional.

Tests: 24 novos (5 BUGs + reordem + texto total) + 1 update engine. Suite total 945 passing, 1 skipped, 0 failures.

Arquivos sensiveis (tools.ts, think.ts, aiCascade.ts) intocados.