### PR TITLE
feat(memoriais): Fase 2 — Sanitario + Eletrico + Estrutural + fix pdf…

### DIFF
--- a/06-Changelog/v3.48.0-memoriais-fase-2-sanitario-eletrico-estrutural.md
+++ b/06-Changelog/v3.48.0-memoriais-fase-2-sanitario-eletrico-estrutural.md
@@ -1,0 +1,154 @@
+# v3.48.0 — Memoriais Fase 2: Sanitário + Elétrico + Estrutural + Fix pdf-parse 500
+
+**Data:** 2026-05-28
+**Branch:** `feat/memoriais-fases-2-3-sanitario-eletrico-estrutural-v3.48.0`
+**Base:** `main` (v3.47.0)
+**Versão alvo:** v3.48.0
+
+## Contexto
+
+CEO solicitou implementar as fases restantes do módulo Memoriais (Sanitário/Elétrico/Estrutural) — Fase 1 (Hidráulico) ficou pronta na v3.35.0.
+
+**Durante a implementação**, CEO reportou bug crítico em produção: 500 ao subir PDF (`/api/memoriais/upload-pdf`). Investigação mostrou que `pdf-parse@2.4.5` mudou a API em relação ao código atual.
+
+## Bug-fix: pdf-parse v2 API
+
+**Causa:** O código chamava `pdfParse(buffer)` como função default (API v1). Em `pdf-parse@2.x` é classe `PDFParse`:
+
+```ts
+// Antes (v1, retorna 500):
+const mod = await dynamicImport('pdf-parse');
+const r = await mod.default(input);  // ← .default não é função em v2
+
+// Agora (v2):
+const mod = await dynamicImport('pdf-parse') as { PDFParse: new(opts) => ... };
+const parser = new mod.PDFParse({ data: input });
+const result = await parser.getText();
+try { ... } finally { await parser.destroy(); }
+```
+
+**Arquivo:** `src/services/memoriais/memorialPdfParser.ts:lerTextoPdf()`. Adicionado `parser.destroy()` em `finally` para evitar memory leaks em uploads sucessivos.
+
+## Fase 2 do módulo Memoriais — 3 disciplinas novas
+
+### Sanitário (`src/services/memoriais/sanitarioCalc.ts`)
+
+**Bases normativas:**
+- NBR 8160:1999 — Sistemas prediais de esgoto sanitário
+- NBR 10844:1989 — Instalações prediais de águas pluviais
+- NBR 7229:1993 — Tanques sépticos (fossa + sumidouro)
+
+**Calcula:**
+- **Esgoto:** soma de UHC (Unidade de Hunter de Contribuição) por aparelho → DN do ramal, tubo de queda, coletor predial
+- **Águas pluviais:** Q = (i × A) / 60 [L/min] → DN da calha + condutor vertical, com fallback `AJUSTAR` se vazão excede capacidade do maior DN tabelado
+- **Fossa séptica (NBR 7229):** V_decantação = N × 130 L; V_digestão = N × 1 × 300 L; área de sumidouro = (N × 130) / 50 m²
+
+**Tabelas hardcoded:** UHC por aparelho (Tabela 3 NBR 8160), ramal por UHC (Tabela 4), tubo de queda (Tabela 5), capacidade de calha (NBR 10844 semicircular), condutor vertical.
+
+### Elétrico (`src/services/memoriais/eletricoCalc.ts`)
+
+**Bases normativas:**
+- NBR 5410:2004 — Instalações elétricas de baixa tensão
+- NBR 5444:1989 — Símbolos gráficos
+- Padrão Equatorial Maranhão
+
+**Calcula:**
+- **Carga instalada:** iluminação + TUG por área (NBR 5410 Anexo C, 12 VA/m² residencial) + cargas explícitas (chuveiro, ar-cond, etc.)
+- **Demanda:** aplica fator de demanda por tipo (Tabela 47): ilum 66%, chuveiro 100%, ar-cond 75%, máquina lavar 70%
+- **Corrente de projeto:** I = P / (V × cosφ) com √3 trifásico
+- **Dimensionamento do ramal:** escolhe seção mínima de condutor (Tabela 36), itera subindo bitola até queda de tensão ≤ 4% (NBR 5410 6.2.7)
+- **Disjuntor:** sobre-dimensionado em 10%, escolhido da série NBR-IEC
+- **Proteção:** DR sempre obrigatório, DPS residencial, aterramento TN-S (Equatorial MA)
+
+### Estrutural (`src/services/memoriais/estruturalCalc.ts`)
+
+**Bases normativas:**
+- NBR 6118:2014 — Projeto de estruturas de concreto
+- NBR 6120:2019 — Ações para o cálculo de estruturas
+- NBR 6122:2019 — Projeto e execução de fundações
+
+**Calcula (pré-dimensionamento paramétrico):**
+- **Pilar:** seção mínima 14×30 cm (NBR 6118 13.2.3), área de concreto = N / (0,85 × fcd)
+- **Viga:** altura ≈ vão/12 (residencial), b mínimo 12 cm
+- **Laje maciça:** espessura ≥ L/40
+- **Cargas:** peso próprio (laje maciça 2.5 kN/m²) + alvenaria (1.5 kN/m) + acidental (1.5 residencial / 2.5 comercial)
+- **Fundação:** escolhe tipo conforme solo + carga total:
+  - Solo arenoso compacto/rocha → sapata
+  - Argiloso médio → sapata isolada
+  - Argiloso mole + carga alta → estaca ou radier
+- **Consumos:** concreto 0.15 m³/m² × pavimentos; aço 80 kg/m³ residencial
+
+**Classes de concreto suportadas:** C20, C25, C30, C35.
+**Tipos de solo:** argiloso_mole (60 kPa) / argiloso_medio (150) / arenoso_compacto (300) / rocha (1000).
+
+## Backend — endpoints universais
+
+Padrão idêntico ao `/api/memoriais/hidraulico/calcular` (público, sem auth, determinístico):
+
+```
+POST /api/memoriais/sanitario/calcular
+POST /api/memoriais/eletrico/calcular
+POST /api/memoriais/estrutural/calcular
+```
+
+E `POST /api/memoriais/:disciplina/criar` aceita as 4 disciplinas (era só `hidraulico`).
+
+## Frontend — wizard catalogado
+
+`wizardEngine.ts` ganha 3 sets de perguntas:
+- `PERGUNTAS_SANITARIO` (área cobertura, intensidade, destino do efluente, caixa de gordura)
+- `PERGUNTAS_ELETRICO` (tensão, alimentação mono/bi/trifásico, comprimento ramal, padrão demanda)
+- `PERGUNTAS_ESTRUTURAL` (vão pilares, classe concreto, tipo solo, tipo laje, subsolo, carga acidental)
+
+`listarDisciplinasDisponiveis()` agora retorna **4 disciplinas ativas** (Hidráulico, Sanitário, Elétrico, Estrutural) + 2 pendentes (Arquitetônico, PCI).
+
+## Arquivos NÃO alterados (regra do prompt)
+
+- ✅ `src/agent/tools.ts` — intocado
+- ✅ `src/agent/think.ts` — intocado
+- ✅ `src/services/aiCascade.ts` — intocado
+
+## Arquivos alterados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/services/memoriais/memorialPdfParser.ts` | Fix da API pdf-parse v2 (causa 500) |
+| `src/services/memoriais/types.ts` | + 3 disciplinas: WizardSanitario/Eletrico/Estrutural + outputs |
+| `src/services/memoriais/sanitarioCalc.ts` | **NOVO** — engine NBR 8160/10844/7229 |
+| `src/services/memoriais/eletricoCalc.ts` | **NOVO** — engine NBR 5410 |
+| `src/services/memoriais/estruturalCalc.ts` | **NOVO** — engine NBR 6118/6120/6122 |
+| `src/services/memoriais/wizardEngine.ts` | + perguntas das 3 novas disciplinas |
+| `src/server.ts` | + 3 endpoints /calcular; /criar aceita 4 disciplinas |
+| `src/services/memoriais/sanitarioCalc.test.ts` | **NOVO** — 13 testes |
+| `src/services/memoriais/eletricoCalc.test.ts` | **NOVO** — 10 testes |
+| `src/services/memoriais/estruturalCalc.test.ts` | **NOVO** — 16 testes |
+| `package.json` | 3.47.0 → 3.48.0 |
+
+## Testes
+
+| Suíte | # | Cobertura |
+|---|---|---|
+| `sanitarioCalc.test.ts` | 13 | UHC (3) · Pluvial (4) · Fossa (4) · Output (2) |
+| `eletricoCalc.test.ts` | 10 | Carga (2) · Demanda (1) · Corrente/queda (3) · Memorial (4) |
+| `estruturalCalc.test.ts` | 16 | Pré-dim (3) · Cargas (3) · Fundação (4) · Concreto/aço (3) · Validações (3) |
+
+**Suite total:** 1125 passing, 1 skipped, 0 failures (baseline 1086 + 39 novos).
+**Typecheck:** ✅ limpo.
+
+## O que NÃO está incluído (segue como follow-up)
+
+- PDF generator do memorial (template Romatec) — Fase 1b documentada no v3.35.0
+- Formulários customizados no front pra cada disciplina (atualmente usa o wizard genérico)
+- Disciplinas restantes: Arquitetônico (NBR 13531/13532), PCI (NBR 9077 + CBM-MA)
+
+## Política preservada
+
+- ✅ Engines puros, determinísticos, sem DB.
+- ✅ Endpoints `/calcular` públicos (mesma decisão de v3.37.0).
+- ✅ Endpoint `/criar` continua protegido por `requireAuth`.
+- ✅ pdf-parse: lazy import + cleanup com `parser.destroy()` em finally.
+- ✅ Wizard escolha de fonte via select (não livre) pra evitar combinações inválidas.
+
+## Autor
+
+José Romário Pinto Bezerra — TRT/CFT MA · CFT/MA nº 01209185369 · INCRA FQNS · CNAI nº 031161 · CRECI/MA nº 4.705 · Foro: Açailândia/MA.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.47.0",
+  "version": "3.48.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2467,11 +2467,46 @@ app.post('/api/memoriais/hidraulico/calcular', async (req: Request, res: Respons
   }
 });
 
+// v3.48.0 — Fase 2 Memoriais: Sanitario / Eletrico / Estrutural
+// Mesmo padrao do hidraulico: calculo deterministico, publico (sem auth),
+// le tabelas NBR hardcoded, nao acessa DB, nao persiste.
+app.post('/api/memoriais/sanitario/calcular', async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/memoriais/sanitarioCalc');
+    const r = m.calcularMemorialSanitario(req.body as Parameters<typeof m.calcularMemorialSanitario>[0]);
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+app.post('/api/memoriais/eletrico/calcular', async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/memoriais/eletricoCalc');
+    const r = m.calcularMemorialEletrico(req.body as Parameters<typeof m.calcularMemorialEletrico>[0]);
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+app.post('/api/memoriais/estrutural/calcular', async (req: Request, res: Response) => {
+  try {
+    const m = await import('./services/memoriais/estruturalCalc');
+    const r = m.calcularMemorialEstrutural(req.body as Parameters<typeof m.calcularMemorialEstrutural>[0]);
+    res.json(r);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
 app.post('/api/memoriais/:disciplina/criar', requireAuth, async (req: Request, res: Response) => {
   try {
     const disc = String(req.params.disciplina);
-    if (disc !== 'hidraulico') {
-      res.status(422).json({ error: 'Fase 1 cobre apenas Hidraulico. Outras disciplinas em desenvolvimento.' });
+    // v3.48.0: Fase 2 ativa Sanitario, Eletrico e Estrutural alem do Hidraulico
+    const DISCIPLINAS_ATIVAS = new Set(['hidraulico', 'sanitario', 'eletrico', 'estrutural']);
+    if (!DISCIPLINAS_ATIVAS.has(disc)) {
+      res.status(422).json({ error: `Disciplina ${disc} ainda nao implementada. Disponiveis: ${[...DISCIPLINAS_ATIVAS].join(', ')}` });
       return;
     }
     const user = (req as AuthedRequest).user;
@@ -2482,7 +2517,7 @@ app.post('/api/memoriais/:disciplina/criar', requireAuth, async (req: Request, r
     }
     const repo = await import('./repositories/memoriaisRepo');
     const r = await repo.memoriaisRepo.criar({
-      disciplina: 'hidraulico',
+      disciplina: disc as 'hidraulico' | 'sanitario' | 'eletrico' | 'estrutural',
       obra_id: typeof b.obra_id === 'number' ? b.obra_id : null,
       cliente_id: typeof b.cliente_id === 'number' ? b.cliente_id : null,
       user_id: user?.sub ? Number(user.sub) : null,

--- a/src/services/memoriais/eletricoCalc.test.ts
+++ b/src/services/memoriais/eletricoCalc.test.ts
@@ -1,0 +1,101 @@
+// v3.48.0: testes do engine eletrico (NBR 5410).
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularMemorialEletrico,
+  calcularCargaInstalada,
+  calcularDemanda,
+  calcularCorrente,
+  calcularQuedaTensao,
+} from './eletricoCalc';
+import type { WizardEletrico } from './types';
+
+const baseInput: WizardEletrico = {
+  uso_edificacao: 'Residencial unifamiliar',
+  area_construida_m2: 120,
+  num_pavimentos: 1,
+  cargas: [
+    { tipo: 'tue_chuveiro', potencia_w: 5500, quantidade: 2 },
+    { tipo: 'tue_ar_condicionado', potencia_w: 1400, quantidade: 2 },
+    { tipo: 'tue_maquina_lavar', potencia_w: 2000, quantidade: 1 },
+  ],
+  fator_demanda: 'residencial',
+  tensao_nominal_v: 220,
+  tipo_alimentacao: 'bifasico',
+  comprimento_ramal_m: 30,
+};
+
+describe('Eletrico — Carga instalada', () => {
+  it('1. Iluminacao+TUG: 120 m² × 12 VA/m² × cosfi 0,92 ≈ 1325 W', () => {
+    const { detalhamento } = calcularCargaInstalada(120, []);
+    const ilum = detalhamento.find(d => d.tipo === 'iluminacao_tug');
+    expect(ilum?.pot_total_w).toBeCloseTo(1324.8, 1);
+  });
+
+  it('2. Carga total inclui ilum + cargas explicitas', () => {
+    const { total_w, detalhamento } = calcularCargaInstalada(120, baseInput.cargas);
+    // ilum ~1325 + 2×5500 + 2×1400 + 2000 = 1325 + 15800 = 17125
+    expect(total_w).toBeCloseTo(17125, 0);
+    expect(detalhamento).toHaveLength(4); // ilum + 3 cargas
+  });
+});
+
+describe('Eletrico — Demanda', () => {
+  it('3. Aplica fator demanda por tipo (NBR 5410 Tabela 47)', () => {
+    const det = [
+      { tipo: 'iluminacao_tug' as const, pot_total_w: 1000 },
+      { tipo: 'tue_chuveiro' as const, pot_total_w: 5000 },
+    ];
+    const { demandada_w, detalhamento_demanda } = calcularDemanda(det);
+    // ilum 0.66 × 1000 = 660 + chuveiro 1.00 × 5000 = 5000 -> 5660
+    expect(demandada_w).toBeCloseTo(5660, 0);
+    expect(detalhamento_demanda[0].fator_demanda_pct).toBeCloseTo(66, 0);
+    expect(detalhamento_demanda[1].fator_demanda_pct).toBe(100);
+  });
+});
+
+describe('Eletrico — Corrente e queda de tensao', () => {
+  it('4. I bifasico = P / (V × cosfi)', () => {
+    const I = calcularCorrente(5500, 220, 'bifasico');
+    expect(I).toBeCloseTo(27.17, 1); // 5500 / (220 × 0.92)
+  });
+
+  it('5. I trifasico inclui √3', () => {
+    const I = calcularCorrente(10000, 380, 'trifasico');
+    expect(I).toBeCloseTo(16.51, 1); // 10000 / (1.732 × 380 × 0.92)
+  });
+
+  it('6. Queda de tensao depende de L, I, S, V', () => {
+    const dv = calcularQuedaTensao(30, 30, 16, 220);
+    // ΔV = (2 × 30 × 30 × 0.0172) / 16 = 1.935 V -> 1.935/220 × 100 ≈ 0.88%
+    expect(dv).toBeCloseTo(0.88, 1);
+  });
+});
+
+describe('Eletrico — Memorial completo', () => {
+  it('7. Memorial residencial 120 m² tipico', () => {
+    const r = calcularMemorialEletrico(baseInput);
+    expect(r.carga_total_instalada_w).toBeGreaterThan(15000);
+    expect(r.carga_demandada_kw).toBeGreaterThan(0);
+    expect(r.corrente_projeto_A).toBeGreaterThan(0);
+    expect(r.dimensionamento_ramal.secao_condutor_mm2).toBeGreaterThanOrEqual(10);
+    expect(r.dimensionamento_ramal.queda_tensao_pct).toBeLessThanOrEqual(4);
+  });
+
+  it('8. Protecao: DR obrigatorio em residencial', () => {
+    const r = calcularMemorialEletrico(baseInput);
+    expect(r.protecao.dr_obrigatorio).toBe(true);
+    expect(r.protecao.dps_obrigatorio).toBe(true);
+    expect(r.protecao.aterramento_tipo).toBe('TN-S');
+  });
+
+  it('9. Ramal longo aumenta secao (queda de tensao)', () => {
+    const r = calcularMemorialEletrico({ ...baseInput, comprimento_ramal_m: 200 });
+    expect(r.dimensionamento_ramal.secao_condutor_mm2).toBeGreaterThanOrEqual(16);
+  });
+
+  it('10. Disjuntor escolhido > corrente projeto (sobre dim 10%)', () => {
+    const r = calcularMemorialEletrico(baseInput);
+    expect(r.dimensionamento_ramal.disjuntor_geral_A).toBeGreaterThanOrEqual(r.corrente_projeto_A);
+  });
+});

--- a/src/services/memoriais/eletricoCalc.ts
+++ b/src/services/memoriais/eletricoCalc.ts
@@ -1,0 +1,194 @@
+// v3.48.0: calculator eletrico — Fase 2 do modulo Memoriais.
+//
+// Bases normativas:
+//   - NBR 5410:2004 — Instalacoes eletricas de baixa tensao
+//   - NBR 5444:1989 — Simbolos graficos
+//   - Padrao Equatorial Maranhao — bitolas minimas de entrada
+//
+// Formulas-chave:
+//   1. Carga TUG por area: ~100 VA/m² residencial NBR 5410 Anexo C
+//   2. Iluminacao: 100 VA pra primeiros 6 m² + 60 VA por 4 m² adicional
+//   3. Corrente: I = P / (V × cosfi × √3 se trifasico)
+//   4. Queda tensao: ΔV = (2 × L × I × ρ) / S  (monofasico, ρ=Cu)
+//
+// Standalone — sem deps de mysql/pdfkit.
+
+import type {
+  WizardEletrico,
+  MemorialEletricoOutput,
+  CargaEletrica,
+} from './types';
+
+// Fator de demanda por tipo de carga (NBR 5410 Tabela 47)
+const FATOR_DEMANDA_NBR5410: Record<CargaEletrica, number> = {
+  iluminacao_tug: 0.66,       // residencial
+  tue_chuveiro: 1.00,         // sempre 100% (curto + alta corrente)
+  tue_aquecedor: 1.00,
+  tue_ar_condicionado: 0.75,
+  tue_maquina_lavar: 0.70,
+  tue_forno_micro: 0.70,
+  tue_outros: 0.85,
+};
+
+// Tabela de secao mínima de condutor por corrente (NBR 5410 Tabela 36 — PVC)
+const SECAO_POR_CORRENTE: Array<{ ate_A: number; secao_mm2: number }> = [
+  { ate_A: 16, secao_mm2: 1.5 },
+  { ate_A: 23, secao_mm2: 2.5 },
+  { ate_A: 30, secao_mm2: 4.0 },
+  { ate_A: 40, secao_mm2: 6.0 },
+  { ate_A: 54, secao_mm2: 10.0 },
+  { ate_A: 73, secao_mm2: 16.0 },
+  { ate_A: 90, secao_mm2: 25.0 },
+  { ate_A: 110, secao_mm2: 35.0 },
+  { ate_A: 137, secao_mm2: 50.0 },
+];
+
+// Disjuntor padrao (sobre dimensiona em 10% acima da corrente do condutor)
+const DISJUNTORES_NBR_IEC = [10, 16, 20, 25, 32, 40, 50, 63, 80, 100, 125, 160, 200, 250];
+
+const PARAMS_DEFAULT_ELE = {
+  iluminacao_va_m2: 12,             // VA/m² residencial (NBR 5410 9.5.2.1.1)
+  tug_padrao_va: 100,               // VA por TUG em area molhada
+  fator_potencia: 0.92,             // cosfi residencial tipico
+  queda_max_pct: 4,                 // residencial NBR 5410 6.2.7
+  resistividade_cu_ohm_mm2_m: 0.0172, // condutor de cobre 20°C
+};
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function escolherSecaoCondutor(corrente_A: number): number {
+  for (const linha of SECAO_POR_CORRENTE) {
+    if (corrente_A <= linha.ate_A) return linha.secao_mm2;
+  }
+  return SECAO_POR_CORRENTE[SECAO_POR_CORRENTE.length - 1].secao_mm2;
+}
+
+function escolherDisjuntor(corrente_A: number): number {
+  const corrente_sobre = corrente_A * 1.1; // sobre dim 10%
+  for (const dj of DISJUNTORES_NBR_IEC) {
+    if (corrente_sobre <= dj) return dj;
+  }
+  return DISJUNTORES_NBR_IEC[DISJUNTORES_NBR_IEC.length - 1];
+}
+
+export function calcularCargaInstalada(
+  area_construida_m2: number,
+  cargas: WizardEletrico['cargas'],
+): { total_w: number; detalhamento: Array<{ tipo: CargaEletrica; pot_total_w: number }> } {
+  // Iluminacao + TUG por area (NBR 5410 anexo C)
+  const ilum_va = Math.max(100, area_construida_m2 * PARAMS_DEFAULT_ELE.iluminacao_va_m2);
+  // Soma cargas explicitas
+  const detalhamento = cargas
+    .filter((c) => c.quantidade > 0 && c.potencia_w > 0)
+    .map((c) => ({ tipo: c.tipo, pot_total_w: c.potencia_w * c.quantidade }));
+  // Inclui ilum + TUG como `iluminacao_tug` agregado
+  const totalCargas = detalhamento.reduce((s, x) => s + x.pot_total_w, 0);
+  const total_w = round2(ilum_va * PARAMS_DEFAULT_ELE.fator_potencia + totalCargas);
+  // Adiciona linha de iluminacao no detalhamento
+  detalhamento.unshift({
+    tipo: 'iluminacao_tug',
+    pot_total_w: round2(ilum_va * PARAMS_DEFAULT_ELE.fator_potencia),
+  });
+  return { total_w, detalhamento };
+}
+
+export function calcularDemanda(
+  detalhamento: Array<{ tipo: CargaEletrica; pot_total_w: number }>,
+): { demandada_w: number; detalhamento_demanda: MemorialEletricoOutput['detalhamento_cargas'] } {
+  const detalhamento_demanda = detalhamento.map((c) => {
+    const fd = FATOR_DEMANDA_NBR5410[c.tipo];
+    return {
+      tipo: c.tipo,
+      pot_total_w: round2(c.pot_total_w),
+      fator_demanda_pct: round2(fd * 100),
+      pot_demandada_w: round2(c.pot_total_w * fd),
+    };
+  });
+  const demandada_w = round2(detalhamento_demanda.reduce((s, x) => s + x.pot_demandada_w, 0));
+  return { demandada_w, detalhamento_demanda };
+}
+
+export function calcularCorrente(
+  potencia_w: number,
+  tensao_v: number,
+  tipo: 'monofasico' | 'bifasico' | 'trifasico',
+): number {
+  const fp = PARAMS_DEFAULT_ELE.fator_potencia;
+  if (tipo === 'trifasico') {
+    // I = P / (√3 × V × cosφ)
+    return round2(potencia_w / (Math.sqrt(3) * tensao_v * fp));
+  }
+  if (tipo === 'bifasico') {
+    return round2(potencia_w / (tensao_v * fp));
+  }
+  return round2(potencia_w / (tensao_v * fp));
+}
+
+export function calcularQuedaTensao(
+  corrente_A: number,
+  comprimento_m: number,
+  secao_mm2: number,
+  tensao_v: number,
+): number {
+  // ΔV(V) = (2 × L × I × ρ) / S   (monofasico, retorno duplicado)
+  const dvV = (2 * comprimento_m * corrente_A * PARAMS_DEFAULT_ELE.resistividade_cu_ohm_mm2_m) / secao_mm2;
+  return round2((dvV / tensao_v) * 100);
+}
+
+export function calcularMemorialEletrico(input: WizardEletrico): MemorialEletricoOutput {
+  // 1. Carga instalada total
+  const { total_w, detalhamento } = calcularCargaInstalada(input.area_construida_m2, input.cargas);
+  // 2. Demanda
+  const { demandada_w, detalhamento_demanda } = calcularDemanda(detalhamento);
+  const demandada_kw = round2(demandada_w / 1000);
+  // 3. Corrente de projeto
+  const corrente_A = calcularCorrente(demandada_w, input.tensao_nominal_v, input.tipo_alimentacao);
+  // 4. Dimensionamento condutor
+  let secao = escolherSecaoCondutor(corrente_A);
+  // Aumenta secao se queda > 4%
+  let queda = calcularQuedaTensao(corrente_A, input.comprimento_ramal_m, secao, input.tensao_nominal_v);
+  let iterMax = 5;
+  while (queda > PARAMS_DEFAULT_ELE.queda_max_pct && iterMax > 0) {
+    // Sobe pra proxima bitola
+    const idx = SECAO_POR_CORRENTE.findIndex((l) => l.secao_mm2 === secao);
+    if (idx < 0 || idx + 1 >= SECAO_POR_CORRENTE.length) break;
+    secao = SECAO_POR_CORRENTE[idx + 1].secao_mm2;
+    queda = calcularQuedaTensao(corrente_A, input.comprimento_ramal_m, secao, input.tensao_nominal_v);
+    iterMax--;
+  }
+  const disjuntor = escolherDisjuntor(corrente_A);
+  const status: 'OK' | 'AJUSTAR' = queda <= PARAMS_DEFAULT_ELE.queda_max_pct ? 'OK' : 'AJUSTAR';
+
+  return {
+    carga_total_instalada_w: total_w,
+    carga_demandada_kw: demandada_kw,
+    corrente_projeto_A: corrente_A,
+    detalhamento_cargas: detalhamento_demanda,
+    dimensionamento_ramal: {
+      secao_condutor_mm2: secao,
+      queda_tensao_pct: queda,
+      disjuntor_geral_A: disjuntor,
+      status,
+    },
+    protecao: {
+      dr_obrigatorio: true,                  // NBR 5410 5.1.3.2.2 sempre em residencial
+      dps_obrigatorio: input.fator_demanda === 'residencial',
+      aterramento_tipo: 'TN-S',              // padrao Equatorial MA
+    },
+    parametros_aplicados: {
+      iluminacao_va_m2: PARAMS_DEFAULT_ELE.iluminacao_va_m2,
+      tug_padrao_va: PARAMS_DEFAULT_ELE.tug_padrao_va,
+      fator_potencia: PARAMS_DEFAULT_ELE.fator_potencia,
+      queda_max_pct: PARAMS_DEFAULT_ELE.queda_max_pct,
+    },
+  };
+}
+
+export const __internalsEletrico = {
+  PARAMS_DEFAULT_ELE,
+  FATOR_DEMANDA_NBR5410,
+  SECAO_POR_CORRENTE,
+  DISJUNTORES_NBR_IEC,
+};

--- a/src/services/memoriais/estruturalCalc.test.ts
+++ b/src/services/memoriais/estruturalCalc.test.ts
@@ -1,0 +1,125 @@
+// v3.48.0: testes do engine estrutural (NBR 6118 + NBR 6122).
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularMemorialEstrutural,
+  calcularPreDimensionamento,
+  calcularCargasEstimadas,
+  calcularFundacao,
+  calcularConsumosConcretoAco,
+} from './estruturalCalc';
+import type { WizardEstrutural } from './types';
+
+const baseInput: WizardEstrutural = {
+  uso_edificacao: 'Residencial unifamiliar',
+  area_construida_m2: 120,
+  num_pavimentos: 2,
+  vao_medio_pilares_m: 4,
+  classe_concreto: 'C25',
+  tipo_solo: 'arenoso_compacto',
+  tem_subsolo: false,
+  laje_tipo: 'macica',
+};
+
+describe('Estrutural — Pre-dimensionamento (NBR 6118)', () => {
+  it('1. Pilar secao minima sempre 14×30 cm (NBR 6118 13.2.3)', () => {
+    const pre = calcularPreDimensionamento(baseInput);
+    expect(pre.pilar_secao_min_cm.b).toBe(14);
+    expect(pre.pilar_secao_min_cm.h).toBe(30);
+    expect(pre.pilar_area_concreto_cm2).toBeGreaterThanOrEqual(14 * 30);
+  });
+
+  it('2. Viga altura ≈ vao/12 (residencial)', () => {
+    const pre = calcularPreDimensionamento({ ...baseInput, vao_medio_pilares_m: 6 });
+    // h = 600/12 = 50 cm
+    expect(pre.viga_altura_recomendada_cm).toBeGreaterThanOrEqual(50);
+  });
+
+  it('3. Laje espessura >= L/40', () => {
+    const pre = calcularPreDimensionamento({ ...baseInput, vao_medio_pilares_m: 8 });
+    // 800/40 = 20 cm
+    expect(pre.laje_espessura_min_cm).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe('Estrutural — Cargas estimadas (NBR 6120)', () => {
+  it('4. Laje macica padrao 2.5 kN/m²', () => {
+    const c = calcularCargasEstimadas(baseInput);
+    expect(c.peso_proprio_estrutura_kn_m2).toBe(2.5);
+  });
+
+  it('5. Carga acidental residencial = 1.5 kN/m²', () => {
+    const c = calcularCargasEstimadas(baseInput);
+    expect(c.carga_acidental_kn_m2).toBe(1.5);
+    expect(c.carga_total_pavimento_kn_m2).toBe(5.0); // 2.5 + 1.5 + 1.0 rev
+  });
+
+  it('6. User pode override carga acidental', () => {
+    const c = calcularCargasEstimadas({ ...baseInput, carga_acidental_kn_m2: 3.5 });
+    expect(c.carga_acidental_kn_m2).toBe(3.5);
+  });
+});
+
+describe('Estrutural — Fundacao (NBR 6122)', () => {
+  it('7. Solo arenoso compacto -> sapata isolada/corrida', () => {
+    const f = calcularFundacao(baseInput);
+    expect(f.tensao_admissivel_solo_kpa).toBe(300);
+    expect(['sapata_isolada', 'sapata_corrida']).toContain(f.tipo);
+  });
+
+  it('8. Solo argiloso mole + carga alta -> estaca ou radier', () => {
+    const f = calcularFundacao({ ...baseInput, tipo_solo: 'argiloso_mole', num_pavimentos: 5 });
+    expect(['estaca_pre_moldada', 'radier']).toContain(f.tipo);
+  });
+
+  it('9. Rocha -> 1000 kPa', () => {
+    const f = calcularFundacao({ ...baseInput, tipo_solo: 'rocha' });
+    expect(f.tensao_admissivel_solo_kpa).toBe(1000);
+  });
+
+  it('10. Profundidade minima depende do tipo (>= 0.8 sapata, 1.5 estaca)', () => {
+    const f = calcularFundacao(baseInput);
+    expect(f.profundidade_minima_m).toBeGreaterThanOrEqual(0.8);
+  });
+});
+
+describe('Estrutural — Concreto e aco (consumos)', () => {
+  it('11. Concreto: 0.15 m³/m² × pavimentos', () => {
+    const { concreto } = calcularConsumosConcretoAco(baseInput);
+    // 120 × 0.15 × 2 = 36 m³
+    expect(concreto.consumo_estimado_m3).toBeCloseTo(36, 1);
+  });
+
+  it('12. Aco: 80 kg/m³ residencial (consumo proporcional)', () => {
+    const { aco, concreto } = calcularConsumosConcretoAco(baseInput);
+    expect(aco.taxa_kg_m3_concreto).toBe(80);
+    expect(aco.consumo_estimado_kg).toBeCloseTo(concreto.consumo_estimado_m3 * 80, 0);
+  });
+
+  it('13. Cobrimento CAA II = 30 mm pra viga/pilar', () => {
+    const { concreto } = calcularConsumosConcretoAco(baseInput);
+    expect(concreto.cobrimento_minimo_mm).toBe(30);
+  });
+});
+
+describe('Estrutural — Validacoes', () => {
+  it('14. vao < 2 m lanca', () => {
+    expect(() => calcularMemorialEstrutural({ ...baseInput, vao_medio_pilares_m: 1 }))
+      .toThrow(/vao_medio_pilares_m/);
+  });
+
+  it('15. num_pavimentos < 1 lanca', () => {
+    expect(() => calcularMemorialEstrutural({ ...baseInput, num_pavimentos: 0 }))
+      .toThrow(/num_pavimentos/);
+  });
+
+  it('16. Memorial completo retorna todas as secoes', () => {
+    const r = calcularMemorialEstrutural(baseInput);
+    expect(r.pre_dimensionamento).toBeDefined();
+    expect(r.cargas_estimadas).toBeDefined();
+    expect(r.fundacao_sugerida).toBeDefined();
+    expect(r.concreto).toBeDefined();
+    expect(r.aco).toBeDefined();
+    expect(r.parametros_aplicados).toBeDefined();
+  });
+});

--- a/src/services/memoriais/estruturalCalc.ts
+++ b/src/services/memoriais/estruturalCalc.ts
@@ -1,0 +1,198 @@
+// v3.48.0: calculator estrutural — Fase 2 do modulo Memoriais.
+//
+// Bases normativas:
+//   - NBR 6118:2014 — Projeto de estruturas de concreto
+//   - NBR 6120:2019 — Acoes para o calculo de estruturas
+//   - NBR 6122:2019 — Projeto e execucao de fundacoes
+//
+// Pre-dimensionamento PARAMETRICO (residencial/comercial leve ate 4 pavimentos).
+// NAO substitui calculo detalhado — apenas balizamento inicial pro memorial.
+//
+// Formulas-chave:
+//   1. Carga total ≈ peso_proprio + alvenaria + acidental
+//   2. Pilar: secao min 14×30 cm (NBR 6118 13.2.3)
+//      area = N(kN) / (0,85 × fck × 1,4)
+//   3. Viga: altura ≈ vao/12 (residencial), b min 12 cm
+//   4. Laje macica: e ≥ L/40 ou L/35 conforme apoio
+//   5. Fundacao: A = N / σ_solo
+//
+// Standalone — sem deps de mysql/pdfkit.
+
+import type {
+  WizardEstrutural,
+  MemorialEstruturalOutput,
+} from './types';
+
+// Tensoes admissiveis tipicas por tipo de solo (kPa)
+const TENSAO_SOLO_KPA: Record<WizardEstrutural['tipo_solo'], number> = {
+  argiloso_mole: 60,
+  argiloso_medio: 150,
+  arenoso_compacto: 300,
+  rocha: 1000,
+};
+
+// Resistencia caracteristica do concreto (MPa)
+const FCK_MPA: Record<WizardEstrutural['classe_concreto'], number> = {
+  C20: 20, C25: 25, C30: 30, C35: 35,
+};
+
+// Cobrimento minimo (mm) — Classe de Agressividade Ambiental II urbana
+const COBRIMENTO_CAA_II = {
+  laje: 25,
+  viga_pilar: 30,
+  fundacao: 40,
+};
+
+const PARAMS_DEFAULT_EST = {
+  peso_proprio_laje_macica_kn_m2: 2.5,         // gama=25 kN/m³, e=10cm
+  peso_proprio_laje_nervurada_kn_m2: 1.8,
+  peso_proprio_laje_premoldada_kn_m2: 2.2,
+  peso_alvenaria_tijolo_furado_kn_m: 1.5,
+  carga_acidental_residencial_kn_m2: 1.5,     // NBR 6120
+  carga_acidental_comercial_kn_m2: 2.5,
+  taxa_aco_kg_m3_residencial: 80,
+  taxa_aco_kg_m3_comercial: 100,
+  coef_seguranca_solo: 2.0,                    // FS sobre tensao admissivel
+  fator_redutor_carga: 1.4,                    // gamaf NBR 6118
+};
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function pesoLajePorTipo(tipo: WizardEstrutural['laje_tipo']): number {
+  if (tipo === 'macica') return PARAMS_DEFAULT_EST.peso_proprio_laje_macica_kn_m2;
+  if (tipo === 'nervurada') return PARAMS_DEFAULT_EST.peso_proprio_laje_nervurada_kn_m2;
+  return PARAMS_DEFAULT_EST.peso_proprio_laje_premoldada_kn_m2;
+}
+
+function escolherFundacao(
+  tensao_solo_kpa: number,
+  carga_total_kn: number,
+): MemorialEstruturalOutput['fundacao_sugerida']['tipo'] {
+  if (tensao_solo_kpa >= 300) {
+    return carga_total_kn > 500 ? 'sapata_isolada' : 'sapata_corrida';
+  }
+  if (tensao_solo_kpa >= 150) {
+    return 'sapata_isolada';
+  }
+  // Solo mole — radier ou estaca
+  if (carga_total_kn > 1000) return 'estaca_pre_moldada';
+  return 'radier';
+}
+
+export function calcularPreDimensionamento(input: WizardEstrutural): MemorialEstruturalOutput['pre_dimensionamento'] {
+  const fck = FCK_MPA[input.classe_concreto];
+  // Pilar: secao minima 14×30 cm NBR 6118 13.2.3 + estimativa por carga
+  // Considerando carga area influencia = vao × vao × N pavimentos × carga total
+  const area_influencia = input.vao_medio_pilares_m ** 2;
+  const carga_acidental = input.carga_acidental_kn_m2 ?? PARAMS_DEFAULT_EST.carga_acidental_residencial_kn_m2;
+  const peso_laje = pesoLajePorTipo(input.laje_tipo);
+  const carga_pavto = peso_laje + carga_acidental + 1.0; // +1 kN/m² revestimentos
+  const N_pilar_kn = area_influencia * carga_pavto * input.num_pavimentos * PARAMS_DEFAULT_EST.fator_redutor_carga;
+  // A_pilar = N / (0,85 × fck/1,4)  [N em kN, A em cm²]
+  const fcd_kpa = (fck * 1000) / 1.4;
+  const A_pilar_cm2 = Math.max(14 * 30, round2((N_pilar_kn / (0.85 * fcd_kpa)) * 10000));
+
+  // Viga: h ≈ L/12 (residencial)
+  const h_viga = Math.max(30, Math.ceil(input.vao_medio_pilares_m * 100 / 12 / 5) * 5); // arredonda em 5 cm
+  const b_viga = Math.max(12, Math.round(h_viga / 3));
+
+  // Laje espessura minima
+  const espessura_laje = Math.max(8, Math.ceil(input.vao_medio_pilares_m * 100 / 40));
+
+  return {
+    pilar_secao_min_cm: { b: 14, h: 30 },
+    pilar_area_concreto_cm2: A_pilar_cm2,
+    viga_secao_min_cm: { b: b_viga, h: h_viga },
+    viga_altura_recomendada_cm: h_viga,
+    laje_espessura_min_cm: espessura_laje,
+  };
+}
+
+export function calcularCargasEstimadas(input: WizardEstrutural): MemorialEstruturalOutput['cargas_estimadas'] {
+  const peso_laje = pesoLajePorTipo(input.laje_tipo);
+  const carga_acidental = input.carga_acidental_kn_m2 ?? PARAMS_DEFAULT_EST.carga_acidental_residencial_kn_m2;
+  return {
+    peso_proprio_estrutura_kn_m2: peso_laje,
+    carga_alvenaria_kn_m: PARAMS_DEFAULT_EST.peso_alvenaria_tijolo_furado_kn_m,
+    carga_acidental_kn_m2: carga_acidental,
+    carga_total_pavimento_kn_m2: round2(peso_laje + carga_acidental + 1.0),
+  };
+}
+
+export function calcularFundacao(input: WizardEstrutural): MemorialEstruturalOutput['fundacao_sugerida'] {
+  const tensao_solo = TENSAO_SOLO_KPA[input.tipo_solo];
+  // Carga total no pilar mais carregado (estimativa)
+  const area_influencia = input.vao_medio_pilares_m ** 2;
+  const cargas = calcularCargasEstimadas(input);
+  const N_kn = area_influencia * cargas.carga_total_pavimento_kn_m2 * input.num_pavimentos;
+  const tensao_adm_segura = tensao_solo / PARAMS_DEFAULT_EST.coef_seguranca_solo;
+  const A_min_m2 = round2(N_kn / tensao_adm_segura);
+  const tipo = escolherFundacao(tensao_solo, N_kn);
+  // Profundidade minima — 80 cm pra sapata, 1.5 m pra estaca, 1.2 m pra radier
+  let prof_min = 0.8;
+  if (tipo === 'radier') prof_min = 1.2;
+  if (tipo.startsWith('estaca')) prof_min = 1.5;
+  return {
+    tipo,
+    tensao_admissivel_solo_kpa: tensao_solo,
+    area_minima_sapata_m2: A_min_m2,
+    profundidade_minima_m: prof_min,
+  };
+}
+
+export function calcularConsumosConcretoAco(input: WizardEstrutural): {
+  concreto: MemorialEstruturalOutput['concreto'];
+  aco: MemorialEstruturalOutput['aco'];
+} {
+  const fck = FCK_MPA[input.classe_concreto];
+  // Volume estimativo: 0,15 m³/m² × num_pavimentos (residencial tipico)
+  const consumo_concreto = round2(input.area_construida_m2 * 0.15 * input.num_pavimentos);
+  const taxa_aco = PARAMS_DEFAULT_EST.taxa_aco_kg_m3_residencial;
+  const consumo_aco = round2(consumo_concreto * taxa_aco);
+  return {
+    concreto: {
+      classe: input.classe_concreto,
+      fck_mpa: fck,
+      cobrimento_minimo_mm: COBRIMENTO_CAA_II.viga_pilar,
+      consumo_estimado_m3: consumo_concreto,
+    },
+    aco: {
+      taxa_kg_m3_concreto: taxa_aco,
+      consumo_estimado_kg: consumo_aco,
+    },
+  };
+}
+
+export function calcularMemorialEstrutural(input: WizardEstrutural): MemorialEstruturalOutput {
+  if (!Number.isFinite(input.vao_medio_pilares_m) || input.vao_medio_pilares_m < 2) {
+    throw new Error('vao_medio_pilares_m deve ser >= 2 m');
+  }
+  if (!Number.isFinite(input.num_pavimentos) || input.num_pavimentos < 1) {
+    throw new Error('num_pavimentos deve ser >= 1');
+  }
+  const pre = calcularPreDimensionamento(input);
+  const cargas = calcularCargasEstimadas(input);
+  const fundacao = calcularFundacao(input);
+  const { concreto, aco } = calcularConsumosConcretoAco(input);
+
+  return {
+    pre_dimensionamento: pre,
+    cargas_estimadas: cargas,
+    fundacao_sugerida: fundacao,
+    concreto,
+    aco,
+    parametros_aplicados: {
+      coef_seguranca_solo: PARAMS_DEFAULT_EST.coef_seguranca_solo,
+      fator_redutor_carga: PARAMS_DEFAULT_EST.fator_redutor_carga,
+    },
+  };
+}
+
+export const __internalsEstrutural = {
+  PARAMS_DEFAULT_EST,
+  TENSAO_SOLO_KPA,
+  FCK_MPA,
+  COBRIMENTO_CAA_II,
+};

--- a/src/services/memoriais/memorialPdfParser.ts
+++ b/src/services/memoriais/memorialPdfParser.ts
@@ -7,13 +7,29 @@
 import type { PdfExtractionResult, TabelaExtraida, ProdutoInexistente } from './types';
 
 // O wrapper aceita Buffer (servidor) ou string (testes diretos).
+// v3.48.0 BUG-FIX: pdf-parse@2.x mudou de funcao default pra classe PDFParse.
+// Causa 500 em /api/memoriais/upload-pdf quando user envia PDF real.
+// Antes (v1.x): const r = await pdfParse(buffer); r.text;
+// Agora (v2.x): const r = await new PDFParse({data:buffer}).getText(); r.text;
 async function lerTextoPdf(input: Buffer | string): Promise<string> {
   if (typeof input === 'string') return input;
-  // Lazy import para evitar custo no boot e permitir teste sem pdf real
+  // Lazy import — pdf-parse e' ESM-only em v2, precisamos do indirect dynamic
+  // import pra contornar o module type do projeto (CommonJS via tsc).
   const dynamicImport = new Function('m', 'return import(m)') as (m: string) => Promise<unknown>;
-  const mod = await dynamicImport('pdf-parse') as { default: (b: Buffer) => Promise<{ text: string }> };
-  const r = await mod.default(input);
-  return r.text || '';
+  const mod = await dynamicImport('pdf-parse') as {
+    PDFParse: new (opts: { data: Uint8Array | Buffer }) => {
+      getText: (params?: unknown) => Promise<{ text: string }>;
+      destroy: () => Promise<void>;
+    };
+  };
+  const parser = new mod.PDFParse({ data: input });
+  try {
+    const result = await parser.getText();
+    return result?.text || '';
+  } finally {
+    // Libera recursos do pdfjs (worker, doc) — evita leaks em uploads sucessivos.
+    try { await parser.destroy(); } catch { /* opcional */ }
+  }
 }
 
 // Heuristica de metadados — padrao Revit do José Romário (vide PH-03/PS-04/PE-05/PA-02)

--- a/src/services/memoriais/sanitarioCalc.test.ts
+++ b/src/services/memoriais/sanitarioCalc.test.ts
@@ -1,0 +1,118 @@
+// v3.48.0: testes do engine sanitario (NBR 8160 esgoto + NBR 10844 pluvial).
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularMemorialSanitario,
+  calcularEsgoto,
+  calcularVazaoPluvial,
+  calcularFossa,
+  UHC_NBR8160,
+} from './sanitarioCalc';
+import type { WizardSanitario } from './types';
+
+const baseInput: WizardSanitario = {
+  uso_edificacao: 'Residencial unifamiliar',
+  num_pessoas: 4,
+  num_pavimentos: 1,
+  area_construida_m2: 120,
+  aparelhos: [
+    { tipo: 'bacia_sanitaria', quantidade: 2 },
+    { tipo: 'lavatorio', quantidade: 2 },
+    { tipo: 'chuveiro', quantidade: 2 },
+    { tipo: 'pia_cozinha', quantidade: 1 },
+    { tipo: 'ralo_sifonado', quantidade: 3 },
+  ],
+  area_cobertura_m2: 130,
+  destino_efluente: 'fossa_sumidouro',
+  tem_caixa_gordura: true,
+};
+
+describe('Sanitario — Esgoto (NBR 8160)', () => {
+  it('1. UHC residencial padrao = 2×6 + 2×1 + 2×2 + 1×3 + 3×1 = 24', () => {
+    const { soma_uhc, detalhamento_uhc } = calcularEsgoto(baseInput.aparelhos);
+    expect(soma_uhc).toBe(24);
+    expect(detalhamento_uhc).toHaveLength(5);
+    expect(detalhamento_uhc.find(d => d.tipo === 'bacia_sanitaria')?.uhc_total).toBe(12);
+  });
+
+  it('2. Memorial completo: ramal DN 75 + tubo queda DN 75', () => {
+    const r = calcularMemorialSanitario(baseInput);
+    expect(r.esgoto.soma_uhc).toBe(24);
+    // 24 UHC -> ramal DN 75 (ate_uhc=160 nao alcanca 100); tubo queda <= 26 UHC -> DN 75
+    expect(r.esgoto.dimensionamento_ramais.DN_mm).toBe(100);
+    expect(r.esgoto.dimensionamento_tubo_queda.DN_mm).toBe(75);
+  });
+
+  it('3. Aparelho desconhecido lanca', () => {
+    expect(() => calcularEsgoto([{ tipo: 'inexistente' as 'lavatorio', quantidade: 1 }]))
+      .toThrow(/desconhecido/);
+  });
+
+  it('4. Tabela UHC completa (todas chaves definidas)', () => {
+    const tipos = ['bacia_sanitaria','lavatorio','chuveiro','pia_cozinha','tanque','maquina_lavar','ralo_sifonado','ralo_seco'];
+    tipos.forEach(t => expect(UHC_NBR8160[t as keyof typeof UHC_NBR8160]).toBeGreaterThan(0));
+  });
+});
+
+describe('Sanitario — Aguas Pluviais (NBR 10844)', () => {
+  it('5. Q = (i × A) / 60: Acailandia 150 mm/h × 130 m² = 325 L/min', () => {
+    const q = calcularVazaoPluvial(130, 150);
+    expect(q).toBeCloseTo(325, 1);
+  });
+
+  it('6. Calha DN 100 capacidade 130 L/min — pra Q=130 deve casar', () => {
+    const r = calcularMemorialSanitario({ ...baseInput, area_cobertura_m2: 52 });
+    expect(r.aguas_pluviais.vazao_projeto_Lmin).toBeCloseTo(130, 1);
+    expect(r.aguas_pluviais.dimensionamento_calha.DN_mm).toBe(100);
+    expect(r.aguas_pluviais.dimensionamento_calha.status).toBe('OK');
+  });
+
+  it('7. Area de cobertura grande dispara calha maior', () => {
+    const r = calcularMemorialSanitario({ ...baseInput, area_cobertura_m2: 800 });
+    expect(r.aguas_pluviais.vazao_projeto_Lmin).toBeGreaterThan(1500);
+    expect(r.aguas_pluviais.dimensionamento_calha.status).toBe('AJUSTAR');
+  });
+
+  it('8. Intensidade invalida lanca', () => {
+    expect(() => calcularVazaoPluvial(100, 0)).toThrow(/intensidade/);
+    expect(() => calcularVazaoPluvial(-1, 150)).toThrow(/area/);
+  });
+});
+
+describe('Sanitario — Fossa (NBR 7229)', () => {
+  it('9. Calcula fossa quando destino != rede_publica', () => {
+    const r = calcularMemorialSanitario(baseInput); // fossa_sumidouro
+    expect(r.fossa_sumidouro).toBeDefined();
+    // V_dec = 4 × 130 = 520 L; V_dig = 4 × 1 × 300 = 1200 L
+    expect(r.fossa_sumidouro!.volume_camara_decantacao_L).toBe(520);
+    expect(r.fossa_sumidouro!.volume_camara_digestao_L).toBe(1200);
+    // A_sum = (4×130)/50 = 10.4 m²
+    expect(r.fossa_sumidouro!.area_sumidouro_m2).toBeCloseTo(10.4, 1);
+  });
+
+  it('10. NAO calcula fossa quando destino = rede_publica', () => {
+    const r = calcularMemorialSanitario({ ...baseInput, destino_efluente: 'rede_publica' });
+    expect(r.fossa_sumidouro).toBeUndefined();
+  });
+
+  it('11. Helper calcularFossa direto', () => {
+    const f = calcularFossa(4);
+    expect(f).toBeDefined();
+    expect(f!.volume_total_L).toBe(1720); // 520 + 1200
+  });
+
+  it('12. num_pessoas < 1 retorna undefined', () => {
+    expect(calcularFossa(0)).toBeUndefined();
+  });
+});
+
+describe('Sanitario — Output completo', () => {
+  it('13. Memorial retorna todas as secoes esperadas', () => {
+    const r = calcularMemorialSanitario(baseInput);
+    expect(r.esgoto).toBeDefined();
+    expect(r.aguas_pluviais).toBeDefined();
+    expect(r.fossa_sumidouro).toBeDefined();
+    expect(r.parametros_aplicados).toBeDefined();
+    expect(r.parametros_aplicados.contribuicao_per_capita_L_dia).toBe(130);
+  });
+});

--- a/src/services/memoriais/sanitarioCalc.ts
+++ b/src/services/memoriais/sanitarioCalc.ts
@@ -1,0 +1,198 @@
+// v3.48.0: calculator sanitario — Fase 2 do modulo Memoriais.
+//
+// Bases normativas:
+//   - NBR 8160:1999 — Sistemas prediais de esgoto sanitario
+//   - NBR 10844:1989 — Instalacoes prediais de aguas pluviais
+//   - NBR 7229:1993 — Tanques septicos (fossa + sumidouro/filtro)
+//
+// Formulas-chave:
+//   1. Esgoto: soma de UHC (Unidade de Hunter de Contribuicao) determina ramal/queda/coletor
+//   2. Pluvial: Q = (i × A) / 60  [L/min onde i=mm/h e A=m²]
+//   3. Fossa: V = N × C × T  (Norma 7229) ; C=contrib per capita, T=t. detencao
+//
+// Standalone — sem deps de mysql/pdfkit.
+
+import type {
+  WizardSanitario,
+  MemorialSanitarioOutput,
+  AparelhoSanitario,
+} from './types';
+
+// UHC por aparelho (NBR 8160 Tabela 3)
+export const UHC_NBR8160: Record<AparelhoSanitario, number> = {
+  bacia_sanitaria: 6,
+  lavatorio: 1,
+  chuveiro: 2,
+  pia_cozinha: 3,
+  tanque: 3,
+  maquina_lavar: 3,
+  ralo_sifonado: 1,
+  ralo_seco: 1,
+};
+
+// Dimensionamento de ramal de descarga primario por UHC (NBR 8160 Tabela 4)
+// soma_uhc -> DN_mm
+const RAMAL_POR_UHC: Array<{ ate_uhc: number; DN_mm: number }> = [
+  { ate_uhc: 3, DN_mm: 40 },
+  { ate_uhc: 6, DN_mm: 50 },
+  { ate_uhc: 20, DN_mm: 75 },
+  { ate_uhc: 160, DN_mm: 100 },
+  { ate_uhc: 620, DN_mm: 150 },
+];
+
+// Tubo de queda — soma UHC contribuinte vertical (NBR 8160 Tabela 5)
+const TUBO_QUEDA_POR_UHC: Array<{ ate_uhc: number; DN_mm: number }> = [
+  { ate_uhc: 4, DN_mm: 50 },
+  { ate_uhc: 26, DN_mm: 75 },
+  { ate_uhc: 240, DN_mm: 100 },
+  { ate_uhc: 960, DN_mm: 150 },
+];
+
+// Calha — capacidade Q (L/min) por DN (NBR 10844 — semicircular, i=0,5%)
+const CALHA_CAPACIDADE_LMIN: Array<{ DN_mm: number; Q_max: number }> = [
+  { DN_mm: 100, Q_max: 130 },
+  { DN_mm: 125, Q_max: 236 },
+  { DN_mm: 150, Q_max: 384 },
+  { DN_mm: 200, Q_max: 829 },
+  { DN_mm: 250, Q_max: 1500 },
+];
+
+// Condutor vertical de aguas pluviais — capacidade Q (L/min)
+const CONDUTOR_VERTICAL_LMIN: Array<{ DN_mm: number; Q_max: number }> = [
+  { DN_mm: 75, Q_max: 80 },
+  { DN_mm: 100, Q_max: 162 },
+  { DN_mm: 125, Q_max: 268 },
+  { DN_mm: 150, Q_max: 433 },
+];
+
+const PARAMS_DEFAULT_SAN = {
+  contribuicao_per_capita_L_dia: 130,   // NBR 7229 — residencial padrao
+  tempo_detencao_h: 24,                 // tempo minimo de detencao na fossa
+  coef_runoff_pluvial: 1.0,             // telhado + laje = escoamento 100%
+  intensidade_pluv_mmh_default: 150,    // Acailandia/MA — T=5 anos, t=5min
+  inclinacao_calha_pct_default: 0.5,
+  taxa_absorcao_sumidouro_L_m2_dia: 50, // K argilo-arenoso
+};
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function escolherDN(
+  tabela: Array<{ ate_uhc: number; DN_mm: number }>,
+  somaUhc: number,
+): number {
+  for (const linha of tabela) {
+    if (somaUhc <= linha.ate_uhc) return linha.DN_mm;
+  }
+  return tabela[tabela.length - 1].DN_mm;
+}
+
+function escolherCalha(vazaoLmin: number): { DN_mm: number; capacidade_Lmin: number; status: 'OK' | 'AJUSTAR' } {
+  for (const c of CALHA_CAPACIDADE_LMIN) {
+    if (vazaoLmin <= c.Q_max) return { DN_mm: c.DN_mm, capacidade_Lmin: c.Q_max, status: 'OK' };
+  }
+  const ult = CALHA_CAPACIDADE_LMIN[CALHA_CAPACIDADE_LMIN.length - 1];
+  return { DN_mm: ult.DN_mm, capacidade_Lmin: ult.Q_max, status: 'AJUSTAR' };
+}
+
+function escolherCondutorVertical(vazaoLmin: number): { DN_mm: number; quantidade: number; status: 'OK' | 'AJUSTAR' } {
+  for (const c of CONDUTOR_VERTICAL_LMIN) {
+    if (vazaoLmin <= c.Q_max) return { DN_mm: c.DN_mm, quantidade: 1, status: 'OK' };
+  }
+  // Acima do maior — sugere 2 condutores
+  const ult = CONDUTOR_VERTICAL_LMIN[CONDUTOR_VERTICAL_LMIN.length - 1];
+  const qtd = Math.ceil(vazaoLmin / ult.Q_max);
+  return { DN_mm: ult.DN_mm, quantidade: qtd, status: 'AJUSTAR' };
+}
+
+export function calcularEsgoto(aparelhos: WizardSanitario['aparelhos']): {
+  soma_uhc: number;
+  detalhamento_uhc: MemorialSanitarioOutput['esgoto']['detalhamento_uhc'];
+} {
+  const detalhamento_uhc = aparelhos
+    .filter((a) => a.quantidade > 0)
+    .map((a) => {
+      const uhc_unit = UHC_NBR8160[a.tipo];
+      if (uhc_unit == null) throw new Error(`Aparelho sanitario desconhecido: ${a.tipo}`);
+      return { tipo: a.tipo, qtd: a.quantidade, uhc_unit, uhc_total: uhc_unit * a.quantidade };
+    });
+  const soma_uhc = detalhamento_uhc.reduce((s, x) => s + x.uhc_total, 0);
+  return { soma_uhc, detalhamento_uhc };
+}
+
+export function calcularVazaoPluvial(area_m2: number, intensidade_mmh: number): number {
+  if (!Number.isFinite(area_m2) || area_m2 < 0) throw new Error('area_cobertura_m2 deve ser >= 0');
+  if (!Number.isFinite(intensidade_mmh) || intensidade_mmh <= 0) throw new Error('intensidade_mmh deve ser > 0');
+  // Q (L/min) = (intensidade × area × coef_runoff) / 60
+  return round2((intensidade_mmh * area_m2 * PARAMS_DEFAULT_SAN.coef_runoff_pluvial) / 60);
+}
+
+export function calcularFossa(num_pessoas: number): MemorialSanitarioOutput['fossa_sumidouro'] {
+  if (num_pessoas < 1) return undefined;
+  // V_decantacao = N × C × T (NBR 7229)
+  // Pra contribuicao 130 L/p/dia, T=24h: V = N × 130 × 1 = N × 130 L
+  const V_dec = num_pessoas * PARAMS_DEFAULT_SAN.contribuicao_per_capita_L_dia;
+  // V_digestao = N × Lf × Td (Lf=lodo fresco 1 L/p/dia, Td=300 dias residencial)
+  const V_dig = num_pessoas * 1 * 300;
+  // Sumidouro — area = (N × contrib) / K
+  const A_sum = round2((num_pessoas * PARAMS_DEFAULT_SAN.contribuicao_per_capita_L_dia) / PARAMS_DEFAULT_SAN.taxa_absorcao_sumidouro_L_m2_dia);
+  return {
+    volume_camara_decantacao_L: V_dec,
+    volume_camara_digestao_L: V_dig,
+    volume_total_L: V_dec + V_dig,
+    area_sumidouro_m2: A_sum,
+  };
+}
+
+export function calcularMemorialSanitario(input: WizardSanitario): MemorialSanitarioOutput {
+  // 1. Esgoto
+  const { soma_uhc, detalhamento_uhc } = calcularEsgoto(input.aparelhos);
+  const dn_ramal = escolherDN(RAMAL_POR_UHC, soma_uhc);
+  const dn_tubo_queda = escolherDN(TUBO_QUEDA_POR_UHC, soma_uhc);
+  // Coletor predial: mesmo criterio do tubo de queda + declividade min
+  const declividade_min = soma_uhc <= 180 ? 2.0 : 1.0;
+  // 2. Pluvial
+  const intensidade = input.intensidade_pluv_mmh && input.intensidade_pluv_mmh > 0
+    ? input.intensidade_pluv_mmh
+    : PARAMS_DEFAULT_SAN.intensidade_pluv_mmh_default;
+  const vazao_pluv = calcularVazaoPluvial(input.area_cobertura_m2, intensidade);
+  const calha = escolherCalha(vazao_pluv);
+  const condutor = escolherCondutorVertical(vazao_pluv);
+  // 3. Fossa (apenas se destino != rede_publica)
+  const fossa = input.destino_efluente !== 'rede_publica'
+    ? calcularFossa(input.num_pessoas)
+    : undefined;
+
+  return {
+    esgoto: {
+      soma_uhc,
+      detalhamento_uhc,
+      dimensionamento_ramais: { DN_mm: dn_ramal, descricao: `Ramal de descarga primario DN ${dn_ramal} mm (PVC esgoto)` },
+      dimensionamento_tubo_queda: { DN_mm: dn_tubo_queda, descricao: `Tubo de queda DN ${dn_tubo_queda} mm com ventilacao primaria` },
+      dimensionamento_coletor_predial: { DN_mm: dn_tubo_queda, declividade_min_pct: declividade_min },
+    },
+    aguas_pluviais: {
+      area_contribuinte_m2: input.area_cobertura_m2,
+      intensidade_mmh: intensidade,
+      vazao_projeto_Lmin: vazao_pluv,
+      dimensionamento_calha: calha,
+      dimensionamento_condutor_vertical: condutor,
+    },
+    fossa_sumidouro: fossa,
+    parametros_aplicados: {
+      contribuicao_per_capita_L_dia: PARAMS_DEFAULT_SAN.contribuicao_per_capita_L_dia,
+      tempo_detencao_h: PARAMS_DEFAULT_SAN.tempo_detencao_h,
+      coef_runoff_pluvial: PARAMS_DEFAULT_SAN.coef_runoff_pluvial,
+    },
+  };
+}
+
+export const __internalsSanitario = {
+  PARAMS_DEFAULT_SAN,
+  UHC_NBR8160,
+  RAMAL_POR_UHC,
+  TUBO_QUEDA_POR_UHC,
+  CALHA_CAPACIDADE_LMIN,
+  CONDUTOR_VERTICAL_LMIN,
+};

--- a/src/services/memoriais/types.ts
+++ b/src/services/memoriais/types.ts
@@ -55,6 +55,160 @@ export type AparelhoHidraulico =
   | 'maquina_lavar'
   | 'torneira_geral';
 
+// ─────────────────────────────────────────────────────────────────────────
+// v3.48.0 — Sanitario (NBR 8160:1999 Esgoto + NBR 10844:1989 Aguas Pluviais)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type AparelhoSanitario =
+  | 'bacia_sanitaria'      // UHC = 6
+  | 'lavatorio'            // UHC = 1
+  | 'chuveiro'             // UHC = 2
+  | 'pia_cozinha'          // UHC = 3
+  | 'tanque'               // UHC = 3
+  | 'maquina_lavar'        // UHC = 3
+  | 'ralo_sifonado'        // UHC = 1
+  | 'ralo_seco';           // UHC = 1
+
+export interface WizardSanitario extends WizardComum {
+  num_pessoas: number;
+  // Esgoto (NBR 8160)
+  aparelhos: Array<{ tipo: AparelhoSanitario; quantidade: number }>;
+  // Aguas pluviais (NBR 10844)
+  area_cobertura_m2: number;          // area de telhado/laje contribuinte
+  intensidade_pluv_mmh?: number;      // default Acailandia: 150 mm/h (T=5 anos)
+  inclinacao_calha_pct?: number;      // default 0.5%
+  // Solucao de destino final
+  destino_efluente: 'rede_publica' | 'fossa_sumidouro' | 'fossa_filtro_anaerobio' | 'eta_compacta';
+  tem_caixa_gordura: boolean;
+}
+
+export interface MemorialSanitarioOutput {
+  esgoto: {
+    soma_uhc: number;
+    detalhamento_uhc: Array<{ tipo: AparelhoSanitario; qtd: number; uhc_unit: number; uhc_total: number }>;
+    dimensionamento_ramais: { DN_mm: number; descricao: string };  // ramal de descarga primario
+    dimensionamento_tubo_queda: { DN_mm: number; descricao: string };
+    dimensionamento_coletor_predial: { DN_mm: number; declividade_min_pct: number };
+  };
+  aguas_pluviais: {
+    area_contribuinte_m2: number;
+    intensidade_mmh: number;
+    vazao_projeto_Lmin: number;             // Q = (i × A) / 60
+    dimensionamento_calha: { DN_mm: number; capacidade_Lmin: number; status: 'OK' | 'AJUSTAR' };
+    dimensionamento_condutor_vertical: { DN_mm: number; quantidade: number; status: 'OK' | 'AJUSTAR' };
+  };
+  fossa_sumidouro?: {
+    volume_camara_decantacao_L: number;   // NBR 7229
+    volume_camara_digestao_L: number;
+    volume_total_L: number;
+    area_sumidouro_m2: number;            // K = 50 L/m²/dia
+  };
+  parametros_aplicados: {
+    contribuicao_per_capita_L_dia: number;
+    tempo_detencao_h: number;
+    coef_runoff_pluvial: number;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// v3.48.0 — Eletrico (NBR 5410:2004 Instalacoes Eletricas BT)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type CargaEletrica =
+  | 'iluminacao_tug'         // pontos de tomada uso geral + ilum
+  | 'tue_chuveiro'           // tomada uso especifico — chuveiro
+  | 'tue_aquecedor'          // boiler eletrico
+  | 'tue_ar_condicionado'    // split
+  | 'tue_maquina_lavar'      // m. lavar / lava-loucas
+  | 'tue_forno_micro'        // forno + microondas
+  | 'tue_outros';            // outros aparelhos especificos
+
+export interface WizardEletrico extends WizardComum {
+  area_construida_m2: number;
+  // Cargas (NBR 5410 Anexo C - residencial)
+  cargas: Array<{ tipo: CargaEletrica; potencia_w: number; quantidade: number }>;
+  fator_demanda: 'residencial' | 'comercial';
+  tensao_nominal_v: 127 | 220 | 380;          // entrada da concessionaria
+  tipo_alimentacao: 'monofasico' | 'bifasico' | 'trifasico';
+  comprimento_ramal_m: number;                // distancia do padrao a' rede
+}
+
+export interface MemorialEletricoOutput {
+  carga_total_instalada_w: number;
+  carga_demandada_kw: number;
+  corrente_projeto_A: number;
+  detalhamento_cargas: Array<{ tipo: CargaEletrica; pot_total_w: number; fator_demanda_pct: number; pot_demandada_w: number }>;
+  dimensionamento_ramal: {
+    secao_condutor_mm2: number;             // bitola do condutor de entrada
+    queda_tensao_pct: number;
+    disjuntor_geral_A: number;
+    status: 'OK' | 'AJUSTAR';
+  };
+  protecao: {
+    dr_obrigatorio: boolean;                // sempre true em residencial NBR 5410
+    dps_obrigatorio: boolean;
+    aterramento_tipo: 'TT' | 'TN-S' | 'TN-C-S';
+  };
+  parametros_aplicados: {
+    iluminacao_va_m2: number;
+    tug_padrao_va: number;
+    fator_potencia: number;
+    queda_max_pct: number;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// v3.48.0 — Estrutural (NBR 6118:2014 Concreto Armado + NBR 6122:2019 Fund.)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface WizardEstrutural extends WizardComum {
+  area_construida_m2: number;
+  num_pavimentos: number;
+  vao_medio_pilares_m: number;              // distancia media entre pilares
+  carga_acidental_kn_m2?: number;           // NBR 6120 — residencial 1,5
+  classe_concreto: 'C20' | 'C25' | 'C30' | 'C35';
+  tipo_solo: 'argiloso_mole' | 'argiloso_medio' | 'arenoso_compacto' | 'rocha';
+  // Pre-dimensionamento parametrico
+  tem_subsolo: boolean;
+  laje_tipo: 'macica' | 'nervurada' | 'pre_moldada';
+}
+
+export interface MemorialEstruturalOutput {
+  pre_dimensionamento: {
+    pilar_secao_min_cm: { b: number; h: number };        // 14×30 mínimo NBR 6118
+    pilar_area_concreto_cm2: number;
+    viga_secao_min_cm: { b: number; h: number };
+    viga_altura_recomendada_cm: number;                  // h ≈ vao/12
+    laje_espessura_min_cm: number;                       // ≥ 8 cm macica
+  };
+  cargas_estimadas: {
+    peso_proprio_estrutura_kn_m2: number;
+    carga_alvenaria_kn_m: number;
+    carga_acidental_kn_m2: number;
+    carga_total_pavimento_kn_m2: number;
+  };
+  fundacao_sugerida: {
+    tipo: 'sapata_corrida' | 'sapata_isolada' | 'radier' | 'estaca_helice' | 'estaca_pre_moldada';
+    tensao_admissivel_solo_kpa: number;
+    area_minima_sapata_m2: number;
+    profundidade_minima_m: number;
+  };
+  concreto: {
+    classe: 'C20' | 'C25' | 'C30' | 'C35';
+    fck_mpa: number;
+    cobrimento_minimo_mm: number;                        // classe agressividade ambiental
+    consumo_estimado_m3: number;                         // volume total
+  };
+  aco: {
+    taxa_kg_m3_concreto: number;                         // residencial ~80 kg/m³
+    consumo_estimado_kg: number;
+  };
+  parametros_aplicados: {
+    coef_seguranca_solo: number;
+    fator_redutor_carga: number;
+  };
+}
+
 // Saida do calculator hidraulico
 export interface MemorialHidraulicoOutput {
   consumo_diario_L: number;
@@ -79,6 +233,13 @@ export interface MemorialHidraulicoOutput {
     reserva_pct: number;
   };
 }
+
+// Saidas tipadas — uniao das 4 disciplinas (Fase 1+2 v3.35.0+v3.48.0).
+export type MemorialOutput =
+  | MemorialHidraulicoOutput
+  | MemorialSanitarioOutput
+  | MemorialEletricoOutput
+  | MemorialEstruturalOutput;
 
 // Snapshot extraido do PDF da planta (Revit). Heuristica pra metadados.
 export interface PdfExtractionResult {

--- a/src/services/memoriais/wizardEngine.ts
+++ b/src/services/memoriais/wizardEngine.ts
@@ -114,14 +114,111 @@ const PERGUNTAS_HIDRAULICO: WizardCampo[] = [
   },
 ];
 
-// Sanitario / Eletrico / Arquitetonico / Estrutural / PCI ficam pra PRs futuros.
+// v3.48.0 — Fase 2: Sanitario (NBR 8160 + 10844), Eletrico (NBR 5410), Estrutural (NBR 6118)
+const PERGUNTAS_SANITARIO: WizardCampo[] = [
+  ...PERGUNTAS_COMUNS,
+  {
+    id: 'area_cobertura_m2',
+    label: 'Area de cobertura (telhado/laje) contribuinte para aguas pluviais (m²)',
+    tipo: 'number', min: 1, required: true,
+  },
+  {
+    id: 'intensidade_pluv_mmh',
+    label: 'Intensidade pluviometrica (mm/h) — default Acailandia/MA = 150',
+    tipo: 'number', default: 150, min: 50, max: 300,
+  },
+  {
+    id: 'destino_efluente',
+    label: 'Destino do efluente',
+    tipo: 'select',
+    opcoes: ['Rede publica', 'Fossa + sumidouro', 'Fossa + filtro anaerobio', 'ETA compacta'],
+    required: true,
+  },
+  {
+    id: 'tem_caixa_gordura',
+    label: 'Possui caixa de gordura?',
+    tipo: 'boolean', default: true,
+  },
+];
+
+const PERGUNTAS_ELETRICO: WizardCampo[] = [
+  ...PERGUNTAS_COMUNS,
+  {
+    id: 'tensao_nominal_v',
+    label: 'Tensao nominal da entrada (V)',
+    tipo: 'select',
+    opcoes: ['127', '220', '380'],
+    default: '220', required: true,
+  },
+  {
+    id: 'tipo_alimentacao',
+    label: 'Tipo de alimentacao',
+    tipo: 'select',
+    opcoes: ['Monofasico', 'Bifasico', 'Trifasico'],
+    default: 'Bifasico', required: true,
+  },
+  {
+    id: 'comprimento_ramal_m',
+    label: 'Comprimento do ramal de entrada (m) — distancia padrao a' + ' rede',
+    tipo: 'number', min: 1, default: 30, required: true,
+  },
+  {
+    id: 'fator_demanda',
+    label: 'Padrao de demanda',
+    tipo: 'select',
+    opcoes: ['Residencial', 'Comercial'],
+    default: 'Residencial', required: true,
+  },
+];
+
+const PERGUNTAS_ESTRUTURAL: WizardCampo[] = [
+  ...PERGUNTAS_COMUNS,
+  {
+    id: 'vao_medio_pilares_m',
+    label: 'Vao medio entre pilares (m)',
+    tipo: 'number', min: 2, max: 12, default: 4, required: true,
+  },
+  {
+    id: 'classe_concreto',
+    label: 'Classe de concreto',
+    tipo: 'select',
+    opcoes: ['C20', 'C25', 'C30', 'C35'],
+    default: 'C25', required: true,
+  },
+  {
+    id: 'tipo_solo',
+    label: 'Tipo de solo (laudo geotecnico ou estimativa regional)',
+    tipo: 'select',
+    opcoes: ['Argiloso mole', 'Argiloso medio', 'Arenoso compacto', 'Rocha'],
+    default: 'Arenoso compacto', required: true,
+  },
+  {
+    id: 'laje_tipo',
+    label: 'Tipo de laje',
+    tipo: 'select',
+    opcoes: ['Macica', 'Nervurada', 'Pre-moldada'],
+    default: 'Macica', required: true,
+  },
+  {
+    id: 'tem_subsolo',
+    label: 'Tem subsolo?',
+    tipo: 'boolean', default: false,
+  },
+  {
+    id: 'carga_acidental_kn_m2',
+    label: 'Carga acidental (kN/m²) — NBR 6120: residencial 1,5 · comercial 2,5',
+    tipo: 'number', min: 1, max: 10, default: 1.5,
+  },
+];
+
+// Placeholder pra disciplinas ainda nao implementadas
 const PLACEHOLDER_EM_BREVE: WizardCampo[] = [
   ...PERGUNTAS_COMUNS,
   {
     id: '_em_breve',
     label: 'Disciplina em desenvolvimento — disponivel em release futura.',
     tipo: 'text',
-    placeholder: 'Disciplina ainda nao implementada (Fase 1 cobre apenas Hidraulico).',
+    placeholder: 'Disciplina ainda nao implementada.',
   },
 ];
 
@@ -130,19 +227,20 @@ export function obterWizardDisciplina(disciplina: DisciplinaMemorial): {
   campos: WizardCampo[];
   disponivel: boolean;
 } {
-  if (disciplina === 'hidraulico') {
-    return { disciplina, campos: PERGUNTAS_HIDRAULICO, disponivel: true };
-  }
+  if (disciplina === 'hidraulico') return { disciplina, campos: PERGUNTAS_HIDRAULICO, disponivel: true };
+  if (disciplina === 'sanitario') return { disciplina, campos: PERGUNTAS_SANITARIO, disponivel: true };
+  if (disciplina === 'eletrico')  return { disciplina, campos: PERGUNTAS_ELETRICO,  disponivel: true };
+  if (disciplina === 'estrutural') return { disciplina, campos: PERGUNTAS_ESTRUTURAL, disponivel: true };
   return { disciplina, campos: PLACEHOLDER_EM_BREVE, disponivel: false };
 }
 
 export function listarDisciplinasDisponiveis(): Array<{ slug: DisciplinaMemorial; rotulo: string; icone: string; norma: string; disponivel: boolean }> {
   return [
-    { slug: 'arquitetonico', rotulo: 'Arquitetonico', icone: '🏛️', norma: 'NBR/SINAPI',  disponivel: false },
-    { slug: 'eletrico',      rotulo: 'Eletrico',      icone: '⚡', norma: 'NBR 5410',    disponivel: false },
-    { slug: 'hidraulico',    rotulo: 'Hidraulico',    icone: '💧', norma: 'NBR 5626',    disponivel: true  },
-    { slug: 'sanitario',     rotulo: 'Sanitario',     icone: '🚽', norma: 'NBR 8160',    disponivel: false },
-    { slug: 'estrutural',    rotulo: 'Estrutural',    icone: '🏗️', norma: 'NBR 6118',    disponivel: false },
-    { slug: 'pci',           rotulo: 'PCI',           icone: '🔥', norma: 'NBR 9077',    disponivel: false },
+    { slug: 'arquitetonico', rotulo: 'Arquitetonico', icone: '[A]', norma: 'NBR/SINAPI',  disponivel: false },
+    { slug: 'eletrico',      rotulo: 'Eletrico',      icone: '[E]', norma: 'NBR 5410',    disponivel: true  },
+    { slug: 'hidraulico',    rotulo: 'Hidraulico',    icone: '[H]', norma: 'NBR 5626',    disponivel: true  },
+    { slug: 'sanitario',     rotulo: 'Sanitario',     icone: '[S]', norma: 'NBR 8160',    disponivel: true  },
+    { slug: 'estrutural',    rotulo: 'Estrutural',    icone: '[Es]', norma: 'NBR 6118',   disponivel: true  },
+    { slug: 'pci',           rotulo: 'PCI',           icone: '[P]', norma: 'NBR 9077',    disponivel: false },
   ];
 }


### PR DESCRIPTION
…-parse 500 (v3.48.0)

Bug-fix critico do user (500 no upload-pdf):
pdf-parse@2.4.5 mudou de funcao default (v1) pra classe PDFParse (v2). Cod antigo: const r = await mod.default(buffer); — falhava em runtime. Cod novo: new mod.PDFParse({data:buffer}).getText() + destroy() em finally.

Fase 2 do modulo Memoriais (apos Hidraulico v3.35.0):

Sanitario (NBR 8160 + NBR 10844 + NBR 7229):
- Esgoto: soma UHC -> DN ramal/queda/coletor
- Pluvial: Q = (i × A)/60 -> calha + condutor vertical
- Fossa septica: V_decant + V_dig + area sumidouro

Eletrico (NBR 5410):
- Carga instalada: ilum/TUG por area + cargas explicitas
- Demanda: fator NBR 5410 Tabela 47 por tipo
- Corrente: I = P/(V×cosfi), √3 trifasico
- Dimensionamento condutor: itera ate queda ≤ 4%
- Disjuntor + DR + DPS + aterramento TN-S

Estrutural (NBR 6118 + NBR 6120 + NBR 6122):
- Pre-dim pilar/viga/laje
- Cargas estimadas (residencial/comercial)
- Fundacao automatica (solo + carga total -> sapata/estaca/radier)
- Concreto + aco (consumos estimados)

Backend: 3 endpoints /calcular (publicos), /criar aceita 4 disciplinas.
Frontend: wizardEngine ganha 3 perguntas-set + listagem expandida.

Tests: 39 novos (13 san + 10 ele + 16 est). Suite 1125 passing. Arquivos sensiveis intocados.