### PR TITLE
fix(pdf): substitui emojis corrompidos por ASCII no PDF do Adicional …

### DIFF
--- a/06-Changelog/v3.44.0-hotfix-adicional-pdf-emoji-corrompido.md
+++ b/06-Changelog/v3.44.0-hotfix-adicional-pdf-emoji-corrompido.md
@@ -1,0 +1,112 @@
+# v3.44.0 — Hotfix: emojis corrompidos no PDF do Adicional de Insal/Peric
+
+**Data:** 2026-05-28
+**Branch:** `fix/adicional-pdf-emoji-corrompido-v3.44.0`
+**Base:** `main` (v3.43.0)
+**Versão alvo:** v3.44.0
+
+## Sintoma reportado
+
+CEO comparou:
+
+**Na UI (form do wizard):**
+```
+🌲 Servicos em area rural com mata densa, animais peconhentos...
+📜 Fundamento Legal não-editável
+🔍 Enquadramento Técnico editável
+💬 Justificativa ao Cliente editável
+```
+
+**No PDF gerado (corrompido):**
+```
+& ADICIONAL DE INSALUBRIDADE · +20% Cenário: mata densa animais, Grau Medio
+Ø=ÜÜ FUNDAMENTO LEGAL
+Ø=Ý ENQUADRAMENTO TÉCNICO
+Ø=Ü¬ JUSTIFICATIVA AO CLIENTE
+```
+
+CEO: *"PRECISO QUE FIQUE O MESMO TEXTO QUE EU SELECIONAR NO SISTEMA, NA VERDADE ESTÁ SÓ OS EMOTION NÃO FORMA"*.
+
+## Causa raiz
+
+**PDFKit + Helvetica embedded (Type1) só suporta Latin-1 (0x00–0xFF).**
+
+Os emojis usados estão fora dessa codepage:
+- `⚠` U+26A0 (Symbols)
+- `📜` U+1F4DC (Misc. Symbols)
+- `🔍` U+1F50D (Misc. Symbols)
+- `💬` U+1F4AC (Emoticons)
+- `⬆` U+2B06 (Misc. Symbols)
+
+Quando PDFKit tenta codificar esses pontos pra Latin-1, o encoder fallback retorna bytes inválidos. O resultado no PDF varia conforme o viewer:
+- `⚠` → `&` (no exemplo do CEO) ou caractere de placeholder
+- `📜` → `Ø=ÜÜ` (sequência de 4 bytes lida como Latin-1 errada)
+- `🔍` → `Ø=Ý`
+- `💬` → `Ø=Ü¬`
+
+Não é bug do conteúdo nem do snapshot jurídico — é **limitação da fonte embedded**. O texto dos blocos jurídicos (CLT/NR-15) está **íntegro**, só os emojis decorativos saem quebrados.
+
+## Solução escolhida
+
+**Substituir emojis decorativos por equivalentes ASCII/Latin-1**:
+
+| Original | Substituição | Motivo |
+|---|---|---|
+| `⚠ ADICIONAL` | `! ADICIONAL` | `!` sinaliza atenção, ASCII puro |
+| `📜 FUNDAMENTO LEGAL` | `FUNDAMENTO LEGAL` | Hierarquia já garantida por bold + cor amber |
+| `🔍 ENQUADRAMENTO TÉCNICO` | `ENQUADRAMENTO TECNICO` | Idem |
+| `💬 JUSTIFICATIVA AO CLIENTE` | `JUSTIFICATIVA AO CLIENTE` | Idem |
+| `⚠ SERVIÇO NÃO CONTRATADO` | `! SERVIÇO NÃO CONTRATADO` | Idem |
+| `⚠ Desconto concedido` | `! Desconto concedido` | Idem |
+| `⬆ Acrescimo` | `+ Acrescimo` | `+` sinaliza aumento |
+
+**Por que não embedar uma fonte com suporte a emoji?**
+- Aumenta o tamanho do PDF (~5-10 MB com Noto Color Emoji).
+- Quebra reprodutibilidade em viewers antigos.
+- Quebra assinatura digital se a fonte mudar entre gerações.
+- A hierarquia visual já é clara via bold + cor + estrutura do box — emojis eram redundantes.
+
+## Arquivos alterados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/integrations/propostasConsultoria.ts` | 7 emojis removidos em 4 lugares: `renderAdicionalCampoBody` (4× — título + 3 sub-headers), `renderAditivoCampoBody` (1× — título legado v3.29.0), seção "SERVIÇO NÃO CONTRATADO" (1×), aviso desconto/acréscimo (2×) |
+| `src/test/hotfix-adicional-pdf-emoji-corrompido-v3.44.0.test.ts` | **NOVO** — 10 testes |
+| `package.json` | 3.43.0 → 3.44.0 |
+
+## Arquivos NÃO alterados (regra do prompt)
+
+- ✅ `src/agent/tools.ts` — intocado
+- ✅ `src/agent/think.ts` — intocado
+- ✅ `src/services/aiCascade.ts` — intocado
+
+## Testes
+
+`hotfix-adicional-pdf-emoji-corrompido-v3.44.0.test.ts` — **10 testes**:
+
+| # | Cobertura |
+|---|---|
+| 1–5 | Nenhuma chamada `doc.text()` contém os 5 emojis problemáticos (⚠ 📜 🔍 💬 ⬆) |
+| 6 | Título usa `! ADICIONAL DE INSALUBRIDADE` / `! ADICIONAL DE PERICULOSIDADE` |
+| 7 | Labels textuais limpos (`FUNDAMENTO LEGAL`, `ENQUADRAMENTO TECNICO`, `JUSTIFICATIVA AO CLIENTE`) |
+| 8 | `! SERVIÇO NÃO CONTRATADO` em vez de `⚠` |
+| 9 | Avisos de desconto/acréscimo usam `!` e `+` |
+| 10 | `AdicionalCampoSnapshotPdf` interface NÃO inclui `icone` (garante que emoji do cenário do pricing-params não escapa pro PDF) |
+
+**Suite total:** 999 passing, 1 skipped, 0 failures (baseline 989 + 10 novos).
+**Typecheck:** ✅ limpo.
+
+## Notas sobre a UI (frontend)
+
+Os emojis na UI (`wizard de adicional de campo` no form) **permanecem** — browsers renderizam Unicode nativamente. Só o PDF tinha o problema. CEO continua vendo os emojis no formulário (🌲 mata, 🛣️ rodovia, ⚡ elétrico, 💥 explosivo, ⚗️ químico).
+
+## Política preservada
+
+- ✅ Conteúdo jurídico dos blocos (CLT/NR-15/NR-16) inalterado.
+- ✅ Hierarquia visual no PDF preservada por cor + bold + box rounded com borda amber/red.
+- ✅ Retrocompat: propostas antigas (v3.33.0+) com `adicional_campo` persistido continuam abrindo idênticas, agora SEM os emojis bugados.
+- ✅ Emojis na UI/wizard inalterados.
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.43.0",
+  "version": "3.44.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -1714,10 +1714,15 @@ function renderAdicionalCampoBody(
   doc.y = startY + PADDING;
 
   // Cabecalho
+  // v3.44.0: REMOVIDOS emojis (⚠📜🔍💬) — Helvetica embedded so' suporta Latin-1.
+  // Os emojis (U+26A0, U+1F4DC, U+1F50D, U+1F4AC) saiam corrompidos no PDF
+  // como "Ø=ÜÜ" / "Ø=Ý" / "Ø=Ü¬" / "&". Substituidos por "!" (ASCII, sinaliza
+  // atencao no titulo) e labels textuais limpos nos sub-headers — a hierarquia
+  // visual e' preservada pela cor (COR_TITULO amber/red), bold e estrutura.
   doc.fontSize(11).fillColor(COR_TITULO).font('Helvetica-Bold');
   const titulo = isPeric
-    ? '⚠ ADICIONAL DE PERICULOSIDADE'
-    : '⚠ ADICIONAL DE INSALUBRIDADE';
+    ? '! ADICIONAL DE PERICULOSIDADE'
+    : '! ADICIONAL DE INSALUBRIDADE';
   doc.text(`${titulo}  ·  +${snap.percentual.toFixed(0)}%`, { width: colW - 2 * PADDING });
   doc.moveDown(0.3);
 
@@ -1729,7 +1734,7 @@ function renderAdicionalCampoBody(
 
   // Bloco 1 — Fundamento Legal (locked)
   doc.fontSize(9.5).fillColor(COR_TITULO).font('Helvetica-Bold')
-    .text('📜 FUNDAMENTO LEGAL', { width: colW - 2 * PADDING });
+    .text('FUNDAMENTO LEGAL', { width: colW - 2 * PADDING });
   doc.fontSize(8.5).fillColor('#111').font('Helvetica')
     .text(snap.bloco_fundamento_legal, colX + PADDING + 8, doc.y, {
       width: colW - 2 * PADDING - 8, align: 'justify',
@@ -1738,7 +1743,7 @@ function renderAdicionalCampoBody(
 
   // Bloco 2 — Enquadramento Tecnico
   doc.fontSize(9.5).fillColor(COR_TITULO).font('Helvetica-Bold')
-    .text('🔍 ENQUADRAMENTO TÉCNICO', colX + PADDING, doc.y, { width: colW - 2 * PADDING });
+    .text('ENQUADRAMENTO TECNICO', colX + PADDING, doc.y, { width: colW - 2 * PADDING });
   doc.fontSize(8.5).fillColor('#111').font('Helvetica')
     .text(snap.bloco_enquadramento_tecnico, colX + PADDING + 8, doc.y, {
       width: colW - 2 * PADDING - 8, align: 'justify',
@@ -1747,7 +1752,7 @@ function renderAdicionalCampoBody(
 
   // Bloco 3 — Justificativa ao Cliente
   doc.fontSize(9.5).fillColor(COR_TITULO).font('Helvetica-Bold')
-    .text('💬 JUSTIFICATIVA AO CLIENTE', colX + PADDING, doc.y, { width: colW - 2 * PADDING });
+    .text('JUSTIFICATIVA AO CLIENTE', colX + PADDING, doc.y, { width: colW - 2 * PADDING });
   doc.fontSize(8.5).fillColor('#111').font('Helvetica')
     .text(snap.bloco_justificativa_cliente, colX + PADDING + 8, doc.y, {
       width: colW - 2 * PADDING - 8, align: 'justify',
@@ -1819,7 +1824,8 @@ function renderAditivoCampoBody(
 
   // Titulo
   doc.fontSize(11).fillColor(COR_AMBER_TITULO).font('Helvetica-Bold');
-  doc.text(`⚠ ${snap.descricao_curta.toUpperCase()}`, { width: colW - 2 * PADDING, lineBreak: true });
+  // v3.44.0: ⚠ -> ! (Helvetica embedded nao suporta U+26A0)
+  doc.text(`! ${snap.descricao_curta.toUpperCase()}`, { width: colW - 2 * PADDING, lineBreak: true });
   doc.moveDown(0.3);
 
   // Linha do valor
@@ -2991,7 +2997,8 @@ export async function gerarPdfPropostaConsultoria(
     } else {
       // v3.23.0: Assessoria NÃO contratada — aviso explícito
       doc.font('Helvetica-Bold').fontSize(10).fillColor('#b91c1c');
-      doc.text('⚠ SERVIÇO NÃO CONTRATADO');
+      // v3.44.0: ⚠ -> ! (corrompe em Helvetica)
+      doc.text('! SERVIÇO NÃO CONTRATADO');
       doc.moveDown(0.2);
       doc.font('Helvetica').fontSize(9).fillColor('#222');
       doc.text('A presente proposta contempla exclusivamente a elaboração das peças técnicas descritas no item anterior. As diligências administrativas (Superintendência de Habitação e Regularização Fundiária e Cartório de Registro de Imóveis), recolhimento de assinaturas e demais providências correrão por conta do contratante ou de procurador por ele constituído.', { align: 'justify' });
@@ -3177,10 +3184,12 @@ function desenharTabelaCustos(doc: PDFKit.PDFDocument, items: CustosCalculados['
       const diff = it.valor - it.valor_original;
       const pct = (Math.abs(diff) / it.valor_original) * 100;
       if (diff < 0) {
-        avisoDesconto = `\n   ⚠ Desconto concedido: ${formatBRL(Math.abs(diff))} (-${pct.toFixed(1)}%)`;
+        // v3.44.0: ⚠ -> ! (corrompe em Helvetica embedded)
+        avisoDesconto = `\n   ! Desconto concedido: ${formatBRL(Math.abs(diff))} (-${pct.toFixed(1)}%)`;
         corAviso = '#dc2626';
       } else {
-        avisoDesconto = `\n   ⬆ Acrescimo: ${formatBRL(diff)} (+${pct.toFixed(1)}%)`;
+        // v3.44.0: ⬆ (U+2B06) -> + (corrompe em Helvetica embedded)
+        avisoDesconto = `\n   + Acrescimo: ${formatBRL(diff)} (+${pct.toFixed(1)}%)`;
         corAviso = '#fb923c';
       }
     } else if ((!it.valor_original || it.valor_original === 0) && it.valor > 0 && it.pendente === false && (it as { _eraOriginalmenteZero?: boolean })._eraOriginalmenteZero) {

--- a/src/test/hotfix-adicional-pdf-emoji-corrompido-v3.44.0.test.ts
+++ b/src/test/hotfix-adicional-pdf-emoji-corrompido-v3.44.0.test.ts
@@ -1,0 +1,99 @@
+// v3.44.0: hotfix dos emojis corrompidos no PDF do Adicional de Insal/Peric.
+//
+// Sintoma: o user via no PDF:
+//   "& ADICIONAL DE INSALUBRIDADE · +20% Cenario: ..."
+//   "Ø=ÜÜ FUNDAMENTO LEGAL"
+//   "Ø=Ý ENQUADRAMENTO TECNICO"
+//   "Ø=Ü¬ JUSTIFICATIVA AO CLIENTE"
+//
+// Causa: PDFKit usa Helvetica embedded (Type1) que so' suporta Latin-1.
+// Emojis Unicode (U+26A0 ⚠, U+1F4DC 📜, U+1F50D 🔍, U+1F4AC 💬, U+2B06 ⬆)
+// estao fora dessa codepage — encoder fallback retorna bytes invalidos.
+//
+// Fix: substituir emojis por equivalentes ASCII ("!", "+") OU remover.
+// A hierarquia visual e' preservada por cor + bold + estrutura do box.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PROPOSTAS_CONS_TS = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'integrations', 'propostasConsultoria.ts'),
+  'utf-8',
+);
+
+describe('HOTFIX v3.44.0 — emojis decorativos removidos do PDF', () => {
+  // Localiza so o trecho de funcoes de render do PDF — comentarios documentais
+  // PODEM mencionar emojis (so' nao podem chegar ao doc.text()).
+  function extractDocTextCalls(): string[] {
+    // Captura todas as chamadas doc.text(...) e doc.text(`...`)
+    const calls: string[] = [];
+    const regex = /doc\.text\(\s*[`'"]([^`'"]*)[`'"]/g;
+    let m;
+    while ((m = regex.exec(PROPOSTAS_CONS_TS)) !== null) {
+      calls.push(m[1]);
+    }
+    // Tambem captura strings template com ${...} no inicio que viram label
+    const tplRegex = /doc\.text\(\s*`([^`]*\$\{[^`]*)`/g;
+    while ((m = tplRegex.exec(PROPOSTAS_CONS_TS)) !== null) {
+      calls.push(m[1]);
+    }
+    return calls;
+  }
+
+  const docTextCalls = extractDocTextCalls();
+
+  it('1. Nenhuma chamada doc.text() contem ⚠ (U+26A0)', () => {
+    const bugadas = docTextCalls.filter((s) => s.includes('⚠'));
+    expect(bugadas).toEqual([]);
+  });
+
+  it('2. Nenhuma chamada doc.text() contem 📜 (U+1F4DC)', () => {
+    const bugadas = docTextCalls.filter((s) => s.includes('\u{1F4DC}'));
+    expect(bugadas).toEqual([]);
+  });
+
+  it('3. Nenhuma chamada doc.text() contem 🔍 (U+1F50D)', () => {
+    const bugadas = docTextCalls.filter((s) => s.includes('\u{1F50D}'));
+    expect(bugadas).toEqual([]);
+  });
+
+  it('4. Nenhuma chamada doc.text() contem 💬 (U+1F4AC)', () => {
+    const bugadas = docTextCalls.filter((s) => s.includes('\u{1F4AC}'));
+    expect(bugadas).toEqual([]);
+  });
+
+  it('5. Nenhuma chamada doc.text() contem ⬆ (U+2B06)', () => {
+    const bugadas = docTextCalls.filter((s) => s.includes('⬆'));
+    expect(bugadas).toEqual([]);
+  });
+});
+
+describe('HOTFIX v3.44.0 — substituicoes aplicadas corretamente', () => {
+  it('6. Titulo "ADICIONAL DE INSALUBRIDADE" usa "!" em vez de "⚠"', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/'! ADICIONAL DE INSALUBRIDADE'/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/'! ADICIONAL DE PERICULOSIDADE'/);
+  });
+
+  it('7. Labels FUNDAMENTO LEGAL / ENQUADRAMENTO TECNICO / JUSTIFICATIVA AO CLIENTE sem emoji', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/\.text\('FUNDAMENTO LEGAL'/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/\.text\('ENQUADRAMENTO TECNICO'/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/\.text\('JUSTIFICATIVA AO CLIENTE'/);
+  });
+
+  it('8. SERVICO NAO CONTRATADO usa "!" sem emoji', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/'! SERVIÇO NÃO CONTRATADO'/);
+  });
+
+  it('9. Aviso de Desconto usa "!" e Acrescimo usa "+"', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/! Desconto concedido:/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/\+ Acrescimo:/);
+  });
+
+  it('10. AdicionalCampoSnapshotPdf NAO inclui icone (emoji nao chega ao PDF via cenario)', () => {
+    // Confirma que o interface nao tem o campo icone (so' usado na UI do wizard)
+    const interfaceMatch = PROPOSTAS_CONS_TS.match(/interface AdicionalCampoSnapshotPdf \{[\s\S]*?\n\}/);
+    expect(interfaceMatch).not.toBeNull();
+    expect(interfaceMatch![0]).not.toMatch(/icone/);
+  });
+});


### PR DESCRIPTION
…(v3.44.0)

Sintoma: CEO via no PDF "& ADICIONAL DE INSALUBRIDADE" + "Ø=ÜÜ FUNDAMENTO LEGAL" + "Ø=Ý ENQUADRAMENTO TECNICO" + "Ø=Ü¬ JUSTIFICATIVA AO CLIENTE".

Causa: PDFKit usa Helvetica embedded (Type1) que so' suporta Latin-1 (0x00-0xFF). Emojis usados estao fora dessa codepage:
  ⚠ (U+26A0), 📜 (U+1F4DC), 🔍 (U+1F50D), 💬 (U+1F4AC), ⬆ (U+2B06)
Encoder fallback retorna bytes invalidos -> caracteres bugados no PDF. Conteudo juridico (CLT/NR-15) NAO estava corrompido — so' os emojis decorativos. Texto que importa esta integro.

Fix: substituir emojis por equivalentes ASCII compativeis:
  ⚠ -> !  (sinaliza atencao, ASCII puro)
  📜 🔍 💬 -> [removidos] (hierarquia ja' via bold + cor + box)
  ⬆ -> +  (sinaliza aumento)

Aplicado em 4 lugares: renderAdicionalCampoBody (titulo + 3 sub-headers), renderAditivoCampoBody (titulo legado v3.29.0), "SERVIÇO NÃO CONTRATADO", aviso desconto/acrescimo.

Tests: 10 novos validam que nenhum doc.text() contem emoji problematico + substituicoes corretas. Suite total 999 passing.

UI/wizard nao mudou — emojis renderizam normal no browser. Bug era so' PDF.