### PR TITLE
fix(demarcacao): completa edicao end-to-end (achata cache + PUT + cle…

### DIFF
--- a/06-Changelog/v3.42.0-hotfix-demarcacao-drl-edit-parcelas.md
+++ b/06-Changelog/v3.42.0-hotfix-demarcacao-drl-edit-parcelas.md
@@ -56,8 +56,40 @@ const avisosDem = [
 // renderAvisoDRL REMOVIDO daqui — só permanece em Georref Rural.
 ```
 
-### B. Habilita edição de demarcação
+### B. Habilita edição de demarcação (na verdade: corrige edição de TODOS os subtipos)
 
+Ao revisar pra responder "certeza que funcionará?", descobri que o fix inicial **estava incompleto**. Apenas adicionar à lista `SUBTIPOS_EDITAVEIS` desbloqueava o alert, mas o form abria **com campos vazios** e o save ainda **criava proposta nova** em vez de atualizar.
+
+**Sub-bugs descobertos no review:**
+
+**B1.** Cache do form vinha aninhado:
+```js
+// Antes: forms leem cache.municipio (flat), mas edit setava:
+state.consultoriaFormCache = { subtipo, cliId, endereco, dados_imovel: {...} };
+// Form lia cache.municipio → undefined → campo aparece vazio
+```
+Fix: achata `dados_imovel` no cache via spread + mantém aninhamento pra retrocompat:
+```js
+state.consultoriaFormCache = { ...di, ...derivadosDemarc, subtipo, cliId, endereco, dados_imovel: di };
+```
+
+**B2.** Campos derivados precisavam de conversão (array → counts, aninhado → flat):
+- `marcos: [{tipo: 'concreto', quantidade: 4}, ...]` → `marcos_concreto: 4`
+- `locacao_kit_gnss: { qtd_diarias: 1, diaria: 250 }` → `locacao_kit_gnss_qtd: 1`, `locacao_kit_gnss_diaria: 250`
+- `laudo_tecnico_direto: { contratado: true }` → `laudo_tecnico_direto_contratado: true`
+- `opcionais.alinhamento_cerca.metros: 2190.78` → `alinhamento_metros: 2190.78`
+
+**B3.** **cnsSalvar SEMPRE fazia POST**, mesmo em modo edição. O `state.consultoriaEditandoId` era setado mas NUNCA usado pra PUT. Resultado: editar qualquer proposta CRIAVA UMA NOVA em vez de atualizar — bug que afetava todos os subtipos editáveis há tempo, mas só foi notado agora porque demarcação não estava na lista. Fix:
+```js
+const editandoId = state.consultoriaEditandoId;
+const r2 = editandoId
+  ? await api('/api/propostas-consultoria/' + editandoId, { method: 'PUT', body: ... })
+  : await api('/api/propostas-consultoria', { method: 'POST', body: ... });
+```
+
+**B4.** Após o save, `consultoriaEditandoId` permanecia setado — próxima "Nova proposta" também faria PUT na proposta editada anteriormente. Fix: reset explícito em `state.consultoriaEditandoId = null` + cache cleanup após save.
+
+**B5.** Finalmente, adicionados subtipos ao `SUBTIPOS_EDITAVEIS`:
 ```js
 const SUBTIPOS_EDITAVEIS = new Set([
   'averbacao_residencial', 'averbacao_comercial',

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -7261,12 +7261,39 @@ async function renderPropostasConsultoriaLista(v, toggleHTML) {
       }
       // v1.66.15: tambem carrega anexos existentes da proposta
       const anexosExistentes = await api('/api/propostas-consultoria/' + id + '/anexos').catch(() => ({ items: [] }));
-      // Popula cache do form com dados da proposta
+      // Popula cache do form com dados da proposta.
+      // v3.42.0: ACHATA dados_imovel no cache (os forms leem cache?.municipio,
+      // cache?.area_m2, etc — direto, sem aninhamento). Sem isso, edicao abre
+      // com campos vazios. Mantemos dados_imovel TAMBEM aninhado pra retrocompat
+      // com forms que possam ler dele dessa forma.
+      const di = p.dados_imovel || {};
+      // v3.42.0: para demarcacao, deriva campos especificos do form (marcos[] -> counts
+      // por tipo, locacao_kit_gnss aninhado -> qtd/diaria, laudo/alinhamento -> flags).
+      const derivadosDemarc = {};
+      if (subtipo === 'demarcacao_urbana' || subtipo === 'demarcacao_rural') {
+        const marcos = Array.isArray(di.marcos) ? di.marcos : [];
+        derivadosDemarc.marcos_concreto = marcos.filter(m => m && m.tipo === 'concreto').reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+        derivadosDemarc.marcos_tubo = marcos.filter(m => m && m.tipo === 'tubo_galvanizado').reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+        derivadosDemarc.marcos_madeira = marcos.filter(m => m && m.tipo === 'madeira').reduce((s, m) => s + (Number(m.quantidade) || 0), 0);
+        if (di.locacao_kit_gnss && typeof di.locacao_kit_gnss === 'object') {
+          derivadosDemarc.locacao_kit_gnss_qtd = di.locacao_kit_gnss.qtd_diarias ?? 1;
+          derivadosDemarc.locacao_kit_gnss_diaria = di.locacao_kit_gnss.diaria ?? 250;
+        }
+        if (di.laudo_tecnico_direto && typeof di.laudo_tecnico_direto === 'object') {
+          derivadosDemarc.laudo_tecnico_direto_contratado = !!di.laudo_tecnico_direto.contratado;
+        }
+        if (di.opcionais && di.opcionais.alinhamento_cerca) {
+          derivadosDemarc.alinhamento_metros = di.opcionais.alinhamento_cerca.metros ?? '';
+        }
+      }
       state.consultoriaFormCache = {
+        ...di,
+        ...derivadosDemarc,
         subtipo,
         cliId: String(p.cliente.id),
+        cliente_id: String(p.cliente.id), // alias usado pelo form de demarcacao
         endereco: p.endereco_imovel || '',
-        dados_imovel: p.dados_imovel || {},
+        dados_imovel: di,
       };
       state.consultoriaEditandoId = id;
       state.consultoriaPropostaOriginal = p;
@@ -11140,17 +11167,32 @@ function renderPreviewConsultoria(r, ctx) {
       const aditivoCampoLegado = !adicionalCampo
         ? (ctx.aditivo_campo || state.consultoriaPreviewData?.ctx?.aditivo_campo || null)
         : null;
-      const r2 = await api('/api/propostas-consultoria', {
-        method: 'POST',
-        body: JSON.stringify({
-          subtipo: ctx.subtipo,
-          cliente_id: ctx.cliId,
-          endereco_imovel: endereco || null,
-          dados_imovel: ctx.dados_imovel,
-          adicional_campo: adicionalCampo || undefined,
-          aditivo_campo: aditivoCampoLegado || undefined,
-        }),
-      });
+      // v3.42.0: se estamos editando uma proposta (consultoriaEditandoId set), faz
+      // PUT em vez de POST. Antes, mesmo em "editar" o handler fazia POST e criava
+      // uma proposta NOVA — bug que afetava TODOS os subtipos editaveis, nao so'
+      // demarcacao. PUT chama atualizarPropostaConsultoria (linha ~3334 do backend),
+      // que recalcula com dados_imovel novo + preserva adicional_campo via snapshot
+      // existente (v3.42.0 backend fix).
+      const editandoId = state.consultoriaEditandoId;
+      const r2 = editandoId
+        ? await api('/api/propostas-consultoria/' + editandoId, {
+            method: 'PUT',
+            body: JSON.stringify({
+              endereco_imovel: endereco || null,
+              dados_imovel: ctx.dados_imovel,
+            }),
+          })
+        : await api('/api/propostas-consultoria', {
+            method: 'POST',
+            body: JSON.stringify({
+              subtipo: ctx.subtipo,
+              cliente_id: ctx.cliId,
+              endereco_imovel: endereco || null,
+              dados_imovel: ctx.dados_imovel,
+              adicional_campo: adicionalCampo || undefined,
+              aditivo_campo: aditivoCampoLegado || undefined,
+            }),
+          });
 
       // v3.24.6: Upload de anexos pendentes (Projeto Executivo, mas funciona pra qualquer subtipo)
       const anexosPendentes = state.peAnexosPendentes || [];
@@ -11175,6 +11217,15 @@ function renderPreviewConsultoria(r, ctx) {
       } else {
         alert('✅ ' + r2.message);
       }
+
+      // v3.42.0: reseta state de edicao APOS save (qualquer subtipo). Antes
+      // ficava grudado e a proxima "Nova proposta" tambem fazia PUT na proposta
+      // editada anteriormente — comportamento absurdo, mas o bug do POST-sempre
+      // mascarava isso ate v3.42.0.
+      state.consultoriaEditandoId = null;
+      state.consultoriaPropostaOriginal = null;
+      state.consultoriaFormCache = null;
+      state.consultoriaPreviewData = null;
 
       fecharModal();
       await loadPropostasConsultoria();

--- a/src/test/hotfix-demarcacao-drl-edit-parcelas-v3.42.0.test.ts
+++ b/src/test/hotfix-demarcacao-drl-edit-parcelas-v3.42.0.test.ts
@@ -84,6 +84,43 @@ describe('HOTFIX v3.42.0 — BUG D: defesa runtime parcelas R$ 0,00', () => {
   });
 });
 
+describe('HOTFIX v3.42.0 — BUG B+: fluxo de edicao end-to-end', () => {
+  it('B1. Edit carrega cache com dados_imovel ACHATADO (forms leem cache.municipio direto)', () => {
+    // Sem o flatten, edicao abria com campos vazios — o cache antes era
+    // { subtipo, cliId, endereco, dados_imovel: {...} } e os forms liam cache.municipio.
+    expect(OBRAS_HTML).toMatch(/v3\.42\.0: ACHATA dados_imovel no cache/);
+    // Pattern de spread { ...di, ...derivadosDemarc, subtipo, cliId, ... }
+    expect(OBRAS_HTML).toMatch(/\.\.\.di,\s*\n?\s*\.\.\.derivadosDemarc,/);
+  });
+
+  it('B2. Edit deriva counts por tipo de marco (marcos[] -> marcos_concreto/tubo/madeira)', () => {
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.marcos_concreto = marcos\.filter\(m => m && m\.tipo === 'concreto'\)/);
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.marcos_madeira/);
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.marcos_tubo/);
+  });
+
+  it('B3. Edit deriva qtd/diaria do locacao_kit_gnss aninhado', () => {
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.locacao_kit_gnss_qtd = di\.locacao_kit_gnss\.qtd_diarias/);
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.locacao_kit_gnss_diaria = di\.locacao_kit_gnss\.diaria/);
+  });
+
+  it('B4. Edit deriva flag de laudo + metros do alinhamento de cerca', () => {
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.laudo_tecnico_direto_contratado = !!di\.laudo_tecnico_direto\.contratado/);
+    expect(OBRAS_HTML).toMatch(/derivadosDemarc\.alinhamento_metros = di\.opcionais\.alinhamento_cerca\.metros/);
+  });
+
+  it('B5. cnsSalvar faz PUT quando consultoriaEditandoId set (NAO POST)', () => {
+    // Antes, sempre POST -> criava nova proposta em vez de atualizar.
+    expect(OBRAS_HTML).toMatch(/const editandoId = state\.consultoriaEditandoId/);
+    expect(OBRAS_HTML).toMatch(/editandoId\s*\n?\s*\?\s*await api\('\/api\/propostas-consultoria\/' \+ editandoId,\s*\{\s*\n?\s*method: 'PUT'/);
+  });
+
+  it('B6. cnsSalvar limpa state de edicao apos save (consultoriaEditandoId = null)', () => {
+    expect(OBRAS_HTML).toMatch(/state\.consultoriaEditandoId = null;\s*\n?\s*state\.consultoriaPropostaOriginal = null/);
+    expect(OBRAS_HTML).toMatch(/state\.consultoriaFormCache = null/);
+  });
+});
+
 describe('HOTFIX v3.42.0 — BUG D: defesa runtime opcionais valor=0', () => {
   it('10. Engine expoe metros e valor_unitario na linha de alinhamento (forward compat)', () => {
     const r = calcularDemarcacaoLotes({


### PR DESCRIPTION
…anup) (v3.42.0)

Em review respondendo "tem certeza que funcionara?" descobri 4 sub-bugs que apenas adicionar a SUBTIPOS_EDITAVEIS NAO resolveria:

B1 — Cache vinha com dados_imovel aninhado, mas os forms leem cache.municipio
    direto. Fix: ACHATA dados_imovel no cache (spread) + mantem aninhado pra
    retrocompat.

B2 — Campos derivados precisam conversao na carga do edit:
    marcos[] -> marcos_concreto/tubo/madeira (counts por tipo);
    locacao_kit_gnss.qtd_diarias -> locacao_kit_gnss_qtd;
    laudo_tecnico_direto.contratado -> laudo_tecnico_direto_contratado;
    opcionais.alinhamento_cerca.metros -> alinhamento_metros.

B3 — cnsSalvar SEMPRE fazia POST, ate em modo edicao. state.consultoriaEditandoId
    era setado mas NUNCA usado pra PUT. Afetava TODOS os subtipos editaveis:
    "editar" criava proposta nova em vez de atualizar. Fix: PUT em /api/propostas-
    consultoria/:id quando editandoId set.

B4 — Apos save, state nao era limpo. Proxima "Nova proposta" tambem fazia PUT
    na proposta anterior. Fix: reset explicito de consultoriaEditandoId,
    consultoriaPropostaOriginal, consultoriaFormCache, consultoriaPreviewData.

Tests: 6 novos cobrindo B1-B4. Suite total 17 tests no arquivo, 975 global.