### PR TITLE
fix(recibos): chave correta de CEO token + cookie JWT no upload de an…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.49.0",
+  "version": "3.49.1",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -14647,7 +14647,10 @@ function renderReciboForm(v) {
   // Renderiza inicial (mostra existentes que ja foram carregados ou vazio)
   renderAnexosBox();
 
-  // Helper: faz upload dos anexos pendentes pra um recibo ja criado
+  // Helper: faz upload dos anexos pendentes pra um recibo ja criado.
+  // Nao usa api() porque precisa enviar multipart/form-data (api() seta Content-Type JSON).
+  // Envia cookie JWT (credentials: include) + X-CEO-Token (fallback legacy) pra cobrir
+  // tanto admin via /login quanto scripts com token CEO no env.
   async function uploadAnexosPendentes(reciboId) {
     if (!f.anexosPendentes || f.anexosPendentes.length === 0) return { enviados: 0 };
     const fd = new FormData();
@@ -14655,15 +14658,17 @@ function renderReciboForm(v) {
       fd.append('files', a.file, a.file.name);
       fd.append('descricoes', a.descricao || '');
     }
-    const ceoTok = localStorage.getItem('CEO_TOKEN') || '';
+    const ceoTok = (typeof getCeoToken === 'function' ? getCeoToken() : '') || '';
     const resp = await fetch('/api/recibos/' + reciboId + '/anexos', {
       method: 'POST',
-      headers: ceoTok ? { 'x-ceo-token': ceoTok } : {},
+      credentials: 'include',
+      headers: ceoTok ? { 'X-CEO-Token': ceoTok } : {},
       body: fd,
     });
     if (!resp.ok) {
-      const t = await resp.text().catch(() => '');
-      throw new Error('Falha no upload de anexos: ' + (t || resp.status));
+      let detail = '';
+      try { detail = (await resp.json()).error || ''; } catch { detail = await resp.text().catch(() => ''); }
+      throw new Error('Falha no upload de anexos (HTTP ' + resp.status + '): ' + (detail || 'sem detalhe'));
     }
     const j = await resp.json().catch(() => ({ anexos: [] }));
     return { enviados: (j.anexos || []).length };


### PR DESCRIPTION
…exos — v3.49.1

Bug: POST /api/recibos/:id/anexos retornava 403 porque o helper de upload no obras.html lia localStorage.getItem('CEO_TOKEN') (UPPERCASE), mas o sistema inteiro usa a chave 'ceo_token' (lowercase) via getCeoToken().

Fix:
- usa o helper getCeoToken() ja existente (sanitiza pra Safari iOS)
- adiciona credentials: 'include' pro cookie JWT admin ser enviado (cobre login regular sem precisar do X-CEO-Token legacy)
- mensagem de erro agora inclui status HTTP + detalhe do servidor