### PR TITLE
fix(demarcacao): remove DRL + habilita edicao + defesa parcelas/opcio…

### DIFF
--- a/06-Changelog/v3.42.0-hotfix-demarcacao-drl-edit-parcelas.md
+++ b/06-Changelog/v3.42.0-hotfix-demarcacao-drl-edit-parcelas.md
@@ -1,0 +1,162 @@
+# v3.42.0 — Hotfix Demarcação: DRL removido + edição habilitada + defesa parcelas R$ 0,00
+
+**Data:** 2026-05-28
+**Branch:** `fix/demarcacao-drl-edit-adicional-v3.42.0`
+**Base:** `main` (v3.41.0)
+**Versão alvo:** v3.42.0
+
+## Sintomas reportados
+
+Comparando a proposta gerada PROP-2026-0030-R1 (v3.41.0) com o gold standard PROP-2026-0028-R1, **4 divergências**:
+
+1. **Box vermelho "RESPONSABILIDADE DO PROPRIETARIO — DRL"** aparece no PDF de demarcação. Gold standard não tem.
+2. **Bullet "O cliente deve coletar DRLs..."** aparece em Avisos. Gold standard só tem 2 bullets.
+3. **"Edição não disponível para subtipo 'demarcacao_rural'"** ao clicar em Editar.
+4. **Parcelas em R$ 0,00** e/ou opcionais sem valor em algumas propostas.
+
+## Diagnóstico
+
+### BUG A — DRL no lugar errado
+
+`renderAvisoDRL` foi originalmente desenvolvido para **Georreferenciamento Rural** (regularização fundiária via SIGEF — Lei 10.267/2001 + NTGIR 3ª Ed.), onde a coleta de Declarações de Respeito de Limite é **obrigação legal do proprietário** antes da averbação.
+
+Para **Demarcação simples**, o serviço é apenas **materialização física das divisas** — não gera averbação automática e não exige DRL no escopo. O box DRL foi inserido por engano no `renderDemarcacaoLotesBody` na v3.27.0.
+
+### BUG B — Edição bloqueada
+
+Frontend tem `SUBTIPOS_EDITAVEIS = new Set([...])` em `obras.html:7246`. A lista não inclui `demarcacao_urbana` nem `demarcacao_rural`, mesmo com o form ativo desde v3.27.0.
+
+### BUG C — Edição perde o adicional de insalubridade
+
+`atualizarPropostaConsultoria` (linha ~3430) recalcula o engine de demarcação SEM injetar `adicional_campo_pct`. Resultado: ao editar uma proposta que tinha insalubridade selecionada, o novo total **PERDE** a contribuição da insalubridade.
+
+### BUG D — Parcelas/opcionais zerados
+
+Sintoma do antigo bug v3.23.8 ressuscitando em propostas legadas (override sem fallback de `condicoes_pagamento` / `secao_opcionais_demarcacao`). Para essas propostas o `cp.valor = undefined` → `formatBRL(undefined)` = "R$ 0,00".
+
+## Correções
+
+### A. Remove DRL de demarcação
+
+```ts
+// Antes (v3.27.0–v3.41.0):
+const avisosDem = [
+  'A demarcacao consiste na materializacao fisica...',
+  'O cliente deve coletar Declaracoes de Respeito de Limite (DRLs)...',  // ❌
+  'Os codigos INCRA dos marcos sao vitalicios...',
+];
+// ...
+renderAvisoDRL(doc, finalidade, COL_X_INI, COL_W);  // ❌
+
+// Agora (v3.42.0):
+const avisosDem = [
+  'A demarcacao consiste na materializacao fisica...',
+  'Os codigos INCRA dos marcos sao vitalicios...',
+];
+// renderAvisoDRL REMOVIDO daqui — só permanece em Georref Rural.
+```
+
+### B. Habilita edição de demarcação
+
+```js
+const SUBTIPOS_EDITAVEIS = new Set([
+  'averbacao_residencial', 'averbacao_comercial',
+  'georreferenciamento_rural',
+  'desmembramento', 'remembramento', 'retificacao_area', 'avaliacao_ptam',
+  'projeto_executivo',
+  'demarcacao_urbana',  // ✓ v3.42.0
+  'demarcacao_rural',   // ✓ v3.42.0
+]);
+```
+
+### C. Edição preserva adicional_campo
+
+```ts
+} else if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+  // v3.42.0: extrai snapshot do adicional e injeta pct ANTES do engine
+  const dadosInjetados = { ...dadosFinal };
+  const adicionalSnap = (atualCalc as ...)?.adicional_campo;
+  if (adicionalSnap?.ativo && typeof adicionalSnap.percentual === 'number') {
+    dadosInjetados.adicional_campo_pct = adicionalSnap.percentual;
+  }
+  const out = m.calcularDemarcacaoLotes(dadosInjetados);
+  custosFinal = adaptarDemarcacaoParaCustosCalculados(out);
+  // Preserva snapshot pra PDF render
+  if (adicionalSnap) {
+    (custosFinal as ...).adicional_campo = adicionalSnap;
+  }
+}
+```
+
+### D. Defesa runtime para parcelas e opcionais
+
+**Parcelas:** se alguma `cp.valor = 0/undefined` mas `secao_5_total > 0`, recompute via percentual extraído da descrição (`"X% do total"`):
+
+```ts
+const algumZero = parcelas.some((cp) => !Number.isFinite(Number(cp.valor)) || Number(cp.valor) === 0);
+if (algumZero && totalReal > 0) {
+  const pcts = parcelas.map(cp => /(\d+(?:[.,]\d+)?)\s*%/.exec(cp.descricao)?.[1]);
+  // Recomputa cada parcela com a última absorvendo resíduo de arredondamento
+}
+```
+
+**Opcionais:** engine agora expõe `metros` e `valor_unitario` por linha. PDF render recompute se `contratado=true` mas `valor=0`:
+
+```ts
+if (l.contratado && Number(valorRender) === 0 && lExt.metros > 0 && lExt.valor_unitario > 0) {
+  valorRender = Math.round(lExt.metros * lExt.valor_unitario * 100) / 100;
+}
+```
+
+## Sobre o Adicional de Insalubridade
+
+O box ⚠ ADICIONAL DE INSALUBRIDADE / PERICULOSIDADE (CLT art. 192-193 / NR-15 Anexo 14) é renderizado por `renderAdicionalCampoBody()` quando `custos.adicional_campo.ativo === true`. **Já funciona corretamente** desde v3.33.0 — basta o usuário selecionar o cenário no wizard de "Adicional de campo" do form de demarcação.
+
+A v3.42.0 garante adicionalmente que:
+- Editar uma proposta existente preserva o adicional (BUG C)
+- Após remover o box vermelho DRL, o Adicional aparece sem competição visual
+
+## Arquivos alterados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/integrations/propostasConsultoria.ts` | Remove DRL bullet + call de demarcação. Injeta `adicional_campo_pct` em `atualizarPropostaConsultoria` (edit). Defesa runtime para parcelas + opcionais R$ 0,00. |
+| `src/public/obras.html` | `SUBTIPOS_EDITAVEIS` agora inclui demarcacao_urbana/rural. |
+| `src/services/pricing/types.ts` | `secao_opcionais_demarcacao.linhas` ganha `metros?` e `valor_unitario?` (forward compat pra defesa). |
+| `src/services/pricing/demarcacaoLotes.ts` | Engine popula `metros` e `valor_unitario` na linha de alinhamento. |
+| `src/test/hotfix-demarcacao-drl-edit-parcelas-v3.42.0.test.ts` | **NOVO** — 11 testes regressão. |
+| `package.json` | 3.41.0 → 3.42.0 |
+
+## Arquivos NÃO alterados (regra do prompt)
+
+- ✅ `src/agent/tools.ts` — intocado
+- ✅ `src/agent/think.ts` — intocado
+- ✅ `src/services/aiCascade.ts` — intocado
+
+## Testes
+
+`src/test/hotfix-demarcacao-drl-edit-parcelas-v3.42.0.test.ts` — **11 testes**:
+
+| # | Bloco | Cobertura |
+|---|---|---|
+| 1 | BUG A | bullet DRL removido de avisosDem; 2 bullets originais preservados |
+| 2 | BUG A | renderAvisoDRL não mais chamado em demarcação (count ≤ 1) |
+| 3 | BUG A | renderAvisoDRL CONTINUA usado em georref (regressão) |
+| 4 | BUG B | SUBTIPOS_EDITAVEIS contém demarcacao_urbana + rural |
+| 5–6 | BUG C | atualizarPropostaConsultoria injeta pct + preserva snapshot |
+| 7–9 | BUG D parcelas | detecta valor=0; lê percentual da descrição; última absorve resíduo |
+| 10–11 | BUG D opcionais | engine expõe metros+valor_unitario; PDF render recompute |
+
+**Suite total:** 969 passing, 1 skipped, 0 failures (baseline 958 + 11 novos).
+**Typecheck:** ✅ limpo.
+
+## Política preservada
+
+- ✅ Retrocompat: propostas v3.27.0–v3.41.0 com DRL no JSON continuam abrindo (o campo simplesmente não é mais usado no render de demarcação).
+- ✅ Retrocompat: propostas legadas com parcelas R$ 0,00 passam a renderizar corretamente via defesa runtime.
+- ✅ Georref Rural mantém renderAvisoDRL (DRL obrigatório lá).
+- ✅ Wizard de Adicional de Campo continua opcional — user decide se aplica.
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.41.0",
+  "version": "3.42.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -2250,7 +2250,37 @@ function renderDemarcacaoLotesBody(
     doc.font('Helvetica');
     doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
     doc.moveDown(0.2);
-    custos.condicoes_pagamento.forEach((cp) => {
+    // v3.42.0 DEFESA: recompute parcelas em runtime se vieram com valor 0/undefined
+    // mas o total esta > 0 (corrupcao de dados em propostas antigas — bug v3.23.8
+    // ressuscitado em algum subtipo). Le percentual da descricao se preciso.
+    const totalReal = custos.secao_5_total
+      ?? (custos as unknown as { honorarios_romatec_demarcacao?: { total: number } }).honorarios_romatec_demarcacao?.total
+      ?? 0;
+    const parcelas = custos.condicoes_pagamento;
+    const algumZero = parcelas.some((cp) => !Number.isFinite(Number(cp.valor)) || Number(cp.valor) === 0);
+    let parcelasRender = parcelas;
+    if (algumZero && totalReal > 0) {
+      // Tenta extrair percentual da descricao "X% do total"
+      const pcts = parcelas.map((cp) => {
+        const m = String(cp.descricao || '').match(/(\d+(?:[.,]\d+)?)\s*%/);
+        return m ? Number(m[1].replace(',', '.')) / 100 : null;
+      });
+      const todosPct = pcts.every((p) => p != null && p > 0);
+      if (todosPct) {
+        // Ultima parcela absorve residuo
+        parcelasRender = parcelas.map((cp, i, arr) => {
+          let valor: number;
+          if (i === arr.length - 1) {
+            const soma = arr.slice(0, -1).reduce((s, _, j) => s + Math.round((totalReal * (pcts[j] as number)) * 100) / 100, 0);
+            valor = Math.round((totalReal - soma) * 100) / 100;
+          } else {
+            valor = Math.round((totalReal * (pcts[i] as number)) * 100) / 100;
+          }
+          return { ...cp, valor };
+        });
+      }
+    }
+    parcelasRender.forEach((cp) => {
       const y0 = doc.y;
       doc.fontSize(9.5).fillColor('#111').font('Helvetica-Bold')
         .text(cp.rotulo, COL_X_INI + 8, y0, { width: COL_W - 100 });
@@ -2314,7 +2344,17 @@ function renderDemarcacaoLotesBody(
       const check = l.contratado ? '☑' : '☐';
       doc.fontSize(9.5).fillColor('#111').font(l.contratado ? 'Helvetica-Bold' : 'Helvetica')
         .text(`${check} ${l.rotulo}`, COL_X_INI + 8, y0, { width: COL_W - 100 });
-      const valorTxt = l.valor === 'sob_orcamento' ? 'Sob orcamento' : (l.contratado ? formatBRL(l.valor as number) : '—');
+      // v3.42.0 DEFESA: se contratado mas valor=0 e temos metros×valor_unitario,
+      // recompute em runtime (preserva propostas legadas sem persistir esses campos).
+      let valorRender: number | 'sob_orcamento' | undefined = l.valor;
+      const lExt = l as { metros?: number; valor_unitario?: number };
+      if (l.contratado && valorRender !== 'sob_orcamento'
+          && (!Number.isFinite(Number(valorRender)) || Number(valorRender) === 0)
+          && typeof lExt.metros === 'number' && typeof lExt.valor_unitario === 'number'
+          && lExt.metros > 0 && lExt.valor_unitario > 0) {
+        valorRender = Math.round(lExt.metros * lExt.valor_unitario * 100) / 100;
+      }
+      const valorTxt = valorRender === 'sob_orcamento' ? 'Sob orcamento' : (l.contratado ? formatBRL(Number(valorRender)) : '—');
       doc.fontSize(9.5).fillColor(l.contratado ? corHex : '#666').font(l.contratado ? 'Helvetica-Bold' : 'Helvetica')
         .text(valorTxt, COL_X_FIM - 100, y0, { width: 100, align: 'right' });
       doc.font('Helvetica').fillColor('#111');
@@ -2367,9 +2407,14 @@ function renderDemarcacaoLotesBody(
   doc.moveTo(COL_X_INI, doc.y).lineTo(COL_X_FIM, doc.y).strokeColor('#ccc').lineWidth(0.5).stroke();
   doc.moveDown(0.2);
   doc.fontSize(8.5).fillColor('#444');
+  // v3.42.0: DRL removido da demarcacao (gold standard PROP-2026-0028-R1 nao tem).
+  //   DRL (Declaracao de Respeito de Limite) e' obrigacao do proprietario apenas
+  //   no fluxo de Georreferenciamento Rural (regularizacao fundiaria via SIGEF
+  //   conforme Lei 10.267/2001 + NTGIR 3a Ed.). Demarcacao simples e' apenas
+  //   materializacao fisica das divisas — nao gera averbacao automatica e nao
+  //   exige DRL no escopo do servico.
   const avisosDem = [
     'A demarcacao consiste na materializacao fisica das divisas. O servico nao constitui regularizacao fundiaria isolada — para averbacao no cartorio sao necessarios os documentos imprescindiveis acima.',
-    'O cliente deve coletar Declaracoes de Respeito de Limite (DRLs) com firma reconhecida em cartorio (ver box vermelho abaixo).',
     'Os codigos INCRA dos marcos sao vitalicios e atrelados ao tecnico responsavel. Apos atribuidos no envio da proposta, nao podem ser realocados a outra obra.',
   ];
   avisosDem.forEach((a) => {
@@ -2380,8 +2425,10 @@ function renderDemarcacaoLotesBody(
   doc.fillColor('#111');
   doc.moveDown(0.3);
 
-  // ── 10-bis. BOX VERMELHO — AVISO DRL ──────────────────────────────────
-  renderAvisoDRL(doc, finalidade, COL_X_INI, COL_W);
+  // v3.42.0: renderAvisoDRL REMOVIDO. DRL e' especifico do fluxo de Georref Rural
+  // (Lei 10.267/2001 / NTGIR). Para Demarcacao de Lotes nao se aplica — proposta
+  // PROP-2026-0028-R1 (gold standard) nao tem o box. Render do DRL preservado
+  // em Georref Rural (linhas ~1554 deste arquivo).
 }
 
 export async function gerarPdfPropostaConsultoria(
@@ -3421,10 +3468,22 @@ export async function atualizarPropostaConsultoria(input: {
       const r = await calcularConsultoria({ subtipo, dados: dadosFinal });
       custosFinal = r.custos;
     } else if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
-      // v3.27.0: Demarcacao de Lotes
+      // v3.27.0/v3.42.0: Demarcacao de Lotes.
+      // Preserva adicional_campo do snapshot atual injetando pct em dados_imovel
+      // antes do engine — assim o adicional re-entra na base (antes da complexidade).
+      const dadosInjetados: Record<string, unknown> = { ...(dadosFinal as unknown as Record<string, unknown>) };
+      const atualCalc = atual.custos_calculados as CustosCalculados | null;
+      const adicionalSnap = (atualCalc as unknown as { adicional_campo?: { ativo?: boolean; percentual?: number } } | null)?.adicional_campo;
+      if (adicionalSnap?.ativo && typeof adicionalSnap.percentual === 'number') {
+        dadosInjetados.adicional_campo_pct = adicionalSnap.percentual;
+      }
       const m = await import('../services/pricing/demarcacaoLotes');
-      const out = m.calcularDemarcacaoLotes(dadosFinal as unknown as InputDemarcacaoLotes);
+      const out = m.calcularDemarcacaoLotes(dadosInjetados as unknown as InputDemarcacaoLotes);
       custosFinal = adaptarDemarcacaoParaCustosCalculados(out);
+      // Preserva snapshot do adicional_campo no custos atualizado (pro PDF render)
+      if (adicionalSnap) {
+        (custosFinal as unknown as { adicional_campo: typeof adicionalSnap }).adicional_campo = adicionalSnap;
+      }
     } else {
       throw new Error(`Subtipo ${subtipo} nao suportado para edicao nesta fase.`);
     }

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -7243,6 +7243,7 @@ async function renderPropostasConsultoriaLista(v, toggleHTML) {
         return alert('Subtipo da proposta ausente — não é possível editar.');
       }
       // v3.23.0: Editar habilitado para todos os subtipos com form implementado.
+      // v3.42.0: + demarcacao_urbana e demarcacao_rural (form ativo desde v3.27.0).
       const SUBTIPOS_EDITAVEIS = new Set([
         'averbacao_residencial',
         'averbacao_comercial',
@@ -7252,6 +7253,8 @@ async function renderPropostasConsultoriaLista(v, toggleHTML) {
         'retificacao_area',
         'avaliacao_ptam',
         'projeto_executivo', // v3.24.5
+        'demarcacao_urbana', // v3.42.0
+        'demarcacao_rural',  // v3.42.0
       ]);
       if (!SUBTIPOS_EDITAVEIS.has(subtipo)) {
         return alert(`Edição não disponível para subtipo "${subtipo}".`);

--- a/src/services/pricing/demarcacaoLotes.ts
+++ b/src/services/pricing/demarcacaoLotes.ts
@@ -323,10 +323,11 @@ function montarLinhasOpcionais(
   opcionais: OpcionaisDemarcacao,
   cfgOpc: NonNullable<ReturnType<typeof getParams>['demarcacao_lotes_2026']>['opcionais'],
   perimetroM: number,
-): { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string }[] {
+): { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string; metros?: number; valor_unitario?: number }[] {
   // v3.38.0: 4 linhas SEMPRE renderizadas (laudo_tecnico foi promovido a item direto).
   // v3.40.0: linhas ganham campo `detalhe` opcional — regra de calculo visivel no PDF.
-  const linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string }[] = [];
+  // v3.42.0: linhas ganham metros/valor_unitario opcionais — PDF recomputa se valor=0.
+  const linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string; metros?: number; valor_unitario?: number }[] = [];
 
   // 1. Alinhamento de cerca — detalhe com a regra (Extensao × R$/m · default perimetro)
   {
@@ -346,6 +347,10 @@ function montarLinhasOpcionais(
       contratado,
       valor: contratado ? round2(metros * vUnit) : 0,
       detalhe,
+      // v3.42.0: expoe metros e valor_unitario para o PDF render conseguir
+      // recomputar caso o valor venha zerado em propostas legadas.
+      metros: contratado ? metros : 0,
+      valor_unitario: vUnit,
     });
   }
   // 2. Croqui assinado

--- a/src/services/pricing/types.ts
+++ b/src/services/pricing/types.ts
@@ -557,7 +557,16 @@ export interface DemarcacaoLotesOutput {
   secao_opcionais_demarcacao: {
     // v3.40.0: linhas ganham `detalhe` opcional — regra de calculo / memoria descritiva
     // exibida abaixo do rotulo no PDF (ex.: alinhamento de cerca: "Extensao X m × R$ 0,42/m · default perimetro 2.190,78 m (editavel)").
-    linhas: { rotulo: string; valor: number | 'sob_orcamento'; contratado: boolean; detalhe?: string }[];
+    // v3.42.0: + metros e valor_unitario opcionais — permitem ao PDF render
+    // recomputar o valor se persistencia veio zerada (defesa em profundidade).
+    linhas: {
+      rotulo: string;
+      valor: number | 'sob_orcamento';
+      contratado: boolean;
+      detalhe?: string;
+      metros?: number;
+      valor_unitario?: number;
+    }[];
     subtotal: number;
   };
   parcelas: { numero: 1 | 2 | 3; rotulo: string; valor: number; percentual: number }[];

--- a/src/test/hotfix-demarcacao-drl-edit-parcelas-v3.42.0.test.ts
+++ b/src/test/hotfix-demarcacao-drl-edit-parcelas-v3.42.0.test.ts
@@ -1,0 +1,114 @@
+// v3.42.0: 4 fixes na renderização da proposta de Demarcação.
+//
+// BUG A — Box vermelho DRL + bullet aparecia em demarcação. DRL e' obrigacao
+//         do proprietario apenas em Georref Rural (Lei 10.267/2001 / NTGIR).
+//         Demarcacao simples e' so' materializacao fisica das divisas.
+// BUG B — "Edição não disponível para subtipo demarcacao_rural" — frontend nao
+//         tinha demarcacao_* em SUBTIPOS_EDITAVEIS, embora o form exista desde v3.27.0.
+// BUG C — Edicao recalculava sem injetar adicional_campo_pct, perdendo a contribuicao
+//         da insalubridade na base.
+// BUG D — Parcelas R$ 0,00 e/ou opcionais sem valor em propostas legadas/corrompidas.
+//         Aplicada defesa runtime no PDF render (recompute via percentual / metros×R$).
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { calcularDemarcacaoLotes } from '../services/pricing/demarcacaoLotes';
+import type { InputDemarcacaoLotes } from '../services/pricing/types';
+
+const OBRAS_HTML = fs.readFileSync(path.join(process.cwd(), 'src', 'public', 'obras.html'), 'utf-8');
+const PROPOSTAS_CONS_TS = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'integrations', 'propostasConsultoria.ts'),
+  'utf-8',
+);
+
+describe('HOTFIX v3.42.0 — BUG A: DRL removido de demarcação', () => {
+  it('1. avisosDem nao contem mais o bullet sobre DRL/Declaracoes de Respeito de Limite', () => {
+    // localiza o array avisosDem do renderDemarcacaoLotesBody
+    const trecho = PROPOSTAS_CONS_TS.match(/const avisosDem = \[[\s\S]*?\];/);
+    expect(trecho).not.toBeNull();
+    expect(trecho![0]).not.toMatch(/Declaracoes de Respeito de Limite/);
+    expect(trecho![0]).not.toMatch(/DRLs/);
+    // Mas mantem os 2 bullets originais (gold standard 0028-R1)
+    expect(trecho![0]).toMatch(/A demarcacao consiste na materializacao fisica/);
+    expect(trecho![0]).toMatch(/codigos INCRA dos marcos sao vitalicios/);
+  });
+
+  it('2. renderAvisoDRL nao e mais chamado dentro de renderDemarcacaoLotesBody', () => {
+    // Procura pelo comentario explicativo + ausencia da chamada no bloco onde estava
+    expect(PROPOSTAS_CONS_TS).toMatch(/v3\.42\.0: renderAvisoDRL REMOVIDO/);
+    // Conta ocorrencias: deve haver apenas 1 (a do georref), nao 2 (georref + demarcacao)
+    const ocorrencias = (PROPOSTAS_CONS_TS.match(/renderAvisoDRL\(doc,\s*finalidade/g) || []).length;
+    expect(ocorrencias).toBeLessThanOrEqual(1);
+  });
+
+  it('3. renderAvisoDRL CONTINUA usado em georreferenciamento (regressao)', () => {
+    // Linha ~1554-1555: renderAvisoDRL(doc, finalidadeDRL, COL_X_INI, COL_W);
+    expect(PROPOSTAS_CONS_TS).toMatch(/renderAvisoDRL\(doc, finalidadeDRL,/);
+  });
+});
+
+describe('HOTFIX v3.42.0 — BUG B: Edicao habilitada pra demarcação', () => {
+  it('4. SUBTIPOS_EDITAVEIS contem demarcacao_urbana e demarcacao_rural', () => {
+    const m = OBRAS_HTML.match(/SUBTIPOS_EDITAVEIS = new Set\(\[([\s\S]*?)\]\)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toMatch(/'demarcacao_urbana'/);
+    expect(m![1]).toMatch(/'demarcacao_rural'/);
+  });
+});
+
+describe('HOTFIX v3.42.0 — BUG C: Edicao preserva adicional_campo via injecao do pct', () => {
+  it('5. atualizarPropostaConsultoria injeta adicional_campo_pct quando snapshot existe', () => {
+    // Pattern matches the local block where we inject pct, no need to span from function declaration
+    expect(PROPOSTAS_CONS_TS).toMatch(/dadosInjetados\.adicional_campo_pct = adicionalSnap\.percentual/);
+  });
+
+  it('6. atualizarPropostaConsultoria preserva snapshot adicional_campo no custos atualizado', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/\.adicional_campo = adicionalSnap;/);
+  });
+});
+
+describe('HOTFIX v3.42.0 — BUG D: defesa runtime parcelas R$ 0,00', () => {
+  it('7. PDF render detecta parcelas com valor=0 e recompute via percentual', () => {
+    // Garante que o codigo de fallback existe
+    expect(PROPOSTAS_CONS_TS).toMatch(/algumZero = parcelas\.some/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/totalReal > 0/);
+  });
+
+  it('8. Recompute le percentual da descricao "X% do total" via regex', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/match\(\/\(\\d\+\(\?:\[\.,\]\\d\+\)\?\)\\s\*%\//);
+  });
+
+  it('9. Ultima parcela absorve o residuo de arredondamento', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/i === arr\.length - 1/);
+  });
+});
+
+describe('HOTFIX v3.42.0 — BUG D: defesa runtime opcionais valor=0', () => {
+  it('10. Engine expoe metros e valor_unitario na linha de alinhamento (forward compat)', () => {
+    const r = calcularDemarcacaoLotes({
+      subtipo: 'demarcacao_rural',
+      finalidade: 'demarcacao_inicial',
+      municipio: 'X', uf: 'MA',
+      area_hectares: 29.04,
+      perimetro_m: 2190.78,
+      num_vertices: 4,
+      servico_piqueteamento: false,
+      marcos: [],
+      diarias_equipe: 1, km_deslocamento: 0,
+      complexidade: 'media',
+      opcionais: { alinhamento_cerca: { contratado: true, metros: 2190.78, valor_unitario: 0.42 } },
+    } as InputDemarcacaoLotes);
+    const linha = r.secao_opcionais_demarcacao.linhas.find(l => /Alinhamento/i.test(l.rotulo));
+    expect(linha).toBeDefined();
+    const lExt = linha as { metros?: number; valor_unitario?: number };
+    expect(lExt.metros).toBe(2190.78);
+    expect(lExt.valor_unitario).toBe(0.42);
+    expect(linha!.valor).toBeCloseTo(920.13, 1);
+  });
+
+  it('11. PDF render recompute opcional se contratado=true mas valor=0 e tem metros×vUnit', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/v3\.42\.0 DEFESA[\s\S]{0,500}?contratado.*valorRender.*sob_orcamento/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/Math\.round\(lExt\.metros \* lExt\.valor_unitario \* 100\) \/ 100/);
+  });
+});


### PR DESCRIPTION
…nais R$ 0,00 (v3.42.0)

BUG A — Box vermelho DRL aparecia em demarcacao. DRL e' obrigacao do proprietario apenas em Georreferenciamento Rural (Lei 10.267/2001 / NTGIR 3a Ed.). Demarcacao e' so' materializacao fisica das divisas. Removido o bullet DRL + a chamada renderAvisoDRL do renderDemarcacaoLotesBody. Georref Rural permanece com DRL (renderAvisoDRL linha ~1554).

BUG B — "Edicao nao disponivel para demarcacao_rural". Frontend nao tinha demarcacao_urbana/rural em SUBTIPOS_EDITAVEIS, embora o form exista desde v3.27.0. Adicionado.

BUG C — atualizarPropostaConsultoria recalculava demarcacao SEM injetar adicional_campo_pct. Resultado: editar proposta com insalubridade selecionada PERDIA a contribuicao do adicional no novo total. Agora extrai snapshot .adicional_campo, injeta percentual em dados_imovel antes do engine, e preserva o snapshot em custos pra PDF render.

BUG D — Parcelas R$ 0,00 e opcionais sem valor em propostas legadas. Defesa runtime no PDF render: se cp.valor=0 mas secao_5_total>0, recompute via percentual lido da descricao. Para opcionais, engine agora expoe metros + valor_unitario na linha, e render recompute se contratado=true mas valor=0.

Tests: 11 novos. Suite total 969 passing, 1 skipped, 0 failures. Arquivos sensiveis intocados.