### PR TITLE
feat(preview): preview ao vivo (PDF inline) em Proposta de Demarcacao…

### DIFF
--- a/06-Changelog/v3.45.0-preview-ao-vivo-propostas.md
+++ b/06-Changelog/v3.45.0-preview-ao-vivo-propostas.md
@@ -1,0 +1,156 @@
+# v3.45.0 — Preview ao vivo (PDF inline) em Propostas de Consultoria
+
+**Data:** 2026-05-28
+**Branch:** `feat/preview-ao-vivo-propostas-v3.45.0`
+**Base:** `main` (v3.44.0)
+**Versão alvo:** v3.45.0
+
+## Contexto
+
+CEO solicitou replicar o **preview ao vivo do Recibo** ("Atualiza automaticamente enquanto você preenche — é exatamente o PDF que será gerado") para Propostas de Consultoria, começando por Demarcação.
+
+## Nota arquitetural
+
+O prompt original assumia **WeasyPrint (HTML → PDF)** com builder de HTML compartilhado. **Esta premissa estava errada:** o repo usa exclusivamente **PDFKit** (build programático). O preview do Recibo NÃO é HTML em iframe — é **PDF binário renderizado nativamente pelo browser em iframe**.
+
+Implementação aqui segue o padrão real do Recibo, não a teoria do prompt:
+
+```
+form → debounce 600ms → POST /api/.../preview-pdf
+     → PDFKit (mesmo builder do PDF final)
+     → application/pdf
+     → URL.createObjectURL(blob)
+     → <iframe src="blob:.../#toolbar=0">  (browser renderiza PDF nativamente)
+```
+
+**Vantagem:** zero divergência preview ≠ PDF final — é literalmente o MESMO `renderDemarcacaoLotesBody()` rodando.
+
+## Implementação — 3 camadas
+
+### 1. Backend (`src/integrations/propostasConsultoria.ts`)
+
+**Refactor minimal de `gerarPdfPropostaConsultoria`:**
+```ts
+export async function gerarPdfPropostaConsultoria(
+  id: string,
+  signatureMeta?: SignatureVisualMeta,
+  options?: {
+    propostaOverride?: Awaited<ReturnType<typeof buscarPropostaConsultoria>>;
+    isPreview?: boolean;
+  },
+): Promise<Buffer> {
+  const p = options?.propostaOverride ?? await buscarPropostaConsultoria(id);
+  // ... resto idêntico
+  if (isPreview) {
+    // QR/hash placeholder textual
+  } else {
+    // QR/hash real (caminho original)
+  }
+}
+```
+
+**Nova função preview:**
+```ts
+export async function gerarPdfPropostaConsultoriaPreview(input): Promise<Buffer> {
+  const previewResult = await previewCustoConsultoria({ ... });
+  const propostaOverride = { /* objeto fake com placeholders */ };
+  return gerarPdfPropostaConsultoria('0', undefined, { propostaOverride, isPreview: true });
+}
+```
+
+Aceita campos parciais — se cálculo falhar, devolve `secao_5_total: 0` e custos vazios (preview NUNCA derruba o form).
+
+### 2. Endpoint (`src/server.ts`)
+
+```ts
+app.post('/api/propostas-consultoria/preview-pdf', requireAuth, async (req, res) => {
+  const buf = await propostasConsultoria.gerarPdfPropostaConsultoriaPreview(req.body || {});
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Cache-Control', 'no-store');
+  res.send(buf);
+});
+```
+
+### 3. Frontend (`src/public/obras.html`)
+
+**Helper compacto** `__criarLivePreviewProposta(opts)`:
+- Debounce default 600ms (mesmo do Recibo)
+- `inflight` flag previne requests simultâneos
+- `URL.revokeObjectURL` antes de gerar novo blob (sem memory leak)
+- 401 → mensagem clara *"Faça login pra ver o preview"* sem redirect em loop
+
+**Integração no form de Demarcação:**
+- Wrapper grid 2-cols (`#dmSplitGrid`)
+- Painel sticky direita com iframe + botão refresh manual `🔄`
+- Media query 1100px colapsa pra 1 coluna no mobile
+- Bind `input`/`change` em todos os campos via `querySelectorAll`
+- Primeira renderização após `setTimeout(100ms)` (deixa cache popular)
+
+## Escopo de v3.45.0 vs futuro
+
+**v3.45.0 (este PR):**
+- ✅ Backend universal `gerarPdfPropostaConsultoriaPreview` — funciona para TODOS os subtipos sem mudança
+- ✅ Endpoint `/preview-pdf` universal
+- ✅ Helper `__criarLivePreviewProposta` reutilizável
+- ✅ Integração no form de **Demarcação** (urbana + rural)
+
+**Follow-up (v3.46.0+):** integrar o helper aos outros 7 forms:
+- `renderConsultoriaFormInline` (averbação residencial/comercial)
+- `renderConsultoriaFormGeoRural` (georreferenciamento)
+- `renderConsultoriaFormDesmRem` (desmembramento/remembramento)
+- `renderConsultoriaFormRetificacao` (retificação de área)
+- `renderConsultoriaFormPTAM` (avaliação PTAM)
+- `renderConsultoriaFormProjetoExecutivo` (projeto executivo)
+
+Cada um precisa de ~30 linhas de wire-up + teste browser dedicado. O backend e o helper JÁ estão prontos pra eles — só falta o HTML do painel e o `getDados()` específico.
+
+**Por que dividir:** entregar 7 forms num único PR sem teste browser por subtipo é alto risco. O usuário testa o template (Demarcação), valida o padrão, e os outros 6 seguem trivialmente.
+
+## Arquivos alterados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/integrations/propostasConsultoria.ts` | + `gerarPdfPropostaConsultoriaPreview()` (~90 linhas). Refactor mínimo de `gerarPdfPropostaConsultoria` (options.propostaOverride + isPreview). |
+| `src/server.ts` | + `POST /api/propostas-consultoria/preview-pdf` (15 linhas) |
+| `src/public/obras.html` | + helper `__criarLivePreviewProposta` (~55 linhas). Integração no form de Demarcação (~50 linhas: wrapper grid + painel + setup + listeners). |
+| `src/test/feat-preview-ao-vivo-propostas-v3.45.0.test.ts` | **NOVO** — 25 testes |
+| `package.json` | 3.44.0 → 3.45.0 |
+
+## Arquivos NÃO alterados (regra do prompt)
+
+- ✅ `src/agent/tools.ts` — intocado
+- ✅ `src/agent/think.ts` — intocado
+- ✅ `src/services/aiCascade.ts` — intocado
+
+## Testes
+
+`feat-preview-ao-vivo-propostas-v3.45.0.test.ts` — **25 testes**:
+
+| Bloco | Cobertura |
+|---|---|
+| Backend função (1–4) | exportada, reusa `previewCustoConsultoria`, tolera falha, chama o builder com override |
+| Refactor (5–8) | options.propostaOverride/isPreview, bypass do `buscarPropostaConsultoria`, QR/hash substituídos por placeholder em preview |
+| Endpoint (9–12) | `requireAuth`, `application/pdf`, `no-store`, 500 com payload de erro |
+| Helper JS (13–18) | function declaration, debounce 600ms, `credentials: include`, 401 amigável, blob revoke, inflight flag |
+| Demarcação (19–25) | grid wrapper, preview box, setup, listeners, setTimeout inicial, getDados tolera erro, media query |
+
+**Suite total:** 1024 passing, 1 skipped, 0 failures (baseline 999 + 25 novos).
+**Typecheck:** ✅ limpo.
+
+## Política preservada
+
+- ✅ Mesmo builder PDFKit (`renderDemarcacaoLotesBody`) gera preview e PDF final → zero divergência.
+- ✅ Preview NUNCA derruba o form — fallback de custos vazios + try/catch.
+- ✅ `inflight` flag previne race conditions (debounce não cobre tudo).
+- ✅ Sem eventos sintéticos no auto-preenchimento (preserva fix v3.39.0 do RangeError).
+- ✅ Recibo (`/api/recibos/preview-pdf`) inalterado — padrão de referência intacto.
+- ✅ Auth: endpoint requer `requireAuth` (mesmo padrão dos outros endpoints sensíveis).
+
+## Limitações conhecidas
+
+- **Mobile Safari iOS:** rendering de PDF em iframe é flakey. Em telas <1100px o painel já cai pra baixo do form, mas o iframe ainda renderiza. Fallback futuro: link "abrir em nova aba" se detectar iOS Safari.
+- **Preview demora ~300-800ms** dependendo da complexidade. Spinner mostra "Gerando preview..." durante.
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.44.0",
+  "version": "3.45.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/integrations/propostasConsultoria.ts
+++ b/src/integrations/propostasConsultoria.ts
@@ -2460,11 +2460,20 @@ function renderDemarcacaoLotesBody(
 export async function gerarPdfPropostaConsultoria(
   id: string,
   signatureMeta?: SignatureVisualMeta,
+  options?: {
+    // v3.45.0: bypass da busca em DB pro preview ao vivo. Quando setado,
+    // a funcao usa o objeto fornecido em vez de buscar pelo id.
+    propostaOverride?: Awaited<ReturnType<typeof buscarPropostaConsultoria>>;
+    // v3.45.0: pula QR + persistencia de hash (preview nao tem id real).
+    // Tambem suprime warnings de "falha gerar hash" quando o id e' 0.
+    isPreview?: boolean;
+  },
 ): Promise<Buffer> {
-  const p = await buscarPropostaConsultoria(id);
+  const p = options?.propostaOverride ?? await buscarPropostaConsultoria(id);
   if (p.tipo !== 'consultoria') throw new Error('Proposta nao e de consultoria');
   const custos = p.custos_calculados;
   if (!custos) throw new Error('Custos nao calculados');
+  const isPreview = options?.isPreview === true;
 
   const t = await getTenantSettings(1).catch(() => null);
   const brand = t?.brand_name || 'Romatec Consultoria Imobiliaria';
@@ -3098,23 +3107,34 @@ export async function gerarPdfPropostaConsultoria(
   // que cabem inteiros na pagina atual (~120px). Se nao couber, addPage primeiro.
   // Antes eram coords fixas y=720 e o footer em y=800 — se o conteudo passava de 720,
   // o QR sobrepunha conteudo OU caia numa "pagina 4 quase vazia" + footer em "pagina 5".
-  try {
-    const hashValidacao = await gerarOuBuscarHashProposta(Number(p.id));
-    const baseUrl = getValidacaoBaseUrl();
-    const ALTURA_QR_BLOCO = 100; // QR (80) + label embaixo + margem inferior
-    const espacoRestante = doc.page.height - doc.page.margins.bottom - 50 /* footer reservado */ - doc.y;
-    if (espacoRestante < ALTURA_QR_BLOCO) {
-      doc.addPage();
+  // v3.45.0: pula QR/hash em preview (id e' 0/PREVIEW, hash nao faz sentido).
+  if (isPreview) {
+    // Mostra placeholder textual no lugar do QR
+    const espacoRestante = doc.page.height - doc.page.margins.bottom - 50 - doc.y;
+    if (espacoRestante < 60) doc.addPage();
+    doc.fontSize(8).fillColor('#999').font('Helvetica-Oblique')
+      .text('[PREVIEW] QR Code e hash de validacao serao gerados ao salvar a proposta.',
+        48, doc.y + 10, { width: 499, align: 'center' });
+    doc.font('Helvetica').fillColor('#111');
+  } else {
+    try {
+      const hashValidacao = await gerarOuBuscarHashProposta(Number(p.id));
+      const baseUrl = getValidacaoBaseUrl();
+      const ALTURA_QR_BLOCO = 100; // QR (80) + label embaixo + margem inferior
+      const espacoRestante = doc.page.height - doc.page.margins.bottom - 50 /* footer reservado */ - doc.y;
+      if (espacoRestante < ALTURA_QR_BLOCO) {
+        doc.addPage();
+      }
+      const qrY = doc.y;
+      const validUrl = await renderQRValidacao(doc, hashValidacao, baseUrl, 460, qrY, {
+        size: 80,
+        corHex,
+        comLabel: true,
+      });
+      renderHashFooter(doc, hashValidacao, validUrl, 48, qrY + 10, 380);
+    } catch (err) {
+      console.warn(`[propostas-consultoria-pdf] falha QR/hash: ${(err as Error).message}`);
     }
-    const qrY = doc.y;
-    const validUrl = await renderQRValidacao(doc, hashValidacao, baseUrl, 460, qrY, {
-      size: 80,
-      corHex,
-      comLabel: true,
-    });
-    renderHashFooter(doc, hashValidacao, validUrl, 48, qrY + 10, 380);
-  } catch (err) {
-    console.warn(`[propostas-consultoria-pdf] falha QR/hash: ${(err as Error).message}`);
   }
 
   // v3.23.7: Footer global emitido em TODAS as paginas via bufferedPageRange.
@@ -3682,6 +3702,95 @@ export async function removerAnexoProposta(input: { id: string }) {
     `DELETE FROM proposta_anexos WHERE id = ?`, [id]
   );
   return { ok: true as const, affected: r.affectedRows, message: 'Anexo removido.' };
+}
+
+/**
+ * v3.45.0: gera PDF de preview "ao vivo" — sem persistir nada, tolera campos
+ * parciais. Mesmo builder (gerarPdfPropostaConsultoria) que o PDF final, so' que:
+ *   - propostaOverride com placeholders quando faltar campo
+ *   - isPreview=true pula QR/hash de validacao (mostra textual em vez disso)
+ *
+ * Pattern espelho do Recibo (reciboPdf.gerarPdfReciboPreview), pra browser
+ * renderizar PDF em iframe enquanto o user preenche.
+ */
+export async function gerarPdfPropostaConsultoriaPreview(input: {
+  subtipo: SubtipoConsultoria;
+  dados_imovel: Record<string, unknown>;
+  cliente?: { nome?: string; cpf_cnpj?: string; telefone?: string; email?: string };
+  endereco_imovel?: string;
+  validade_dias?: number;
+  adicional_campo?: {
+    ativo?: boolean;
+    cenario?: 'mata_densa_animais' | 'rodovia_faixa_dominio' | 'eletricidade_alta_tensao' | 'pedreira_explosivos' | 'produtos_quimicos';
+    tipo?: 'insalubridade' | 'periculosidade';
+    grau?: 'minimo' | 'medio' | 'maximo' | 'unico';
+  };
+  data_proposta?: string;
+  numero?: string;
+  observacoes?: string;
+  gestor_cargo?: string;
+  gestor_nome?: string;
+  gestor_telefone?: string;
+}): Promise<Buffer> {
+  // 1. Calcula custos via previewCustoConsultoria (reuso 100%)
+  let custos: CustosCalculados;
+  try {
+    const previewResult = await previewCustoConsultoria({
+      subtipo: input.subtipo,
+      dados_imovel: input.dados_imovel,
+      adicional_campo: input.adicional_campo,
+    });
+    custos = previewResult.custos;
+  } catch (err) {
+    // Preview NAO pode quebrar — devolve custos "vazios" pra render parcial
+    console.warn(`[preview-pdf] custos falharam: ${(err as Error).message}`);
+    custos = {
+      secao_1_projetos: [],
+      secao_2_taxas: [],
+      secao_3_honorarios: [],
+      condicoes_pagamento: [],
+      secao_4_checklist: [],
+      secao_5_total: 0,
+      avisos: [],
+    } as unknown as CustosCalculados;
+  }
+
+  // 2. Monta proposta "fake" com mesma shape do retorno de buscarPropostaConsultoria.
+  //    Placeholders pros campos vazios — render-side ja tolera (mostra "-").
+  const ano = new Date().getFullYear();
+  const propostaOverride = {
+    id: '0',
+    numero: input.numero || `PROP-${ano}-PREVIEW`,
+    tipo: 'consultoria' as const,
+    subtipo: input.subtipo,
+    cliente: {
+      id: 0,
+      nome: input.cliente?.nome || '— Cliente (preencher) —',
+      cpf_cnpj: input.cliente?.cpf_cnpj || undefined,
+      telefone: input.cliente?.telefone || undefined,
+      email: input.cliente?.email || undefined,
+      endereco: undefined,
+      cidade: undefined,
+      estado: undefined,
+    },
+    endereco_imovel: input.endereco_imovel || '',
+    data_proposta: input.data_proposta || new Date().toISOString().slice(0, 10),
+    validade_dias: Number(input.validade_dias) > 0 ? Number(input.validade_dias) : 15,
+    valor_total: Number(custos.secao_5_total) || 0,
+    status: 'RASCUNHO',
+    observacoes: input.observacoes,
+    gestor_cargo: input.gestor_cargo,
+    gestor_nome: input.gestor_nome,
+    gestor_telefone: input.gestor_telefone,
+    dados_imovel: input.dados_imovel,
+    custos_calculados: custos,
+    fontes_consulta: null,
+  } as unknown as Awaited<ReturnType<typeof buscarPropostaConsultoria>>;
+
+  return gerarPdfPropostaConsultoria('0', undefined, {
+    propostaOverride,
+    isPreview: true,
+  });
 }
 
 async function carregarAnexosProposta(propId: number): Promise<Array<{ filename: string; mimetype: string; buffer: Buffer }>> {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -9174,6 +9174,62 @@ const PROJETOS_PE_DEFAULT_FRONT = [
   { codigo: 'pci',            nome: 'Projeto de Prevencao e Combate a Incendio (PCI)',      selecionado: false, detalhamento: 'Planta baixa de PCI com rotas de fuga, localizacao de extintores, hidrantes, iluminacao de emergencia e sinalizacao, memorial descritivo conforme Normas Tecnicas do CBMMA e NBR 9077, para protocolo junto ao Corpo de Bombeiros Militar do Maranhao.' },
 ];
 
+// v3.45.0: helper compacto de live preview (PDF inline) pra forms de Proposta de Consultoria.
+// Pattern espelho do Recibo: debounce + fetch /preview-pdf + blob URL + iframe.
+//   opts = {
+//     boxId: string,            // id do <div> container do preview (criado pelo HTML do form)
+//     getDados: () => object,   // retorna body do POST (subtipo, dados_imovel, cliente, etc.)
+//     debounceMs?: number,      // default 600
+//   }
+// Retorna { agendar, atualizar } — chame agendar() em qualquer 'input'/'change' relevante.
+function __criarLivePreviewProposta(opts) {
+  let timer = null;
+  let blobUrl = null;
+  let inflight = false;
+  const debounce = opts.debounceMs ?? 600;
+  const boxId = opts.boxId;
+
+  async function atualizar() {
+    if (inflight) return;
+    const box = document.getElementById(boxId);
+    if (!box) return;
+    inflight = true;
+    const orig = box.innerHTML;
+    if (!box.querySelector('iframe')) {
+      box.innerHTML = '<span style="color:#888; font-size:13px;">⏳ Gerando preview...</span>';
+    }
+    try {
+      const body = opts.getDados();
+      const resp = await fetch('/api/propostas-consultoria/preview-pdf', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (resp.status === 401) {
+        box.innerHTML = '<span style="color:#888; font-size:12px;">🔒 Faça login pra ver o preview.</span>';
+        return;
+      }
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const blob = await resp.blob();
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+      blobUrl = URL.createObjectURL(blob);
+      box.innerHTML = `<iframe src="${blobUrl}#toolbar=0&navpanes=0" style="width:100%; height:100%; border:0;"></iframe>`;
+    } catch (err) {
+      box.innerHTML = `<span style="color:#dc2626; font-size:11px; padding:12px; text-align:center;">Preview indisponível: ${escape(err.message || String(err))}<br><small>Tente o 🔄 manual</small></span>`;
+    } finally {
+      inflight = false;
+    }
+  }
+
+  function agendar() {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(atualizar, debounce);
+  }
+
+  return { agendar, atualizar };
+}
+
 // v3.27.0: form de Demarcação de Lotes (Urbana e Rural). Espelha o padrão
 // do Georref Rural com 2 secoes extras: marcos discriminados + preview FQNS.
 async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
@@ -9191,7 +9247,11 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     ? state.consultoriaFormCache
     : null;
 
+  // v3.45.0: wrapper grid 2-cols (form + live preview sticky). Em telas
+  // <1100px o painel cai pra baixo do form (responsive @media abaixo).
   v.innerHTML = `
+    <div id="dmSplitGrid" style="display:grid; grid-template-columns: minmax(0, 1fr) 480px; gap:12px; align-items:start;">
+    <div>
     ${toggleHTML}
     <div class="card" role="region" aria-label="Cabeçalho do formulário">
       <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap;">
@@ -9330,7 +9390,23 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
           <button class="btn-secondary" id="dmCancelar">Cancelar</button>
         </div>
       </div>
-    </div>`;
+    </div>
+    </div>
+    <!-- v3.45.0: painel preview ao vivo (PDF em iframe). Sticky pra acompanhar scroll. -->
+    <div class="card" style="position:sticky; top:10px; min-width:0;">
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap;">
+        <p class="section-title" style="margin:0;">📄 Preview da proposta</p>
+        <button type="button" id="dmRefreshPreview" style="background:transparent; font-size:11px;" title="Atualizar agora">🔄</button>
+      </div>
+      <p style="font-size:11px; color:var(--text-muted); margin:6px 0 8px;">
+        Atualiza automaticamente enquanto você preenche. É exatamente o PDF que será gerado.
+      </p>
+      <div id="dmPreviewBox" style="background:#FAF7EE; border-radius:8px; min-height:520px; height:75vh; overflow:hidden; display:flex; align-items:center; justify-content:center;">
+        <span style="color:#888; font-size:13px;">⏳ Preencha os campos pra ver o preview</span>
+      </div>
+    </div>
+    </div>
+    <style>@media (max-width: 1100px) { #dmSplitGrid { grid-template-columns: 1fr !important; } }</style>`;
 
   // Handlers
   document.querySelectorAll('[data-toggle-tipo]').forEach(b => b.onclick = () => {
@@ -9385,6 +9461,48 @@ async function renderConsultoriaFormDemarcacao(v, toggleHTML, subtipo) {
     document.getElementById(id).addEventListener('change', recalcMarcosCheck);
   });
   recalcMarcosCheck();
+
+  // v3.45.0: live preview do PDF — debounce 600ms, atualiza a cada input.
+  // Mesmo padrao do Recibo: fetch /preview-pdf -> blob -> iframe.
+  const __dmPreview = __criarLivePreviewProposta({
+    boxId: 'dmPreviewBox',
+    getDados: () => {
+      try {
+        const dadosImovel = montarDadosImovel();
+        const cliId = document.getElementById('dmCliente')?.value;
+        const cliObj = state.propostasClientes?.find(c => String(c.id) === String(cliId));
+        const adicional = (typeof lerAdicionalCampoFormV2 === 'function')
+          ? lerAdicionalCampoFormV2('dmAditivoContainer')
+          : undefined;
+        return {
+          subtipo,
+          dados_imovel: dadosImovel,
+          cliente: cliObj ? {
+            nome: cliObj.nome,
+            cpf_cnpj: cliObj.cpf_cnpj,
+            telefone: cliObj.telefone,
+            email: cliObj.email,
+          } : undefined,
+          endereco_imovel: document.getElementById('dmEndereco')?.value?.trim() || '',
+          validade_dias: parseInt(document.getElementById('dmValidade')?.value, 10) || 15,
+          adicional_campo: adicional || undefined,
+        };
+      } catch (_err) {
+        // montarDadosImovel pode lancar se campos estranhos — devolve minimo
+        return { subtipo, dados_imovel: {} };
+      }
+    },
+  });
+  // Bind nos campos do form (input + change). NAO usa eventos sinteticos
+  // (preserva o fix do RangeError v3.39.0).
+  document.querySelectorAll('#dmSplitGrid input, #dmSplitGrid select, #dmSplitGrid textarea').forEach(el => {
+    if (el.id === 'dmRefreshPreview') return; // botao manual, nao input
+    el.addEventListener('input', __dmPreview.agendar);
+    el.addEventListener('change', __dmPreview.agendar);
+  });
+  document.getElementById('dmRefreshPreview')?.addEventListener('click', () => __dmPreview.atualizar());
+  // Primeira renderizacao depois do form estar montado (campos default + cache)
+  setTimeout(() => __dmPreview.atualizar(), 100);
 
   // v3.29.0: aditivo de campo — base estimada inicial = diarias × ~SM × 0.42
   // (espelho do calculo de tecnicos_campo em demarcacaoLotes.ts). Sera

--- a/src/server.ts
+++ b/src/server.ts
@@ -4100,6 +4100,21 @@ app.put   ('/api/propostas-consultoria/:id',
 app.post  ('/api/propostas-consultoria/preview',
   apiHandle(args => propostasConsultoria.previewCustoConsultoria(args as Parameters<typeof propostasConsultoria.previewCustoConsultoria>[0])));
 
+// v3.45.0: preview ao vivo via PDF binario em iframe (mesmo padrao do recibo).
+// Body: { subtipo, dados_imovel, cliente?, endereco_imovel?, validade_dias?, adicional_campo?, ... }
+// Retorna application/pdf. Tolera campos parciais (placeholders).
+app.post('/api/propostas-consultoria/preview-pdf', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const buf = await propostasConsultoria.gerarPdfPropostaConsultoriaPreview(req.body || {});
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(buf);
+  } catch (err) {
+    console.error('[preview-pdf-proposta]', (err as Error).message);
+    res.status(500).json({ error: 'Falha gerar preview', detail: (err as Error).message });
+  }
+});
+
 // v3.24.8: Catalogo de comodos do Programa de Necessidades (Projeto Executivo).
 // Publico (so leitura de constante TS), serve pro front montar tags clicaveis.
 app.get('/api/propostas-consultoria/projeto-executivo/comodos-catalogo', (_req: Request, res: Response) => {

--- a/src/test/feat-preview-ao-vivo-propostas-v3.45.0.test.ts
+++ b/src/test/feat-preview-ao-vivo-propostas-v3.45.0.test.ts
@@ -1,0 +1,140 @@
+// v3.45.0: live preview ao vivo (PDF inline em iframe) pra Propostas de Consultoria.
+// Espelha o padrao do Recibo (gerarPdfReciboPreview + POST /api/recibos/preview-pdf).
+//
+// Backend: gerarPdfPropostaConsultoriaPreview(input) aceita campos parciais,
+// gera PDF placeholder sem persistir nada.
+// Endpoint: POST /api/propostas-consultoria/preview-pdf -> application/pdf
+// Frontend: __criarLivePreviewProposta() helper + iframe sticky + debounce 600ms
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PROPOSTAS_CONS_TS = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'integrations', 'propostasConsultoria.ts'),
+  'utf-8',
+);
+const SERVER_TS = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'server.ts'),
+  'utf-8',
+);
+const OBRAS_HTML = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'public', 'obras.html'),
+  'utf-8',
+);
+
+describe('HOTFIX/FEAT v3.45.0 — Backend: gerarPdfPropostaConsultoriaPreview', () => {
+  it('1. Funcao exportada com assinatura esperada', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/export async function gerarPdfPropostaConsultoriaPreview\(input:/);
+  });
+
+  it('2. Reusa previewCustoConsultoria pra calcular custos (mesmo engine)', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/gerarPdfPropostaConsultoriaPreview[\s\S]{0,2000}?previewCustoConsultoria\(\{/);
+  });
+
+  it('3. Tolera falha de custos (preview NAO derruba — devolve custos vazios)', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/preview-pdf\] custos falharam/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/secao_5_total: 0/);
+  });
+
+  it('4. Chama gerarPdfPropostaConsultoria com propostaOverride + isPreview=true', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/return gerarPdfPropostaConsultoria\('0', undefined, \{\s*\n?\s*propostaOverride,\s*\n?\s*isPreview: true/);
+  });
+});
+
+describe('HOTFIX/FEAT v3.45.0 — Refactor gerarPdfPropostaConsultoria aceita override', () => {
+  it('5. Assinatura ganha options.propostaOverride opcional', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/options\?: \{[\s\S]{0,300}?propostaOverride\?:/);
+  });
+
+  it('6. Assinatura ganha options.isPreview opcional', () => {
+    // Match em multiline maior — comentario explicativo expandiu o trecho > 300 chars
+    expect(PROPOSTAS_CONS_TS).toMatch(/options\?: \{[\s\S]{0,800}?isPreview\?: boolean/);
+  });
+
+  it('7. Bypass do buscarPropostaConsultoria quando override fornecido', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/const p = options\?\.propostaOverride \?\? await buscarPropostaConsultoria/);
+  });
+
+  it('8. Em preview, QR/hash sao SUBSTITUIDOS por placeholder textual', () => {
+    expect(PROPOSTAS_CONS_TS).toMatch(/if \(isPreview\)/);
+    expect(PROPOSTAS_CONS_TS).toMatch(/QR Code e hash de validacao serao gerados ao salvar/);
+  });
+});
+
+describe('HOTFIX/FEAT v3.45.0 — Endpoint POST /preview-pdf', () => {
+  it('9. Endpoint registrado com requireAuth', () => {
+    expect(SERVER_TS).toMatch(/app\.post\('\/api\/propostas-consultoria\/preview-pdf',\s*requireAuth/);
+  });
+
+  it('10. Retorna application/pdf (nao json)', () => {
+    expect(SERVER_TS).toMatch(/preview-pdf'[\s\S]{0,1000}?setHeader\('Content-Type', 'application\/pdf'\)/);
+  });
+
+  it('11. Cache-Control no-store (cada keystroke gera novo PDF)', () => {
+    expect(SERVER_TS).toMatch(/preview-pdf'[\s\S]{0,1000}?setHeader\('Cache-Control', 'no-store'\)/);
+  });
+
+  it('12. 500 com payload de erro se gerar falhar', () => {
+    expect(SERVER_TS).toMatch(/preview-pdf'[\s\S]{0,1200}?res\.status\(500\)\.json\(\{ error: 'Falha gerar preview'/);
+  });
+});
+
+describe('HOTFIX/FEAT v3.45.0 — Frontend: helper __criarLivePreviewProposta', () => {
+  it('13. Helper existe e e function declaration', () => {
+    expect(OBRAS_HTML).toMatch(/function __criarLivePreviewProposta\(opts\) \{/);
+  });
+
+  it('14. Debounce default 600ms (mesmo do recibo)', () => {
+    expect(OBRAS_HTML).toMatch(/const debounce = opts\.debounceMs \?\? 600/);
+  });
+
+  it('15. Usa POST /api/propostas-consultoria/preview-pdf com credentials include', () => {
+    expect(OBRAS_HTML).toMatch(/fetch\('\/api\/propostas-consultoria\/preview-pdf'/);
+    expect(OBRAS_HTML).toMatch(/__criarLivePreviewProposta[\s\S]{0,800}?credentials: 'include'/);
+  });
+
+  it('16. 401 mostra mensagem clara "Faça login" sem redirect em loop', () => {
+    expect(OBRAS_HTML).toMatch(/resp\.status === 401[\s\S]{0,300}?Faça login pra ver/);
+  });
+
+  it('17. blobUrl revogado antes de gerar novo (evita memory leak)', () => {
+    expect(OBRAS_HTML).toMatch(/if \(blobUrl\) URL\.revokeObjectURL\(blobUrl\)/);
+  });
+
+  it('18. inflight flag previne 2 requests simultaneos', () => {
+    expect(OBRAS_HTML).toMatch(/let inflight = false/);
+    expect(OBRAS_HTML).toMatch(/if \(inflight\) return/);
+  });
+});
+
+describe('HOTFIX/FEAT v3.45.0 — Frontend: integracao no form de Demarcacao', () => {
+  it('19. Form de demarcacao usa wrapper grid 2-cols (dmSplitGrid)', () => {
+    expect(OBRAS_HTML).toMatch(/<div id="dmSplitGrid" style="display:grid;/);
+  });
+
+  it('20. Painel de preview tem #dmPreviewBox + botao refresh manual', () => {
+    expect(OBRAS_HTML).toMatch(/id="dmPreviewBox"/);
+    expect(OBRAS_HTML).toMatch(/id="dmRefreshPreview"/);
+  });
+
+  it('21. Setup do preview chama __criarLivePreviewProposta', () => {
+    expect(OBRAS_HTML).toMatch(/const __dmPreview = __criarLivePreviewProposta\(\{/);
+  });
+
+  it('22. Bind nos inputs/selects do form via querySelectorAll', () => {
+    expect(OBRAS_HTML).toMatch(/#dmSplitGrid input, #dmSplitGrid select, #dmSplitGrid textarea/);
+  });
+
+  it('23. Primeira renderizacao via setTimeout(100ms) — apos cache popular campos', () => {
+    expect(OBRAS_HTML).toMatch(/setTimeout\(\(\) => __dmPreview\.atualizar\(\), 100\)/);
+  });
+
+  it('24. getDados tolera erro de montarDadosImovel (devolve subtipo + dados vazios)', () => {
+    expect(OBRAS_HTML).toMatch(/catch \(_err\)[\s\S]{0,200}?subtipo, dados_imovel: \{\}/);
+  });
+
+  it('25. Media query 1100px colapsa pra 1 coluna no mobile', () => {
+    expect(OBRAS_HTML).toMatch(/@media \(max-width: 1100px\)[\s\S]{0,200}?#dmSplitGrid \{ grid-template-columns: 1fr/);
+  });
+});


### PR DESCRIPTION
… (v3.45.0)

Replica o padrao do Recibo (gerarPdfReciboPreview + /preview-pdf + iframe blob) para Propostas de Consultoria. NAO usa HTML/WeasyPrint como o prompt sugeria — o repo nao tem WeasyPrint. Browser renderiza PDF binario nativamente em iframe.

Backend (3 partes):
- gerarPdfPropostaConsultoria ganha options.propostaOverride + isPreview
- Nova gerarPdfPropostaConsultoriaPreview(input) — tolera campos parciais, reusa previewCustoConsultoria, chama o builder com override
- POST /api/propostas-consultoria/preview-pdf retorna application/pdf

Frontend:
- Helper __criarLivePreviewProposta(opts): debounce 600ms + inflight flag + URL.revokeObjectURL + 401 amigavel
- Integracao no form de Demarcacao: wrapper grid 2-cols + painel sticky com iframe + media query mobile

Escopo: foundation + Demarcacao funcional. Backend/helper sao UNIVERSAIS — outros 7 forms (averbacao, georref, desm/rem, retif, ptam, projeto exec) seguem em v3.46.0+ com integracao trivial (~30 linhas cada) apos validacao visual da demarcacao.

Tests: 25 novos. Suite total 1024 passing, 1 skipped, 0 failures. Arquivos sensiveis intocados.