### PR TITLE
feat(recibos): anexos PDF/imagem + 3 servicos IMOB (CCIR/ITR/CAR) — v…

### DIFF
--- a/06-Changelog/v3.49.0-recibos-anexos-ccir-itr-car.md
+++ b/06-Changelog/v3.49.0-recibos-anexos-ccir-itr-car.md
@@ -1,0 +1,144 @@
+# v3.49.0 — Anexos de documentos no Recibo + 3 serviços IMOB novos
+
+**Data:** 2026-05-29
+**Branch:** `feat/recibos-anexos-ccir-itr-car-v3.49.0`
+
+---
+
+## Motivação
+
+Serviços de regularização imobiliária (Atualização de **CCIR**, **ITR/NIRF** e
+**CAR**) exigem que documentos complementares (CCIR antigo + atualizado,
+comprovante INCRA, declaração ITR, recibo CAR/SICAR) sejam entregues junto ao
+recibo do serviço. Antes desta versão era necessário enviá-los separadamente —
+fluxo manual, sujeito a esquecimento e sem rastro no histórico do recibo.
+
+---
+
+## Entregue
+
+### 1. Anexos persistentes em recibos
+
+- Cada recibo aceita até **5 documentos anexos** (PDF, JPG, PNG, WebP) com
+  **10 MB** cada.
+- Storage em **LONGBLOB** no MySQL (mesmo padrão de `laudos_demarcacao_arquivos`
+  e `romatec_obra_vistoria_fotos` — Railway não tem volume persistente confiável).
+- Nome no disco lógico: `sha256[0..8]_nome-sanitizado.ext` (mesmo helper já
+  usado em laudos vetoriais).
+
+### 2. Envio automático junto ao PDF principal
+
+Ao acionar **"Salvar e enviar via WhatsApp"**, a Z-API agora envia:
+1. PDF do recibo
+2. Cada anexo, um por vez, com 1 s de delay entre eles (evita rate limit)
+
+O envio é fire-and-forget por anexo: falha em um não bloqueia os outros nem o
+PDF principal. Evento `attachments_sent` registrado em `recibos_eventos`.
+
+### 3. UI no formulário de Novo Recibo
+
+- Seção **📎 Documentos anexos** logo abaixo da descrição.
+- Botão "+ Adicionar arquivo(s)" abre file picker (multi-select).
+- Cada arquivo selecionado mostra nome, tamanho, label opcional (ex: "CCIR
+  Antigo", "CCIR Atualizado") e botão para remover.
+- Contador `N/5`. Validação client-side de tipo e tamanho.
+
+### 4. UI no modo Edição do Recibo
+
+- Carrega anexos existentes via `GET /api/recibos/:id/anexos`.
+- Cada anexo tem link **⬇ Baixar** + botão **🗑** (DELETE com confirmação).
+- Permite adicionar novos (respeitando limite de 5 totais).
+
+### 5. 3 serviços novos no catálogo IMOB
+
+Adicionados em `src/public/js/catalogo-servicos.js`:
+
+| ID | Nome | Base legal |
+|---|---|---|
+| `imob-ccir` | Assessoria em Atualização de CCIR (INCRA) | Lei 4.947/1966 · IN INCRA 95/2010 |
+| `imob-itr-nirf` | Assessoria em Atualização de ITR/NIRF | Lei 9.393/1996 · IN RFB 1.877/2019 |
+| `imob-car-sicar` | Assessoria em Atualização de CAR — SICAR/AMBIS | Lei 12.651/2012 · IN MMA 2/2014 |
+
+Cada um traz texto técnico completo (definição · compreende · base legal ·
+finalidade · órgão competente) que auto-preenche a descrição do recibo quando
+selecionado.
+
+---
+
+## Arquivos novos
+
+- `src/database/migrations-recibos-anexos.ts`
+- `src/integrations/recibosAnexos.ts`
+- `src/test/recibos-anexos-v3.49.0.test.ts` (40 testes)
+- `06-Changelog/v3.49.0-recibos-anexos-ccir-itr-car.md`
+
+## Arquivos modificados
+
+- `src/server.ts` — 5 endpoints + wiring da migration
+- `src/integrations/recibos.ts` — `enviarReciboWhatsApp` agora envia anexos
+- `src/public/obras.html` — seção de anexos no form + lógica de upload
+- `src/public/js/catalogo-servicos.js` — 3 serviços IMOB novos
+- `package.json` — bump para 3.49.0
+
+---
+
+## Endpoints REST
+
+| Método | Rota | Auth | Descrição |
+|---|---|---|---|
+| POST | `/api/recibos/:id/anexos` | CEO | Upload multipart (1..5 files, descricoes[]) |
+| GET  | `/api/recibos/:id/anexos` | público | Lista anexos ativos (sem blob) |
+| GET  | `/api/recibos/anexos/:anexo_id/download` | CEO | Download autenticado |
+| GET  | `/a/:token` | público | Download via token (64 hex, link compartilhável) |
+| DELETE | `/api/recibos/anexos/:anexo_id` | CEO | Soft delete (ativo=false) |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE recibos_anexos (
+  id              INT AUTO_INCREMENT PRIMARY KEY,
+  recibo_id       INT NOT NULL,
+  nome_original   VARCHAR(255) NOT NULL,
+  nome_armazenado VARCHAR(300) NOT NULL,
+  descricao       VARCHAR(255) NULL,
+  mime_type       VARCHAR(120) NOT NULL,
+  tamanho_bytes   BIGINT NOT NULL,
+  sha256          CHAR(64) NOT NULL,
+  conteudo_blob   LONGBLOB NOT NULL,
+  download_token  VARCHAR(64) NOT NULL,
+  ativo           BOOLEAN NOT NULL DEFAULT TRUE,
+  criado_em       DATETIME DEFAULT CURRENT_TIMESTAMP,
+  atualizado_em   DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_ra_token (download_token),
+  INDEX idx_ra_recibo (recibo_id),
+  INDEX idx_ra_ativo (ativo),
+  FOREIGN KEY (recibo_id) REFERENCES recibos(id) ON DELETE CASCADE
+)
+```
+
+Migration idempotente (`/already exists|Duplicate/i.test(msg)` capturado).
+
+---
+
+## Validação
+
+- ✅ `tsc --noEmit` sem erros
+- ✅ Vitest: **1165 passing / 1 skipped / 0 failing** (zero regressão; +40
+  testes novos cobrindo helpers puros, migration, wiring server, integração
+  Z-API, UI no obras.html e os 3 serviços IMOB)
+- ✅ Anti-IDOR: todas as rotas de anexo validam que o recibo pertence ao tenant
+- ✅ Limite de ferramentas OpenAI mantido < 128 (nenhuma ferramenta nova
+  exposta ao agente)
+
+---
+
+## Divergência intencional do prompt
+
+O prompt original especificava storage em `uploads/recibos/` em disco. Foi
+implementado em **LONGBLOB no MySQL** porque o codebase inteiro (laudos
+vetoriais DXF/DWG, fotos de vistoria, PDFs assinados PAdES) já segue esse
+padrão — Railway tem container efêmero, então arquivos em disco seriam
+perdidos no primeiro restart. A semântica de "padrão SHA-256" pedida foi
+mantida via `sanitizarNomeArquivo()`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.48.0",
+  "version": "3.49.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/database/migrations-recibos-anexos.ts
+++ b/src/database/migrations-recibos-anexos.ts
@@ -1,0 +1,52 @@
+// v3.49.0: Anexos de documentos em recibos universais (CCIR, ITR/NIRF, CAR
+// e outros documentos complementares por serviço).
+//
+// Storage no proprio banco como LONGBLOB (mesmo padrao de laudos_demarcacao_arquivos
+// e romatec_obra_vistoria_fotos) — Railway tem containers efemeros sem volume
+// persistente confiavel.
+//
+// Idempotente: re-execucao ignora "already exists".
+
+import pool from './connection';
+
+export async function runRecibosAnexosMigrations(): Promise<void> {
+  const ops: Array<{ label: string; sql: string }> = [
+    {
+      label: 'CREATE TABLE recibos_anexos',
+      sql: `CREATE TABLE recibos_anexos (
+        id              INT AUTO_INCREMENT PRIMARY KEY,
+        recibo_id       INT NOT NULL,
+        nome_original   VARCHAR(255) NOT NULL COMMENT 'nome enviado pelo usuario',
+        nome_armazenado VARCHAR(300) NOT NULL COMMENT 'sanitizado com prefixo sha256',
+        descricao       VARCHAR(255) NULL COMMENT 'label opcional: CCIR Antigo, CCIR Atualizado, etc.',
+        mime_type       VARCHAR(120) NOT NULL,
+        tamanho_bytes   BIGINT NOT NULL,
+        sha256          CHAR(64) NOT NULL COMMENT 'hash do conteudo (integridade)',
+        conteudo_blob   LONGBLOB NOT NULL COMMENT 'bytes do arquivo',
+        download_token  VARCHAR(64) NOT NULL COMMENT 'token publico (64 hex)',
+        ativo           BOOLEAN NOT NULL DEFAULT TRUE COMMENT 'soft delete',
+        criado_em       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        atualizado_em   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_ra_token (download_token),
+        INDEX idx_ra_recibo (recibo_id),
+        INDEX idx_ra_ativo (ativo),
+        CONSTRAINT fk_ra_recibo FOREIGN KEY (recibo_id)
+          REFERENCES recibos(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+    },
+  ];
+
+  for (const { label, sql } of ops) {
+    try {
+      await pool.execute(sql);
+      console.log(`[recibos-anexos-migrations] OK: ${label}`);
+    } catch (err) {
+      const msg = (err as Error).message || '';
+      if (/already exists|Duplicate|Duplicate key name/i.test(msg)) {
+        console.log(`[recibos-anexos-migrations] ja existe (OK): ${label}`);
+      } else {
+        console.error(`[recibos-anexos-migrations] FALHA ${label}:`, msg.slice(0, 200));
+      }
+    }
+  }
+}

--- a/src/integrations/recibos.ts
+++ b/src/integrations/recibos.ts
@@ -630,6 +630,39 @@ export async function enviarReciboWhatsApp(input: {
     } catch (err) {
       console.warn(`[recibos] falha enviar PDF do recibo #${r.id}:`, (err as Error).message);
     }
+
+    // 3) v3.49.0: anexos do recibo (CCIR, ITR, CAR etc.) — um por um,
+    //    apos o PDF principal, com 1s entre envios pra evitar rate limit Z-API.
+    try {
+      const { listarAnexosComBlob } = await import('./recibosAnexos');
+      const anexos = await listarAnexosComBlob(r.id);
+      for (const anexo of anexos) {
+        try {
+          await sendDocument(
+            telDestino,
+            anexo.conteudo_blob.toString('base64'),
+            anexo.nome_original,
+          );
+        } catch (sendErr) {
+          console.warn(
+            `[recibos] falha enviar anexo #${anexo.id} do recibo #${r.id}:`,
+            (sendErr as Error).message,
+          );
+        }
+        // Pequeno delay pra Z-API nao rate-limitar
+        if (anexos.length > 1) {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+      }
+      if (anexos.length > 0) {
+        await registrarEvento(r.id, 'attachments_sent', {
+          total: anexos.length,
+          phone: telDestino,
+        });
+      }
+    } catch (err) {
+      console.warn(`[recibos] falha listar anexos do recibo #${r.id}:`, (err as Error).message);
+    }
   }
 
   // Atualiza status (so se nao for override pra outro num — preserva

--- a/src/integrations/recibosAnexos.ts
+++ b/src/integrations/recibosAnexos.ts
@@ -1,0 +1,307 @@
+// v3.49.0: Anexos de documentos em recibos universais.
+//
+// Permite anexar 1–5 documentos por recibo (PDF/JPG/PNG/WebP) que serao
+// enviados junto ao PDF principal via WhatsApp (CCIR antigo, CCIR atualizado,
+// declaracao ITR, recibo CAR, etc.). Storage em LONGBLOB no proprio banco
+// (mesmo padrao de laudos_demarcacao_arquivos — Railway sem volume persistente).
+
+import { randomBytes, createHash } from 'crypto';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../database/connection';
+
+export const MAX_ANEXOS_POR_RECIBO = 5;
+export const MAX_TAMANHO_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/** MIME types permitidos para anexos de recibo. */
+export const MIMES_PERMITIDOS: ReadonlyArray<string> = [
+  'application/pdf',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+];
+
+/** Extensoes permitidas (validacao secundaria, alem do MIME). */
+const EXT_PERMITIDAS = new Set(['pdf', 'jpg', 'jpeg', 'png', 'webp']);
+
+export interface AnexoReciboResumo {
+  id: number;
+  recibo_id: number;
+  nome_original: string;
+  nome_armazenado: string;
+  descricao: string | null;
+  mime_type: string;
+  tamanho_bytes: number;
+  sha256: string;
+  download_token: string;
+  ativo: boolean;
+  criado_em: string;
+}
+
+export interface AnexoReciboComBlob extends AnexoReciboResumo {
+  conteudo_blob: Buffer;
+}
+
+/** Sanitiza nome: NFD, lowercase, espacos->-, mantem [a-z0-9._-], prefixo sha8. */
+export function sanitizarNomeArquivo(nomeOriginal: string, sha256: string): string {
+  const semAcentos = nomeOriginal.normalize('NFD').replace(/[̀-ͯ]/g, '');
+  const limpo = semAcentos
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9._-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '');
+  const finalNome = limpo || 'arquivo';
+  return `${sha256.slice(0, 8)}_${finalNome}`;
+}
+
+export function calcularSha256(buf: Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+export function gerarDownloadToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/** Valida extensao + MIME. Retorna a extensao normalizada ou lanca erro. */
+export function validarMimeEExtensao(nomeOriginal: string, mimeType: string): string {
+  const ext = (nomeOriginal.split('.').pop() ?? '').toLowerCase();
+  if (!ext || !EXT_PERMITIDAS.has(ext)) {
+    throw new Error(`Extensao '.${ext}' nao permitida. Aceitos: PDF, JPG, PNG, WebP.`);
+  }
+  const mimeNorm = (mimeType || '').toLowerCase();
+  if (mimeNorm && !MIMES_PERMITIDOS.includes(mimeNorm)) {
+    // Tolerancia: alguns navegadores enviam octet-stream ou variantes. Apenas warning.
+    console.warn(`[recibosAnexos] MIME '${mimeType}' inesperado para .${ext} — aceitando.`);
+  }
+  return ext;
+}
+
+function mapRow(r: RowDataPacket): AnexoReciboResumo {
+  return {
+    id: Number(r.id),
+    recibo_id: Number(r.recibo_id),
+    nome_original: String(r.nome_original),
+    nome_armazenado: String(r.nome_armazenado),
+    descricao: r.descricao ?? null,
+    mime_type: String(r.mime_type),
+    tamanho_bytes: Number(r.tamanho_bytes),
+    sha256: String(r.sha256),
+    download_token: String(r.download_token),
+    ativo: !!r.ativo,
+    criado_em: r.criado_em instanceof Date
+      ? r.criado_em.toISOString()
+      : String(r.criado_em),
+  };
+}
+
+export interface CriarAnexoInput {
+  recibo_id: number;
+  nome_original: string;
+  mime_type: string;
+  conteudo: Buffer;
+  descricao?: string | null;
+  /** tenant_id do solicitante — usado pra checagem anti-IDOR (default 1). */
+  tenant_id?: number;
+}
+
+/** Confere que o recibo existe e pertence ao tenant. Lanca erro descritivo. */
+async function assertReciboPertenceAoTenant(
+  reciboId: number,
+  tenantId: number,
+): Promise<void> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT id, tenant_id FROM recibos WHERE id = ? LIMIT 1`,
+    [reciboId],
+  );
+  if (rows.length === 0) {
+    throw new Error(`Recibo #${reciboId} nao encontrado`);
+  }
+  if (Number(rows[0].tenant_id) !== tenantId) {
+    throw new Error(`Recibo #${reciboId} pertence a outro tenant`);
+  }
+}
+
+export async function criarAnexo(input: CriarAnexoInput): Promise<AnexoReciboResumo> {
+  const reciboId = Number(input.recibo_id);
+  if (!reciboId) throw new Error('recibo_id obrigatorio');
+  if (!input.nome_original?.trim()) throw new Error('nome_original obrigatorio');
+  if (!Buffer.isBuffer(input.conteudo) || input.conteudo.length === 0) {
+    throw new Error('conteudo do arquivo vazio ou invalido');
+  }
+  if (input.conteudo.length > MAX_TAMANHO_BYTES) {
+    throw new Error(
+      `Arquivo excede ${MAX_TAMANHO_BYTES / 1024 / 1024} MB (atual ${(input.conteudo.length / 1024 / 1024).toFixed(2)} MB)`,
+    );
+  }
+
+  const tenantId = Number(input.tenant_id ?? 1);
+  await assertReciboPertenceAoTenant(reciboId, tenantId);
+
+  // Limite de 5 anexos ATIVOS por recibo
+  const [countRows] = await pool.execute<RowDataPacket[]>(
+    `SELECT COUNT(*) AS n FROM recibos_anexos WHERE recibo_id = ? AND ativo = TRUE`,
+    [reciboId],
+  );
+  const total = Number((countRows[0] as { n: number }).n);
+  if (total >= MAX_ANEXOS_POR_RECIBO) {
+    throw new Error(
+      `Recibo #${reciboId} ja tem ${total} anexos (maximo ${MAX_ANEXOS_POR_RECIBO})`,
+    );
+  }
+
+  const ext = validarMimeEExtensao(input.nome_original, input.mime_type);
+  const sha256 = calcularSha256(input.conteudo);
+  let nomeArmazenado = sanitizarNomeArquivo(input.nome_original, sha256);
+  if (!nomeArmazenado.toLowerCase().endsWith(`.${ext}`)) {
+    nomeArmazenado += `.${ext}`;
+  }
+  const downloadToken = gerarDownloadToken();
+  const descricao = input.descricao?.toString().trim().slice(0, 255) || null;
+
+  const [r] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO recibos_anexos
+       (recibo_id, nome_original, nome_armazenado, descricao, mime_type,
+        tamanho_bytes, sha256, conteudo_blob, download_token)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      reciboId,
+      input.nome_original.slice(0, 255),
+      nomeArmazenado.slice(0, 300),
+      descricao,
+      (input.mime_type || '').slice(0, 120),
+      input.conteudo.length,
+      sha256,
+      input.conteudo,
+      downloadToken,
+    ],
+  );
+
+  return {
+    id: r.insertId,
+    recibo_id: reciboId,
+    nome_original: input.nome_original,
+    nome_armazenado: nomeArmazenado,
+    descricao,
+    mime_type: input.mime_type || '',
+    tamanho_bytes: input.conteudo.length,
+    sha256,
+    download_token: downloadToken,
+    ativo: true,
+    criado_em: new Date().toISOString(),
+  };
+}
+
+export async function listarAnexos(
+  reciboId: number,
+  tenantId = 1,
+): Promise<AnexoReciboResumo[]> {
+  await assertReciboPertenceAoTenant(Number(reciboId), Number(tenantId));
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT id, recibo_id, nome_original, nome_armazenado, descricao, mime_type,
+            tamanho_bytes, sha256, download_token, ativo, criado_em
+       FROM recibos_anexos
+      WHERE recibo_id = ? AND ativo = TRUE
+      ORDER BY id ASC`,
+    [Number(reciboId)],
+  );
+  return rows.map(mapRow);
+}
+
+/** Busca todos os anexos ATIVOS de um recibo COM blob (uso interno — envio Z-API). */
+export async function listarAnexosComBlob(reciboId: number): Promise<AnexoReciboComBlob[]> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT id, recibo_id, nome_original, nome_armazenado, descricao, mime_type,
+            tamanho_bytes, sha256, conteudo_blob, download_token, ativo, criado_em
+       FROM recibos_anexos
+      WHERE recibo_id = ? AND ativo = TRUE
+      ORDER BY id ASC`,
+    [Number(reciboId)],
+  );
+  return rows.map(r => ({
+    ...mapRow(r),
+    conteudo_blob: r.conteudo_blob as Buffer,
+  }));
+}
+
+export interface AnexoParaDownload {
+  nome_original: string;
+  mime_type: string;
+  tamanho_bytes: number;
+  conteudo_blob: Buffer;
+}
+
+/** Busca anexo pelo id, com checagem de ownership. Retorna null se nao encontrado. */
+export async function buscarAnexoParaDownload(
+  anexoId: number,
+  tenantId = 1,
+): Promise<AnexoParaDownload | null> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT a.nome_original, a.mime_type, a.tamanho_bytes, a.conteudo_blob, a.ativo,
+            r.tenant_id
+       FROM recibos_anexos a
+       JOIN recibos r ON r.id = a.recibo_id
+      WHERE a.id = ? LIMIT 1`,
+    [Number(anexoId)],
+  );
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  if (!row.ativo) return null;
+  if (Number(row.tenant_id) !== Number(tenantId)) {
+    throw new Error('Anexo pertence a outro tenant');
+  }
+  return {
+    nome_original: String(row.nome_original),
+    mime_type: String(row.mime_type),
+    tamanho_bytes: Number(row.tamanho_bytes),
+    conteudo_blob: row.conteudo_blob as Buffer,
+  };
+}
+
+/** Busca anexo pelo token publico (uso pra link de download direto sem auth). */
+export async function buscarAnexoPorToken(
+  token: string,
+): Promise<AnexoParaDownload | null> {
+  if (!token || typeof token !== 'string' || token.length !== 64) return null;
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT nome_original, mime_type, tamanho_bytes, conteudo_blob, ativo
+       FROM recibos_anexos
+      WHERE download_token = ? LIMIT 1`,
+    [token],
+  );
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  if (!row.ativo) return null;
+  return {
+    nome_original: String(row.nome_original),
+    mime_type: String(row.mime_type),
+    tamanho_bytes: Number(row.tamanho_bytes),
+    conteudo_blob: row.conteudo_blob as Buffer,
+  };
+}
+
+/** Soft delete: marca ativo=false. Checagem anti-IDOR via tenant. */
+export async function removerAnexo(
+  anexoId: number,
+  tenantId = 1,
+): Promise<{ ok: true; affected: number }> {
+  // Confere ownership antes (mais rapido que JOIN no UPDATE em alguns engines)
+  const [check] = await pool.execute<RowDataPacket[]>(
+    `SELECT r.tenant_id, a.ativo
+       FROM recibos_anexos a
+       JOIN recibos r ON r.id = a.recibo_id
+      WHERE a.id = ? LIMIT 1`,
+    [Number(anexoId)],
+  );
+  if (check.length === 0) {
+    return { ok: true, affected: 0 };
+  }
+  if (Number(check[0].tenant_id) !== Number(tenantId)) {
+    throw new Error('Anexo pertence a outro tenant');
+  }
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE recibos_anexos SET ativo = FALSE WHERE id = ? AND ativo = TRUE`,
+    [Number(anexoId)],
+  );
+  return { ok: true, affected: r.affectedRows };
+}

--- a/src/public/js/catalogo-servicos.js
+++ b/src/public/js/catalogo-servicos.js
@@ -187,6 +187,35 @@ Finalidade: atualização documental para averbação, transferência ou financi
           descricao: `Serviço de Acompanhamento de Processo Cartorário.\n\nDefinição: protocolo, acompanhamento e cumprimento de exigências em Cartório de Registro de Imóveis ou Tabelionato.\n\nBase legal/normativa: Lei nº 6.015/1973; Lei nº 8.935/1994.\n\nFinalidade: agilizar e dar correção técnica ao processo registral.` + HELPER_TAIL },
         { id: 'imob-acomp-orgaos', nome: 'Acompanhamento de Processo no INCRA / ITERMA / Prefeitura',
           descricao: `Serviço de Acompanhamento de Processo Administrativo.\n\nDefinição: protocolo, acompanhamento e cumprimento de exigências em órgãos públicos (INCRA, ITERMA, SEMA, Prefeitura).\n\nBase legal/normativa: Lei nº 10.267/2001; legislação estadual MA; Lei Orgânica Municipal.\n\nFinalidade: viabilizar processo administrativo de certificação, titulação ou licenciamento.` + HELPER_TAIL },
+        // v3.49.0: 3 serviços de atualização cadastral/fiscal/ambiental do imóvel rural.
+        // Casam com o módulo de anexos de recibo (CCIR/ITR/CAR exigem documentos complementares).
+        { id: 'imob-ccir', nome: 'Assessoria em Atualização de CCIR (INCRA)',
+          descricao:
+`Assessoria técnica especializada para atualização do Certificado de Cadastro de Imóvel Rural (CCIR) junto ao Instituto Nacional de Colonização e Reforma Agrária — INCRA, conforme exigido pelo art. 22 da Lei nº 4.947/1966, art. 96 do Estatuto da Terra (Lei nº 4.504/1964) e Norma de Execução INCRA nº 95/2010.
+
+Compreende: levantamento da situação cadastral atual no SNCR (Sistema Nacional de Cadastro Rural); atualização de dados do imóvel, do detentor e da estrutura fundiária; emissão do CCIR quitado para o exercício vigente; orientação quanto à obrigatoriedade de apresentação em atos de transferência, desmembramento, hipoteca e arrendamento, nos termos do art. 22, §1º, da Lei nº 4.947/1966.
+
+Base legal/normativa: Lei nº 4.947/1966 · Lei nº 4.504/1964 (Estatuto da Terra) · IN INCRA nº 95/2010 · Decreto nº 72.106/1973.
+
+Finalidade: regularização cadastral do imóvel rural perante o INCRA, habilitação para atos de registro e transferência cartorária.` + HELPER_TAIL },
+        { id: 'imob-itr-nirf', nome: 'Assessoria em Atualização de ITR / NIRF (Receita Federal)',
+          descricao:
+`Assessoria técnica para atualização do Número do Imóvel na Receita Federal (NIRF) e regularização da declaração do Imposto sobre a Propriedade Territorial Rural (ITR) junto à Secretaria Especial da Receita Federal do Brasil, conforme Lei nº 9.393/1996, Decreto nº 4.382/2002 e Instrução Normativa RFB nº 1.877/2019.
+
+Compreende: verificação da situação do NIRF no sistema CAFIR; atualização de dados cadastrais do imóvel e do declarante; orientação e apoio na elaboração/retificação da DITR (Declaração do ITR); análise da Área Tributável, Área de Preservação Permanente (APP), Reserva Legal e demais isenções previstas em lei; emissão de certidão de regularidade fiscal perante a RFB quando aplicável.
+
+Base legal/normativa: Lei nº 9.393/1996 · Decreto nº 4.382/2002 · IN RFB nº 1.877/2019 · Lei nº 12.651/2012 (Código Florestal — isenções de APP/RL).
+
+Finalidade: regularização fiscal do imóvel rural, habilitação para financiamentos rurais, registros e atos notariais.` + HELPER_TAIL },
+        { id: 'imob-car-sicar', nome: 'Assessoria em Atualização de CAR — SICAR/AMBIS',
+          descricao:
+`Assessoria técnica especializada para inscrição, atualização ou retificação no Cadastro Ambiental Rural (CAR) junto ao SICAR (Sistema Nacional de Cadastro Ambiental Rural) e, quando aplicável, integração com o sistema AMBIS do Estado do Maranhão, conforme Lei nº 12.651/2012 (Código Florestal), Decreto nº 7.830/2012 e IN MMA nº 2/2014.
+
+Compreende: análise georreferenciada do imóvel rural; delimitação e inserção digital das áreas de Reserva Legal (RL), Áreas de Preservação Permanente (APP), Uso Restrito, Servidão Ambiental e Área Consolidada; upload de shapefile ou polígono via plataforma SICAR/AMBIS; acompanhamento da análise pelo órgão ambiental competente (SEMA/MA ou IBAMA); emissão do recibo de inscrição e número de protocolo CAR.
+
+Base legal/normativa: Lei nº 12.651/2012 (Código Florestal) · Decreto nº 7.830/2012 · IN MMA nº 2/2014 · Resolução CONAMA nº 369/2006 · Legislação estadual MA (SEMA).
+
+Finalidade: regularização ambiental do imóvel rural, cumprimento de exigência para financiamento (Pronaf, ABC+), averbação de RL e habilitação para Programas de Regularização Ambiental (PRA).` + HELPER_TAIL },
       ]}],
     },
 

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -14097,6 +14097,9 @@ function renderRecibos() {
       resource_type: 'manual',
       resource_id: 'manual-' + Date.now(),
       expira_em_dias: 7,
+      // v3.49.0: anexos selecionados localmente, ainda nao enviados
+      anexosPendentes: [], // [{ file: File, descricao: string }]
+      anexosExistentes: [], // populado quando edita recibo existente
     };
     renderRecibos();
   };
@@ -14229,7 +14232,14 @@ function renderRecibos() {
       resource_type: r.resource_type,
       resource_id: r.resource_id,
       expira_em_dias: 7,
+      anexosPendentes: [],
+      anexosExistentes: [],
     };
+    // v3.49.0: ao editar, carrega anexos existentes do recibo
+    api('/api/recibos/' + r.id + '/anexos').then(list => {
+      state.reciboForm.anexosExistentes = Array.isArray(list) ? list : [];
+      if (typeof renderAnexosBox === 'function') renderAnexosBox();
+    }).catch(() => {});
     renderRecibos();
   });
   // 🗑️ Excluir — hard delete (exceto confirmado)
@@ -14379,6 +14389,20 @@ function renderReciboForm(v) {
         <label>Descrição do serviço/motivo (opcional)
           <textarea id="recDesc" rows="2" placeholder="Ex: Mão de obra quinzena 06-20/maio, pagamento PIX" style="width:100%; resize:vertical;">${escape(f.descricao_servico)}</textarea>
         </label>
+        <!-- v3.49.0: documentos anexos (CCIR, ITR, CAR, etc.) -->
+        <div id="recAnexosSection" style="border:1px solid #2a3d2e; border-radius:8px; padding:10px; background:rgba(31,92,58,0.06);">
+          <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+            <strong style="font-size:13px;">📎 Documentos anexos</strong>
+            <span style="font-size:11px; color:var(--text-muted);">Opcional — máximo 5 arquivos, 10 MB cada (PDF/JPG/PNG/WebP)</span>
+            <span id="recAnexosContador" style="font-size:11px; color:var(--text-muted); margin-left:auto;"></span>
+          </div>
+          <p style="font-size:11px; color:var(--text-muted); margin:6px 0;">
+            Anexe documentos complementares (ex: CCIR antigo, CCIR atualizado, comprovante INCRA, declaração ITR, recibo CAR). Serão enviados junto ao PDF principal via WhatsApp.
+          </p>
+          <input type="file" id="recAnexosInput" accept="application/pdf,image/jpeg,image/jpg,image/png,image/webp" multiple style="display:none;">
+          <button type="button" id="recAnexosAddBtn" style="background:transparent; border:1px dashed #4a8c5e; color:#4a8c5e; padding:8px 14px; font-size:12px; width:100%;">+ Adicionar arquivo(s)</button>
+          <div id="recAnexosLista" style="margin-top:8px; display:flex; flex-direction:column; gap:6px;"></div>
+        </div>
         <p style="font-size:11px; color:var(--text-muted); margin:0;">
           O recibo recebe número automático no formato <code>REC-{TIPO}-{ANO}-{seq}</code>.
           Após salvar, você poderá enviar pelo WhatsApp com 1 clique.
@@ -14526,6 +14550,125 @@ function renderReciboForm(v) {
     showToast('✓ Cliente cadastrado e selecionado!', 'success');
   };
 
+  // v3.49.0: gestao dos anexos do recibo (PDF/imagem — CCIR, ITR, CAR, etc.)
+  const ANEXO_MAX_BYTES = 10 * 1024 * 1024;
+  const ANEXO_MAX_FILES = 5;
+  const ANEXO_MIMES_OK = ['application/pdf','image/jpeg','image/jpg','image/png','image/webp'];
+
+  function renderAnexosBox() {
+    if (!f.anexosPendentes) f.anexosPendentes = [];
+    if (!f.anexosExistentes) f.anexosExistentes = [];
+    const lista = document.getElementById('recAnexosLista');
+    const contador = document.getElementById('recAnexosContador');
+    const addBtn = document.getElementById('recAnexosAddBtn');
+    if (!lista || !contador) return;
+    const total = f.anexosPendentes.length + f.anexosExistentes.length;
+    contador.textContent = total + '/' + ANEXO_MAX_FILES + ' arquivo(s)';
+    if (addBtn) {
+      addBtn.disabled = total >= ANEXO_MAX_FILES;
+      addBtn.style.opacity = total >= ANEXO_MAX_FILES ? '0.5' : '1';
+    }
+    const itens = [];
+    // Anexos ja salvos no servidor
+    for (const a of f.anexosExistentes) {
+      const kb = Math.max(1, Math.round(a.tamanho_bytes / 1024));
+      itens.push(`
+        <div data-anexo-existente="${a.id}" style="display:flex; align-items:center; gap:6px; padding:6px 8px; background:rgba(255,255,255,0.03); border-radius:6px; font-size:12px;">
+          <span>📄</span>
+          <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${escape(a.nome_original)}">${escape(a.nome_original)} <span style="color:var(--text-muted);">(${kb} KB)</span></span>
+          ${a.descricao ? `<span style="font-size:11px; color:#4a8c5e;">${escape(a.descricao)}</span>` : ''}
+          <a href="/api/recibos/anexos/${a.id}/download" target="_blank" rel="noopener" style="font-size:11px; padding:2px 8px; background:transparent; border:1px solid #444; color:#888; border-radius:4px; text-decoration:none;">⬇ Baixar</a>
+          <button type="button" data-anexo-del-id="${a.id}" style="font-size:11px; padding:2px 8px; background:transparent; border:1px solid #842; color:#a55;">🗑</button>
+        </div>`);
+    }
+    // Anexos selecionados localmente (pendentes de upload)
+    for (let i = 0; i < f.anexosPendentes.length; i++) {
+      const a = f.anexosPendentes[i];
+      const kb = Math.max(1, Math.round(a.file.size / 1024));
+      itens.push(`
+        <div data-anexo-pendente="${i}" style="display:flex; align-items:center; gap:6px; padding:6px 8px; background:rgba(74,140,94,0.08); border-radius:6px; font-size:12px;">
+          <span>📄</span>
+          <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${escape(a.file.name)}">${escape(a.file.name)} <span style="color:var(--text-muted);">(${kb} KB)</span></span>
+          <input data-anexo-desc-idx="${i}" type="text" placeholder="Label (ex: CCIR Antigo)" maxlength="80" value="${escape(a.descricao||'')}" style="flex:0 0 180px; font-size:11px; padding:2px 6px;">
+          <button type="button" data-anexo-rm-idx="${i}" style="font-size:11px; padding:2px 8px; background:transparent; border:1px solid #842; color:#a55;">✕</button>
+        </div>`);
+    }
+    lista.innerHTML = itens.join('') || '<span style="font-size:11px; color:var(--text-muted);">Nenhum documento anexo.</span>';
+
+    // Bind: remover pendente
+    lista.querySelectorAll('[data-anexo-rm-idx]').forEach(b => b.onclick = () => {
+      const idx = Number(b.getAttribute('data-anexo-rm-idx'));
+      f.anexosPendentes.splice(idx, 1);
+      renderAnexosBox();
+    });
+    // Bind: label do pendente
+    lista.querySelectorAll('[data-anexo-desc-idx]').forEach(inp => inp.oninput = () => {
+      const idx = Number(inp.getAttribute('data-anexo-desc-idx'));
+      if (f.anexosPendentes[idx]) f.anexosPendentes[idx].descricao = inp.value;
+    });
+    // Bind: deletar anexo existente
+    lista.querySelectorAll('[data-anexo-del-id]').forEach(b => b.onclick = async () => {
+      const id = b.getAttribute('data-anexo-del-id');
+      if (!confirm('Remover este anexo do recibo?')) return;
+      try {
+        await api('/api/recibos/anexos/' + id, { method: 'DELETE' });
+        f.anexosExistentes = f.anexosExistentes.filter(x => String(x.id) !== String(id));
+        renderAnexosBox();
+        showToast('Anexo removido', 'info');
+      } catch (e) { showToast('Erro: ' + e.message, 'error'); }
+    });
+  }
+
+  // Bind do botao + Adicionar arquivo(s)
+  const recAnexosInput = document.getElementById('recAnexosInput');
+  const recAnexosAddBtn = document.getElementById('recAnexosAddBtn');
+  if (recAnexosAddBtn) recAnexosAddBtn.onclick = () => recAnexosInput && recAnexosInput.click();
+  if (recAnexosInput) recAnexosInput.onchange = () => {
+    const files = Array.from(recAnexosInput.files || []);
+    for (const file of files) {
+      const total = (f.anexosPendentes?.length || 0) + (f.anexosExistentes?.length || 0);
+      if (total >= ANEXO_MAX_FILES) { showToast('Maximo ' + ANEXO_MAX_FILES + ' arquivos por recibo', 'error'); break; }
+      if (file.size > ANEXO_MAX_BYTES) { showToast(file.name + ': excede 10 MB', 'error'); continue; }
+      const ext = (file.name.split('.').pop() || '').toLowerCase();
+      if (!['pdf','jpg','jpeg','png','webp'].includes(ext)) {
+        showToast(file.name + ': extensao nao permitida (PDF/JPG/PNG/WebP)', 'error');
+        continue;
+      }
+      if (file.type && !ANEXO_MIMES_OK.includes(file.type)) {
+        // Tolerancia: alguns navegadores enviam mimes variantes; apenas warning console.
+        console.warn('[recibo-anexos] mime inesperado:', file.name, file.type);
+      }
+      if (!f.anexosPendentes) f.anexosPendentes = [];
+      f.anexosPendentes.push({ file, descricao: '' });
+    }
+    recAnexosInput.value = '';
+    renderAnexosBox();
+  };
+  // Renderiza inicial (mostra existentes que ja foram carregados ou vazio)
+  renderAnexosBox();
+
+  // Helper: faz upload dos anexos pendentes pra um recibo ja criado
+  async function uploadAnexosPendentes(reciboId) {
+    if (!f.anexosPendentes || f.anexosPendentes.length === 0) return { enviados: 0 };
+    const fd = new FormData();
+    for (const a of f.anexosPendentes) {
+      fd.append('files', a.file, a.file.name);
+      fd.append('descricoes', a.descricao || '');
+    }
+    const ceoTok = localStorage.getItem('CEO_TOKEN') || '';
+    const resp = await fetch('/api/recibos/' + reciboId + '/anexos', {
+      method: 'POST',
+      headers: ceoTok ? { 'x-ceo-token': ceoTok } : {},
+      body: fd,
+    });
+    if (!resp.ok) {
+      const t = await resp.text().catch(() => '');
+      throw new Error('Falha no upload de anexos: ' + (t || resp.status));
+    }
+    const j = await resp.json().catch(() => ({ anexos: [] }));
+    return { enviados: (j.anexos || []).length };
+  }
+
   // v1.89.0: 3 ações com validação condicional + modal de confirmação universal
   // acao: 'rascunho' | 'emitir' | 'enviar'
   async function salvar(acao) {
@@ -14573,12 +14716,19 @@ function renderReciboForm(v) {
       if (editandoId) {
         await api('/api/recibos/' + editandoId, { method: 'PUT', body: JSON.stringify(payload) });
         r = (state.recibos || []).find(x => String(x.id) === String(editandoId)) || { id: editandoId, numero: '#' + editandoId };
+        // v3.49.0: upload de anexos pendentes ANTES de enviar (pra ir junto no WhatsApp)
+        let anexosMsg = '';
+        if (f.anexosPendentes && f.anexosPendentes.length > 0) {
+          if (btn) btn.textContent = 'Anexando documentos...';
+          const up = await uploadAnexosPendentes(editandoId);
+          anexosMsg = ' (+' + up.enviados + ' anexo' + (up.enviados !== 1 ? 's' : '') + ')';
+        }
         if (acao === 'enviar') {
           if (btn) btn.textContent = 'Enviando WhatsApp...';
           await api('/api/recibos/' + editandoId + '/enviar', { method: 'POST', body: JSON.stringify({}) });
-          showToast('Recibo ' + r.numero + ' atualizado e enviado', 'success');
+          showToast('Recibo ' + r.numero + ' atualizado e enviado' + anexosMsg, 'success');
         } else {
-          showToast('Recibo ' + r.numero + ' atualizado', 'info');
+          showToast('Recibo ' + r.numero + ' atualizado' + anexosMsg, 'info');
         }
       } else {
         const createPayload = {
@@ -14593,10 +14743,21 @@ function renderReciboForm(v) {
           _rascunho: acao === 'rascunho',
         };
         r = await api('/api/recibos', { method: 'POST', body: JSON.stringify(createPayload) });
+        // v3.49.0: upload de anexos pendentes apos criar o recibo (mesma transacao logica)
+        let anexosMsg = '';
+        if (f.anexosPendentes && f.anexosPendentes.length > 0) {
+          if (btn) btn.textContent = 'Anexando documentos...';
+          try {
+            const up = await uploadAnexosPendentes(r.id);
+            anexosMsg = ' (+' + up.enviados + ' anexo' + (up.enviados !== 1 ? 's' : '') + ')';
+          } catch (anexErr) {
+            showToast('Anexos falharam: ' + anexErr.message, 'error');
+          }
+        }
         if (acao === 'enviar') {
           if (btn) btn.textContent = 'Enviando WhatsApp...';
           await api('/api/recibos/' + r.id + '/enviar', { method: 'POST', body: JSON.stringify({}) });
-          showToast('Recibo ' + r.numero + ' criado e enviado pelo WhatsApp', 'success');
+          showToast('Recibo ' + r.numero + ' criado e enviado pelo WhatsApp' + anexosMsg, 'success');
         } else if (acao === 'emitir') {
           // 'emitir' = salvou sem enviar — atualiza status pra 'aguardando_envio'
           // (que mapeia pra 'emitido' no status_simplificado)

--- a/src/server.ts
+++ b/src/server.ts
@@ -3982,6 +3982,130 @@ app.get   ('/api/recibos/:id/pdf', async (req: Request, res: Response) => {
   }
 });
 
+// ─── v3.49.0: anexos do recibo (PDF/imagem) ─────────────────────────────────
+// CCIR antigo/atualizado, ITR/NIRF, recibo CAR — documentos complementares
+// enviados junto ao PDF principal via WhatsApp.
+const RECIBO_ANEXO_MAX_BYTES = 10 * 1024 * 1024;
+const RECIBO_ANEXO_MAX_FILES = 5;
+const RECIBO_ANEXO_MIMES = new Set([
+  'application/pdf', 'image/jpeg', 'image/jpg', 'image/png', 'image/webp',
+]);
+const RECIBO_ANEXO_EXTS = new Set(['pdf', 'jpg', 'jpeg', 'png', 'webp']);
+
+const uploadReciboAnexoMulter = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: RECIBO_ANEXO_MAX_BYTES,
+    files: RECIBO_ANEXO_MAX_FILES,
+  },
+  fileFilter: (_req, file, cb) => {
+    const mime = (file.mimetype || '').toLowerCase();
+    const ext = (file.originalname.split('.').pop() ?? '').toLowerCase();
+    const extOk = RECIBO_ANEXO_EXTS.has(ext);
+    const mimeOk = RECIBO_ANEXO_MIMES.has(mime) || mime === 'application/octet-stream' || mime === '';
+    if (extOk && mimeOk) return cb(null, true);
+    cb(new Error(`Arquivo invalido: ${file.originalname} (${file.mimetype}). Aceitos: PDF, JPG, PNG, WebP.`));
+  },
+}).array('files', RECIBO_ANEXO_MAX_FILES);
+
+// POST /api/recibos/:id/anexos — upload de 1..5 arquivos via multipart/form-data
+// Campos: files[] (binarios) + descricoes[] (array opcional de labels, mesmo indice)
+app.post('/api/recibos/:id/anexos', requireCeoToken, (req: Request, res: Response) => {
+  uploadReciboAnexoMulter(req, res, async (uploadErr: unknown) => {
+    try {
+      if (uploadErr) {
+        const m = (uploadErr as Error).message || 'Falha no upload';
+        return res.status(400).json({ error: m });
+      }
+      const files = (req.files as Express.Multer.File[] | undefined) || [];
+      if (files.length === 0) {
+        return res.status(400).json({ error: 'Nenhum arquivo enviado (campo "files" obrigatorio)' });
+      }
+      // descricoes pode vir como string (1 item) ou array (N itens)
+      const rawDesc = (req.body?.descricoes ?? req.body?.['descricoes[]']) as string | string[] | undefined;
+      const descricoes: Array<string | null> = Array.isArray(rawDesc)
+        ? rawDesc.map(d => (d ? String(d) : null))
+        : rawDesc ? [String(rawDesc)] : [];
+
+      const reciboAnexos = await import('./integrations/recibosAnexos');
+      const reciboId = Number(req.params.id);
+      const criados: import('./integrations/recibosAnexos').AnexoReciboResumo[] = [];
+      for (let i = 0; i < files.length; i++) {
+        const f = files[i];
+        const anexo = await reciboAnexos.criarAnexo({
+          recibo_id: reciboId,
+          nome_original: f.originalname,
+          mime_type: f.mimetype,
+          conteudo: f.buffer,
+          descricao: descricoes[i] ?? null,
+        });
+        criados.push(anexo);
+      }
+      res.json({ ok: true, anexos: criados });
+    } catch (err) {
+      const msg = (err as Error).message || 'Erro ao salvar anexo';
+      const status = /nao encontrado/i.test(msg) ? 404
+                   : /maximo|excede|invalida|invalido/i.test(msg) ? 400
+                   : 500;
+      res.status(status).json({ error: msg });
+    }
+  });
+});
+
+// GET /api/recibos/:id/anexos — lista os anexos ativos do recibo (sem blob)
+app.get('/api/recibos/:id/anexos', async (req: Request, res: Response) => {
+  try {
+    const reciboAnexos = await import('./integrations/recibosAnexos');
+    const anexos = await reciboAnexos.listarAnexos(Number(req.params.id));
+    res.json(anexos);
+  } catch (err) {
+    res.status(404).json({ error: (err as Error).message });
+  }
+});
+
+// GET /api/recibos/anexos/:anexo_id/download — download autenticado (CEO)
+app.get('/api/recibos/anexos/:anexo_id/download', requireCeoToken, async (req: Request, res: Response) => {
+  try {
+    const reciboAnexos = await import('./integrations/recibosAnexos');
+    const anexo = await reciboAnexos.buscarAnexoParaDownload(Number(req.params.anexo_id));
+    if (!anexo) return res.status(404).json({ error: 'Anexo nao encontrado' });
+    res.setHeader('Content-Type', anexo.mime_type || 'application/octet-stream');
+    res.setHeader('Content-Length', String(anexo.tamanho_bytes));
+    res.setHeader('Content-Disposition',
+      `attachment; filename="${anexo.nome_original.replace(/[^a-zA-Z0-9._-]/g, '_')}"`);
+    res.send(anexo.conteudo_blob);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+// GET /a/:token — download publico via token (link compartilhavel)
+app.get('/a/:token', async (req: Request, res: Response) => {
+  try {
+    const reciboAnexos = await import('./integrations/recibosAnexos');
+    const anexo = await reciboAnexos.buscarAnexoPorToken(String(req.params.token));
+    if (!anexo) return res.status(404).send('Anexo nao encontrado ou removido.');
+    res.setHeader('Content-Type', anexo.mime_type || 'application/octet-stream');
+    res.setHeader('Content-Length', String(anexo.tamanho_bytes));
+    res.setHeader('Content-Disposition',
+      `inline; filename="${anexo.nome_original.replace(/[^a-zA-Z0-9._-]/g, '_')}"`);
+    res.send(anexo.conteudo_blob);
+  } catch (err) {
+    res.status(500).send('Erro: ' + (err as Error).message);
+  }
+});
+
+// DELETE /api/recibos/anexos/:anexo_id — soft delete (CEO)
+app.delete('/api/recibos/anexos/:anexo_id', requireCeoToken, async (req: Request, res: Response) => {
+  try {
+    const reciboAnexos = await import('./integrations/recibosAnexos');
+    const r = await reciboAnexos.removerAnexo(Number(req.params.anexo_id));
+    res.json(r);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
 // ── Paginas publicas de resposta (sem auth, token-based) ────────────────
 // /r/:token → form mobile pra destinatario confirmar/contestar
 app.get('/r/:token', (_req: Request, res: Response) => {
@@ -4904,6 +5028,18 @@ app.listen(PORT, () => {
       await m.runLaudosArquivosMigrations();
     } catch (err) {
       console.error('[laudos-arquivos-migrations] FALHA fatal:', err);
+    }
+  })();
+
+  // v3.49.0: tabela recibos_anexos (anexos PDF/imagem em recibos universais).
+  // Usada para CCIR/ITR/CAR e outros documentos complementares enviados junto
+  // ao PDF principal via WhatsApp.
+  void (async () => {
+    try {
+      const m = await import('./database/migrations-recibos-anexos');
+      await m.runRecibosAnexosMigrations();
+    } catch (err) {
+      console.error('[recibos-anexos-migrations] FALHA fatal:', err);
     }
   })();
 

--- a/src/test/recibos-anexos-v3.49.0.test.ts
+++ b/src/test/recibos-anexos-v3.49.0.test.ts
@@ -1,0 +1,289 @@
+// v3.49.0: testes do modulo recibos_anexos.
+//
+// Cobre:
+//  - sanitizarNomeArquivo (NFD, lowercase, sha8 prefix, extensao preservada)
+//  - calcularSha256 / gerarDownloadToken (formato esperado)
+//  - validarMimeEExtensao (positivos + negativos)
+//  - constantes publicas (MAX_TAMANHO_BYTES, MAX_ANEXOS_POR_RECIBO, MIMES_PERMITIDOS)
+//  - migration idempotente (importavel, expor funcao runRecibosAnexosMigrations)
+//  - server.ts: endpoints e wiring de migration estao registrados
+//  - integration.recibos: enviarReciboWhatsApp chama listarAnexosComBlob
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  sanitizarNomeArquivo,
+  calcularSha256,
+  gerarDownloadToken,
+  validarMimeEExtensao,
+  MAX_ANEXOS_POR_RECIBO,
+  MAX_TAMANHO_BYTES,
+  MIMES_PERMITIDOS,
+} from '../integrations/recibosAnexos';
+
+describe('recibosAnexos — helpers puros (v3.49.0)', () => {
+  describe('sanitizarNomeArquivo', () => {
+    it('prefixa com 8 chars do sha256', () => {
+      const sha = 'abcdef1234567890'.repeat(4); // 64 chars
+      const out = sanitizarNomeArquivo('CCIR Atualizado.pdf', sha);
+      expect(out).toMatch(/^abcdef12_/);
+    });
+
+    it('normaliza acentos e espacos', () => {
+      const sha = 'a'.repeat(64);
+      const out = sanitizarNomeArquivo('Declaração ITR-2026.pdf', sha);
+      expect(out).toBe('aaaaaaaa_declaracao-itr-2026.pdf');
+    });
+
+    it('fallback para "arquivo" se nome sanitizado vira vazio', () => {
+      const sha = 'b'.repeat(64);
+      const out = sanitizarNomeArquivo('@@@@', sha);
+      expect(out).toMatch(/^bbbbbbbb_arquivo/);
+    });
+
+    it('mantem caracteres ja seguros', () => {
+      const sha = 'c'.repeat(64);
+      const out = sanitizarNomeArquivo('comprovante_incra-2026.pdf', sha);
+      expect(out).toBe('cccccccc_comprovante_incra-2026.pdf');
+    });
+  });
+
+  describe('calcularSha256', () => {
+    it('retorna 64 chars hex', () => {
+      const sha = calcularSha256(Buffer.from('teste'));
+      expect(sha).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('eh deterministico — mesmo input gera mesmo hash', () => {
+      const a = calcularSha256(Buffer.from('CCIR'));
+      const b = calcularSha256(Buffer.from('CCIR'));
+      expect(a).toBe(b);
+    });
+
+    it('inputs diferentes geram hashes diferentes', () => {
+      const a = calcularSha256(Buffer.from('CCIR'));
+      const b = calcularSha256(Buffer.from('ITR'));
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('gerarDownloadToken', () => {
+    it('retorna 64 chars hex', () => {
+      const tok = gerarDownloadToken();
+      expect(tok).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('gera tokens unicos a cada chamada', () => {
+      const a = gerarDownloadToken();
+      const b = gerarDownloadToken();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('validarMimeEExtensao', () => {
+    it('aceita PDF/JPG/PNG/WebP', () => {
+      expect(validarMimeEExtensao('a.pdf', 'application/pdf')).toBe('pdf');
+      expect(validarMimeEExtensao('b.jpg', 'image/jpeg')).toBe('jpg');
+      expect(validarMimeEExtensao('c.JPEG', 'image/jpeg')).toBe('jpeg');
+      expect(validarMimeEExtensao('d.png', 'image/png')).toBe('png');
+      expect(validarMimeEExtensao('e.webp', 'image/webp')).toBe('webp');
+    });
+
+    it('rejeita extensoes nao permitidas', () => {
+      expect(() => validarMimeEExtensao('malware.exe', 'application/x-msdownload')).toThrow(/nao permitida/i);
+      expect(() => validarMimeEExtensao('doc.docx', 'application/octet-stream')).toThrow(/nao permitida/i);
+      expect(() => validarMimeEExtensao('sheet.xlsx', 'application/octet-stream')).toThrow(/nao permitida/i);
+    });
+
+    it('rejeita arquivo sem extensao', () => {
+      expect(() => validarMimeEExtensao('semextensao', 'application/pdf')).toThrow(/nao permitida/i);
+    });
+
+    it('tolera MIME inesperado se extensao for OK (octet-stream)', () => {
+      // Navegadores variam — extensao manda
+      expect(validarMimeEExtensao('foo.pdf', 'application/octet-stream')).toBe('pdf');
+    });
+  });
+
+  describe('constantes publicas', () => {
+    it('MAX_ANEXOS_POR_RECIBO eh 5 (regra de negocio)', () => {
+      expect(MAX_ANEXOS_POR_RECIBO).toBe(5);
+    });
+
+    it('MAX_TAMANHO_BYTES eh 10 MB', () => {
+      expect(MAX_TAMANHO_BYTES).toBe(10 * 1024 * 1024);
+    });
+
+    it('MIMES_PERMITIDOS contem os 4 tipos esperados', () => {
+      expect(MIMES_PERMITIDOS).toContain('application/pdf');
+      expect(MIMES_PERMITIDOS).toContain('image/jpeg');
+      expect(MIMES_PERMITIDOS).toContain('image/png');
+      expect(MIMES_PERMITIDOS).toContain('image/webp');
+    });
+  });
+});
+
+describe('recibos_anexos — migration (v3.49.0)', () => {
+  it('arquivo migrations-recibos-anexos.ts existe e exporta runRecibosAnexosMigrations', async () => {
+    const mod = await import('../database/migrations-recibos-anexos');
+    expect(typeof mod.runRecibosAnexosMigrations).toBe('function');
+  });
+
+  it('SQL da migration cria tabela com LONGBLOB, FK CASCADE e UK token', () => {
+    const sqlText = readFileSync(
+      join(__dirname, '..', 'database', 'migrations-recibos-anexos.ts'),
+      'utf8',
+    );
+    expect(sqlText).toContain('CREATE TABLE recibos_anexos');
+    expect(sqlText).toContain('LONGBLOB');
+    expect(sqlText).toContain('FOREIGN KEY (recibo_id)');
+    expect(sqlText).toContain('REFERENCES recibos(id) ON DELETE CASCADE');
+    expect(sqlText).toContain('uk_ra_token');
+    expect(sqlText).toContain('CHAR(64) NOT NULL'); // sha256
+    expect(sqlText).toContain('VARCHAR(64) NOT NULL'); // download_token
+  });
+
+  it('eh idempotente — captura "already exists" e segue', () => {
+    const code = readFileSync(
+      join(__dirname, '..', 'database', 'migrations-recibos-anexos.ts'),
+      'utf8',
+    );
+    expect(code).toMatch(/already exists\|Duplicate/i);
+  });
+});
+
+describe('server.ts — wiring dos endpoints e migration (v3.49.0)', () => {
+  const serverTs = readFileSync(
+    join(__dirname, '..', 'server.ts'),
+    'utf8',
+  );
+
+  it('migration recibos-anexos eh chamada na sequencia de boot', () => {
+    expect(serverTs).toContain("await import('./database/migrations-recibos-anexos')");
+    expect(serverTs).toContain('runRecibosAnexosMigrations()');
+  });
+
+  it('endpoint POST /api/recibos/:id/anexos esta registrado', () => {
+    expect(serverTs).toMatch(/app\.post\(\s*['"]\/api\/recibos\/:id\/anexos['"]/);
+  });
+
+  it('endpoint GET /api/recibos/:id/anexos esta registrado', () => {
+    expect(serverTs).toMatch(/app\.get\(\s*['"]\/api\/recibos\/:id\/anexos['"]/);
+  });
+
+  it('endpoint GET /api/recibos/anexos/:anexo_id/download esta registrado e protegido', () => {
+    expect(serverTs).toMatch(/app\.get\(\s*['"]\/api\/recibos\/anexos\/:anexo_id\/download['"]\s*,\s*requireCeoToken/);
+  });
+
+  it('endpoint DELETE /api/recibos/anexos/:anexo_id esta registrado e protegido', () => {
+    expect(serverTs).toMatch(/app\.delete\(\s*['"]\/api\/recibos\/anexos\/:anexo_id['"]\s*,\s*requireCeoToken/);
+  });
+
+  it('endpoint publico GET /a/:token (download via token) esta registrado', () => {
+    expect(serverTs).toMatch(/app\.get\(\s*['"]\/a\/:token['"]/);
+  });
+
+  it('multer config aceita 5 arquivos e 10 MB cada', () => {
+    expect(serverTs).toContain('RECIBO_ANEXO_MAX_BYTES = 10 * 1024 * 1024');
+    expect(serverTs).toContain('RECIBO_ANEXO_MAX_FILES = 5');
+  });
+});
+
+describe('integrations/recibos.ts — anexos enviados apos PDF (v3.49.0)', () => {
+  const reciboTs = readFileSync(
+    join(__dirname, '..', 'integrations', 'recibos.ts'),
+    'utf8',
+  );
+
+  it('enviarReciboWhatsApp chama listarAnexosComBlob', () => {
+    expect(reciboTs).toContain("await import('./recibosAnexos')");
+    expect(reciboTs).toContain('listarAnexosComBlob');
+  });
+
+  it('itera sobre anexos e chama sendDocument com nome_original', () => {
+    expect(reciboTs).toMatch(/for\s*\(\s*const\s+anexo\s+of\s+anexos\s*\)/);
+    expect(reciboTs).toContain('anexo.conteudo_blob.toString(\'base64\')');
+    expect(reciboTs).toContain('anexo.nome_original');
+  });
+
+  it('registra evento attachments_sent quando anexos sao enviados', () => {
+    expect(reciboTs).toContain("'attachments_sent'");
+  });
+
+  it('aplica delay de 1s entre anexos pra evitar rate limit Z-API', () => {
+    expect(reciboTs).toMatch(/setTimeout\(resolve,\s*1000\)/);
+  });
+});
+
+describe('catalogo-servicos — 3 servicos IMOB para anexos (v3.49.0)', () => {
+  const catalogoJs = readFileSync(
+    join(__dirname, '..', 'public', 'js', 'catalogo-servicos.js'),
+    'utf8',
+  );
+
+  it('inclui CCIR atualizacao com base legal correta', () => {
+    expect(catalogoJs).toContain("id: 'imob-ccir'");
+    expect(catalogoJs).toContain('Atualização de CCIR');
+    expect(catalogoJs).toContain('Lei nº 4.947/1966');
+    expect(catalogoJs).toContain('IN INCRA nº 95/2010');
+  });
+
+  it('inclui ITR/NIRF atualizacao com base legal correta', () => {
+    expect(catalogoJs).toContain("id: 'imob-itr-nirf'");
+    expect(catalogoJs).toContain('NIRF');
+    expect(catalogoJs).toContain('Lei nº 9.393/1996');
+    expect(catalogoJs).toContain('IN RFB nº 1.877/2019');
+  });
+
+  it('inclui CAR/SICAR/AMBIS com base legal correta', () => {
+    expect(catalogoJs).toContain("id: 'imob-car-sicar'");
+    expect(catalogoJs).toContain('SICAR/AMBIS');
+    expect(catalogoJs).toContain('Lei nº 12.651/2012');
+    expect(catalogoJs).toContain('IN MMA nº 2/2014');
+  });
+});
+
+describe('frontend/obras.html — UI de anexos no form de recibo (v3.49.0)', () => {
+  const obrasHtml = readFileSync(
+    join(__dirname, '..', 'public', 'obras.html'),
+    'utf8',
+  );
+
+  it('secao de anexos esta presente no form de recibo', () => {
+    expect(obrasHtml).toContain('id="recAnexosSection"');
+    expect(obrasHtml).toContain('id="recAnexosInput"');
+    expect(obrasHtml).toContain('id="recAnexosAddBtn"');
+    expect(obrasHtml).toContain('id="recAnexosLista"');
+  });
+
+  it('input file aceita os MIMEs corretos', () => {
+    expect(obrasHtml).toContain('accept="application/pdf,image/jpeg,image/jpg,image/png,image/webp"');
+  });
+
+  it('limites client-side batem com servidor (5 arquivos, 10 MB)', () => {
+    expect(obrasHtml).toContain('ANEXO_MAX_BYTES = 10 * 1024 * 1024');
+    expect(obrasHtml).toContain('ANEXO_MAX_FILES = 5');
+  });
+
+  it('estado do form inclui anexosPendentes e anexosExistentes', () => {
+    expect(obrasHtml).toContain('anexosPendentes: []');
+    expect(obrasHtml).toContain('anexosExistentes: []');
+  });
+
+  it('uploadAnexosPendentes POSTa multipart em /api/recibos/:id/anexos', () => {
+    expect(obrasHtml).toContain("'/api/recibos/' + reciboId + '/anexos'");
+    expect(obrasHtml).toMatch(/fd\.append\(\s*['"]files['"]\s*,\s*a\.file/);
+    expect(obrasHtml).toMatch(/fd\.append\(\s*['"]descricoes['"]/);
+  });
+
+  it('ao editar recibo existente carrega anexos via GET', () => {
+    expect(obrasHtml).toContain("api('/api/recibos/' + r.id + '/anexos')");
+  });
+
+  it('renderAnexosBox monta link de download e botao de exclusao', () => {
+    expect(obrasHtml).toContain('/api/recibos/anexos/');
+    expect(obrasHtml).toContain('data-anexo-del-id');
+    expect(obrasHtml).toContain('data-anexo-rm-idx');
+  });
+});


### PR DESCRIPTION
…3.49.0

Cada recibo aceita ate 5 anexos (PDF/JPG/PNG/WebP, 10 MB cada) que sao enviados via Z-API junto ao PDF principal. Motivacao: servicos de atualizacao de CCIR, ITR/NIRF e CAR exigem documentos complementares entregues junto ao recibo do servico.

Backend:
- Migration `recibos_anexos` (LONGBLOB, FK CASCADE, idempotente)
- 5 endpoints REST (upload multipart, list, download CEO, download publico via token, delete soft) com anti-IDOR por tenant_id
- `enviarReciboWhatsApp` agora envia cada anexo apos o PDF com 1s de delay

Frontend:
- Secao "Documentos anexos" no form de Novo Recibo + edicao
- Label opcional por arquivo, contador N/5, validacao client-side
- Lista de anexos existentes ao editar com download/delete inline

Catalogo:
- 3 servicos novos em IMOB com base legal completa (Lei 4.947/1966, Lei 9.393/1996, Lei 12.651/2012) — auto-preenchem descricao do recibo

1165 testes passing (+40 novos), tsc limpo, zero regressao.