### PR TITLE
feat(auth): PIN secundario 4 digitos + admin bypass — v3.50.0

### DIFF
--- a/06-Changelog/v3.50.0-pin-secundario-admin-bypass.md
+++ b/06-Changelog/v3.50.0-pin-secundario-admin-bypass.md
@@ -1,0 +1,141 @@
+# v3.50.0 — PIN secundário (4 dígitos) com admin bypass
+
+**Data:** 2026-05-29
+**Branch:** `feat/pin-secundario-admin-bypass-v3.50.0`
+
+---
+
+## Motivação
+
+Ações destrutivas/críticas (excluir recibo, fechar folha, cancelar NF emitida,
+excluir laudo/proposta) hoje só dependem do `requireCeoToken` — ou seja, ou
+admin total ou nada. Para escalar a operação sem dar token CEO a todo mundo,
+adicionamos um PIN secundário de 4 dígitos: cada usuário cadastra o seu em
+**Configurações → Segurança**; ao executar uma ação sensível o sistema pede o
+PIN num modal nativo. **Roles `admin` e `owner` dispensam o PIN automaticamente.**
+
+---
+
+## Regra de negócio
+
+| Role | Comportamento |
+|---|---|
+| `admin`, `owner` | **Bypass automático** — nunca digitam PIN (autoridade equivalente a CEO) |
+| `gestor`, `engenheiro`, `financeiro`, `colaborador`, `viewer` | Devem cadastrar PIN em Configurações → Segurança e digitá-lo no modal antes de cada ação sensível |
+| Scripts/integrações com `X-CEO-Token` válido | Bypass (compat com automações pré-JWT) |
+
+---
+
+## Rotas protegidas
+
+| Método | Rota | Middleware aplicado |
+|---|---|---|
+| DELETE | `/api/recibos/:id` | `requireAuth, requirePin` |
+| POST | `/api/recibos/:id/cancelar` | `requireAuth, requirePin` |
+| POST | `/api/recibos/disparar` | `requireCeoToken, requirePin` |
+| POST | `/api/folha/fechar` | `requireAuth, requirePin` |
+| DELETE | `/api/laudos-demarcacao/:id` | `requireCeoToken, requirePin` |
+| DELETE | `/api/propostas/:id` | `requireCeoToken, requirePin` |
+| POST | `/api/notas-fiscais/:id/cancelar` | `requireAuth, requirePin` |
+
+PIN aceito via `req.body.pin` ou header `X-Pin`.
+
+---
+
+## Endpoints de gestão do PIN
+
+| Método | Rota | Auth | Descrição |
+|---|---|---|---|
+| GET | `/api/auth/me/pin/status` | requireAuth | Retorna `{ has_pin, set_at, is_locked, locked_until, failed_attempts, role, bypass }` |
+| POST | `/api/auth/me/pin` | requireAuth | Cadastra/troca PIN. Body: `{ senha, pin }` — exige senha atual para confirmar identidade |
+| DELETE | `/api/auth/me/pin` | requireAuth | Remove PIN. Body: `{ senha }` |
+
+---
+
+## Segurança
+
+- **Hash:** bcrypt cost 12 (mesmo da senha de login)
+- **Rate limit:** 5 tentativas erradas seguidas → trava por **15 minutos** (`pin_locked_until`)
+- **Anti-takeover:** cadastrar/trocar/remover PIN sempre exige **senha atual** do usuário (verifica via bcrypt antes)
+- **Reset automático:** contador `pin_failed_attempts` zera ao acertar
+- **Storage:** somente hash no banco — PIN em claro nunca persiste, nunca em log
+
+---
+
+## Schema novo (ALTER em `users`)
+
+```sql
+ALTER TABLE users ADD COLUMN pin_hash VARCHAR(255) NULL;            -- bcrypt
+ALTER TABLE users ADD COLUMN pin_set_at DATETIME NULL;
+ALTER TABLE users ADD COLUMN pin_failed_attempts INT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN pin_locked_until DATETIME NULL;
+```
+
+Migration idempotente (`columnExists()` checa antes; Duplicate column é capturado).
+
+---
+
+## UI
+
+### Cadastro/troca/remoção (Configurações → Segurança)
+
+- Aba nova **🔐 Segurança** no painel de Configurações
+- Mostra status atual (PIN cadastrado em DD/MM/AAAA HH:MM, ou aviso de não cadastrado)
+- Banner verde quando role bypassa: *"Seu papel admin dispensa PIN em todas as rotas. Você pode cadastrar mesmo assim para usar em logins futuros com outros papéis."*
+- Banner vermelho quando travado
+- Formulário com senha atual + 4 dígitos (`pattern="\d{4}"`, `inputmode="numeric"`, monospace letter-spacing pra UX limpa)
+
+### Modal de confirmação (`window.pinConfirmar`)
+
+Helper reutilizável `pinConfirmar(titulo, descricao) → Promise<string|null>`:
+- Se role admin/owner → retorna `''` imediatamente (sem modal)
+- Senão → modal nativo com input 4-dígitos, botões Cancelar/Confirmar, suporte a Enter/Escape
+- Retorna `null` se cancelar, string com PIN se confirmar
+
+Aplicado nos 4 handlers de ação destrutiva:
+- `data-rec-del` (excluir recibo)
+- `data-del-prop` (excluir proposta)
+- `data-laudo-del` (excluir laudo)
+- `data-nf-cancelar` (cancelar NF emitida)
+
+---
+
+## Arquivos novos
+
+- `src/database/migrations-pin-secundario.ts`
+- `src/services/pinSecundario.ts` — `hashPin`, `compararPin`, `verificarPin`, `definirPin`, `removerPin`, `statusPin`, `isAdminBypassPin`, `validarFormatoPin`
+- `src/middleware/requirePin.ts`
+- `src/test/pin-secundario-v3.50.0.test.ts` (44 testes)
+- `06-Changelog/v3.50.0-pin-secundario-admin-bypass.md`
+
+## Arquivos modificados
+
+- `src/server.ts` — wiring da migration + import de `requirePin` + 7 rotas protegidas
+- `src/routes/auth.ts` — 3 endpoints novos (`GET/POST/DELETE /me/pin*`)
+- `src/public/obras.html` — aba Segurança + helper `pinConfirmar()` + 4 handlers patched
+- `package.json` — bump para 3.50.0
+
+---
+
+## Validação
+
+- ✅ `tsc --noEmit` sem erros
+- ✅ Vitest: **1209 passing / 1 skipped / 0 failing** (zero regressão; +44 testes novos cobrindo helpers puros, middleware, migration, wiring server, endpoints auth e UI)
+- ✅ Roles do JWT (`admin`, `owner`, `gestor`, `engenheiro`, `financeiro`, `colaborador`, `viewer`) preservados — só admin/owner bypassam
+- ✅ Compat com `X-CEO-Token` legacy (scripts continuam funcionando)
+- ✅ Limite OpenAI mantido < 128 ferramentas (nenhuma ferramenta nova exposta ao agente)
+
+---
+
+## Notas de adaptação do prompt original
+
+O prompt veio com role nominal `administrador` e rotas genéricas que não existem
+no codebase. Adaptação feita:
+
+- `administrador` → roles `admin`/`owner` (os papéis admin-level reais do sistema, mesmo conjunto que o `requireCeoToken` aceita)
+- PIN cadastrado em Configurações → Segurança (e não em uma rota separada de "perfil"), seguindo a estrutura existente de tabs do painel
+- Aproveitado o helper `getCeoToken()` + cookie JWT já existentes (sem rewrite da auth foundation)
+
+A semântica geral do prompt foi preservada: admin nunca é bloqueado por PIN,
+outros roles cadastram e digitam, log de auditoria continua via `auth_logs`
+sem bloquear execução.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romatec-voice-agent",
-  "version": "3.49.1",
+  "version": "3.50.0",
   "description": "Roma - Assistente executivo de voz da Romatec Consultoria Imobiliaria",
   "main": "dist/server.js",
   "scripts": {

--- a/src/database/migrations-pin-secundario.ts
+++ b/src/database/migrations-pin-secundario.ts
@@ -1,0 +1,53 @@
+// v3.50.0: PIN secundario (4 digitos) pra confirmar acoes destrutivas/criticas.
+//
+// Roles `admin` e `owner` bypassam o PIN em todas as rotas — autoridade admin
+// ja e' suficiente (mesma logica do requireCeoToken hibrido). Outros roles
+// (gestor, engenheiro, financeiro, viewer, colaborador) precisam cadastrar
+// e digitar PIN pra deletar recibos, fechar folha, cancelar NF emitida, etc.
+//
+// Storage: bcrypt hash (cost 12 — mesmo da senha de login). 5 tentativas
+// erradas seguidas -> trava 15 min (pin_locked_until). Reset automatico ao
+// acertar.
+
+import type { RowDataPacket } from 'mysql2';
+import pool from './connection';
+
+async function columnExists(table: string, column: string): Promise<boolean> {
+  const [rows] = await pool.execute<RowDataPacket[]>(
+    `SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1`,
+    [table, column],
+  );
+  return rows.length > 0;
+}
+
+export async function runPinSecundarioMigrations(): Promise<void> {
+  const cols: Array<[string, string]> = [
+    ['pin_hash', `ALTER TABLE users ADD COLUMN pin_hash VARCHAR(255) NULL
+                    COMMENT 'bcrypt do PIN 4 digitos. NULL = sem PIN cadastrado'`],
+    ['pin_set_at', `ALTER TABLE users ADD COLUMN pin_set_at DATETIME NULL
+                      COMMENT 'quando o PIN foi definido/trocado pela ultima vez'`],
+    ['pin_failed_attempts', `ALTER TABLE users ADD COLUMN pin_failed_attempts INT UNSIGNED NOT NULL DEFAULT 0
+                               COMMENT 'tentativas falhas consecutivas — reset ao acertar'`],
+    ['pin_locked_until', `ALTER TABLE users ADD COLUMN pin_locked_until DATETIME NULL
+                            COMMENT 'apos 5 falhas, trava ate este timestamp (15 min)'`],
+  ];
+
+  for (const [col, sql] of cols) {
+    try {
+      if (await columnExists('users', col)) {
+        console.log(`[pin-migrations] ja existe (OK): users.${col}`);
+        continue;
+      }
+      await pool.execute(sql);
+      console.log(`[pin-migrations] OK: ADD COLUMN users.${col}`);
+    } catch (err) {
+      const msg = (err as Error).message || '';
+      if (/Duplicate column|already exists/i.test(msg)) {
+        console.log(`[pin-migrations] ja existe (OK): users.${col}`);
+      } else {
+        console.error(`[pin-migrations] FALHA users.${col}:`, msg.slice(0, 200));
+      }
+    }
+  }
+}

--- a/src/middleware/requirePin.ts
+++ b/src/middleware/requirePin.ts
@@ -1,0 +1,65 @@
+// v3.50.0: middleware requirePin — exige PIN secundario pra rotas destrutivas.
+//
+// Bypass automatico pra roles admin/owner (mesma autoridade que CEO_TOKEN).
+// Outros roles devem enviar PIN no body.pin ou header X-Pin.
+//
+// Uso: app.delete('/api/recibos/:id', requireAuth, requirePin, handler);
+// (sempre apos requireAuth — depende de req.user populado).
+
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthedRequest } from './auth';
+import { isAdminBypassPin, verificarPin } from '../services/pinSecundario';
+
+export function requirePin(req: Request, res: Response, next: NextFunction): void {
+  const claims = (req as AuthedRequest).user;
+
+  // Bypass legacy: X-CEO-Token valido (scripts/integracoes pre-JWT) =
+  // autoridade admin equivalente. Combina com requireCeoToken upstream.
+  if (!claims) {
+    const expected = process.env.CEO_API_TOKEN;
+    const got = req.headers['x-ceo-token'] as string | undefined;
+    if (expected && got && got === expected) {
+      return next();
+    }
+    res.status(401).json({ error: 'Sem sessao autenticada — faca login para usar esta rota.' });
+    return;
+  }
+
+  // Bypass admin/owner (JWT)
+  if (isAdminBypassPin(claims)) {
+    return next();
+  }
+
+  // Le PIN do body ou header
+  const pin = (req.body?.pin as string | undefined)
+            ?? (req.headers['x-pin'] as string | undefined);
+
+  if (!pin) {
+    res.status(403).json({
+      error: 'PIN obrigatorio para esta operacao.',
+      code: 'PIN_REQUIRED',
+    });
+    return;
+  }
+
+  void verificarPin(Number(claims.sub), String(pin)).then(result => {
+    if (result.ok) {
+      return next();
+    }
+    const status = result.motivo === 'travado' ? 423 // Locked
+                 : result.motivo === 'sem_pin' ? 403
+                 : 403;
+    const code = result.motivo === 'travado' ? 'PIN_LOCKED'
+               : result.motivo === 'sem_pin' ? 'PIN_NOT_SET'
+               : result.motivo === 'formato_invalido' ? 'PIN_INVALID_FORMAT'
+               : 'PIN_INVALID';
+    res.status(status).json({
+      error: result.mensagem,
+      code,
+      restantes: 'restantes' in result ? result.restantes : undefined,
+      locked_until: 'locked_until' in result ? result.locked_until : undefined,
+    });
+  }).catch(err => {
+    res.status(500).json({ error: 'Erro ao verificar PIN: ' + (err as Error).message });
+  });
+}

--- a/src/public/obras.html
+++ b/src/public/obras.html
@@ -6257,7 +6257,9 @@ function renderPropostasLista() {
       textoConfirmar: 'Excluir', perigoso: true,
     });
     if (!ok) return;
-    try { await api('/api/propostas/' + b.dataset.delProp, { method: 'DELETE' }); render(); }
+    const pin = await pinConfirmar('Excluir proposta', 'Esta ação remove a proposta. Confirme com seu PIN.');
+    if (pin === null) return;
+    try { await api('/api/propostas/' + b.dataset.delProp, { method: 'DELETE', headers: pin ? { 'X-Pin': pin } : {} }); render(); }
     catch (e) { alert('Erro: ' + e.message + (e.message.includes('Forbidden') ? '\n\nConfigure o token CEO no botão Admin.' : '')); }
   });
 
@@ -14242,12 +14244,17 @@ function renderRecibos() {
     }).catch(() => {});
     renderRecibos();
   });
-  // 🗑️ Excluir — hard delete (exceto confirmado)
+  // 🗑️ Excluir — hard delete (exceto confirmado). v3.50.0: exige PIN (admin bypass).
   document.querySelectorAll('[data-rec-del]').forEach(b => b.onclick = async () => {
     const id = b.dataset.recDel;
     if (!confirm('Excluir DEFINITIVAMENTE este recibo? Não pode desfazer.')) return;
+    const pin = await pinConfirmar('Excluir recibo', 'Esta ação é irreversível. Confirme com seu PIN.');
+    if (pin === null) return; // cancelou
     try {
-      await api('/api/recibos/' + id, { method: 'DELETE' });
+      await api('/api/recibos/' + id, {
+        method: 'DELETE',
+        headers: pin ? { 'X-Pin': pin } : {},
+      });
       await loadRecibos(); renderRecibos();
     } catch (e) { alert('Erro: ' + e.message); }
   });
@@ -15777,9 +15784,13 @@ function renderNotas() {
     const id = b.dataset.nfCancelar;
     const motivo = prompt('Motivo do cancelamento (obrigatório):', '');
     if (!motivo?.trim()) return alert('Motivo obrigatório.');
+    const pin = await pinConfirmar('Cancelar NF emitida', 'Cancelamento de NF é definitivo. Confirme com seu PIN.');
+    if (pin === null) return;
     try {
       await api('/api/notas-fiscais/' + id + '/cancelar', {
-        method:'POST', body: JSON.stringify({ motivo })
+        method:'POST',
+        body: JSON.stringify({ motivo }),
+        headers: pin ? { 'X-Pin': pin } : {},
       });
       alert('✓ Solicitação de cancelamento enviada.');
       await loadNotas(); renderNotas();
@@ -18762,8 +18773,13 @@ function renderLaudosLista(v) {
   });
   v.querySelectorAll('[data-laudo-del]').forEach(b => b.onclick = async () => {
     if (!confirm('Desativar este laudo? (soft delete — pode ser recuperado pelo banco)')) return;
+    const pin = await pinConfirmar('Excluir laudo', 'Esta ação desativa o laudo. Confirme com seu PIN.');
+    if (pin === null) return;
     try {
-      await api('/api/laudos-demarcacao/' + b.dataset.laudoDel, { method: 'DELETE' });
+      await api('/api/laudos-demarcacao/' + b.dataset.laudoDel, {
+        method: 'DELETE',
+        headers: pin ? { 'X-Pin': pin } : {},
+      });
       await render();
     } catch (err) { alert('Erro: '+err.message); }
   });
@@ -23979,8 +23995,9 @@ async function renderConfiguracoes() {
   v.innerHTML = `
     <div class="card">
       <p class="section-title">⚙️ Configurações</p>
-      <div style="display:flex; gap:6px; margin-bottom:14px; border-bottom:1px solid var(--border);">
+      <div style="display:flex; gap:6px; margin-bottom:14px; border-bottom:1px solid var(--border); flex-wrap:wrap;">
         <button class="cfg-tab" data-sub="usuarios"  style="padding:8px 14px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--text-muted); cursor:pointer;">👥 Usuários</button>
+        <button class="cfg-tab" data-sub="seguranca" style="padding:8px 14px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--text-muted); cursor:pointer;">🔐 Segurança</button>
         <button class="cfg-tab" data-sub="auditoria" style="padding:8px 14px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--text-muted); cursor:pointer;">📋 Auditoria</button>
         <button class="cfg-tab" data-sub="galeria"   style="padding:8px 14px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--text-muted); cursor:pointer;">📷 Galeria</button>
       </div>
@@ -23996,12 +24013,128 @@ async function renderConfiguracoes() {
   });
   try {
     if (state.configSub === 'usuarios') await renderCfgUsuarios();
+    else if (state.configSub === 'seguranca') await renderCfgSeguranca();
     else if (state.configSub === 'auditoria') await renderCfgAuditoria();
     else if (state.configSub === 'galeria') await renderCfgGaleria();
   } catch (e) {
     document.getElementById('cfg-body').innerHTML = `<div class="card empty">Erro: ${escape(e.message)}</div>`;
   }
 }
+
+// v3.50.0: aba Seguranca — cadastra/troca/remove PIN secundario (4 digitos).
+// Admin/owner veem aviso de bypass mas podem cadastrar mesmo assim.
+async function renderCfgSeguranca() {
+  const body = document.getElementById('cfg-body');
+  body.innerHTML = '<div style="opacity:.6;">Carregando status do PIN…</div>';
+  let st;
+  try {
+    st = await api('/api/auth/me/pin/status');
+  } catch (e) {
+    body.innerHTML = `<div class="card empty">Erro: ${escape(e.message)}</div>`;
+    return;
+  }
+  const bypassNote = st.bypass
+    ? `<div style="background:rgba(74,140,94,0.12); border:1px solid #4a8c5e; border-radius:6px; padding:10px; margin-bottom:14px; font-size:12px;">
+         ℹ️ Seu papel <b>${escape(st.role)}</b> dispensa PIN em todas as rotas. Você pode cadastrar mesmo assim para usar em logins futuros com outros papéis.
+       </div>`
+    : '';
+  const lockNote = st.is_locked
+    ? `<div style="background:rgba(220,38,38,0.12); border:1px solid #dc2626; border-radius:6px; padding:10px; margin-bottom:14px; font-size:12px;">
+         🔒 PIN travado por tentativas erradas. Libera em ${new Date(st.locked_until).toLocaleString('pt-BR')}.
+       </div>`
+    : '';
+  body.innerHTML = `
+    <div style="max-width:480px;">
+      ${bypassNote}
+      ${lockNote}
+      <p style="margin:0 0 14px; font-size:13px;">
+        ${st.has_pin
+          ? `✅ PIN cadastrado em ${new Date(st.set_at).toLocaleString('pt-BR')}.`
+          : '⚠️ Você ainda não cadastrou um PIN secundário.'}
+      </p>
+      <div style="display:flex; flex-direction:column; gap:10px; padding:14px; border:1px solid var(--border); border-radius:8px;">
+        <p style="margin:0; font-weight:600;">${st.has_pin ? 'Trocar PIN' : 'Cadastrar PIN'}</p>
+        <label style="font-size:12px;">Senha atual *
+          <input id="pinFormSenha" type="password" autocomplete="current-password" style="width:100%; margin-top:4px;">
+        </label>
+        <label style="font-size:12px;">Novo PIN (4 dígitos numéricos) *
+          <input id="pinFormPin" type="password" inputmode="numeric" pattern="\\d{4}" maxlength="4" autocomplete="off" style="width:100%; margin-top:4px; font-family:monospace; letter-spacing:8px; text-align:center; font-size:18px;">
+        </label>
+        <button id="pinFormSalvar" style="background:#1F5C3A; color:#fff; border-color:#1F5C3A; font-weight:600;">💾 ${st.has_pin ? 'Trocar PIN' : 'Cadastrar PIN'}</button>
+      </div>
+      ${st.has_pin ? `
+        <div style="margin-top:14px; padding:14px; border:1px solid #842; border-radius:8px;">
+          <p style="margin:0 0 8px; font-weight:600; color:#dc2626;">⚠️ Remover PIN</p>
+          <p style="margin:0 0 10px; font-size:11px; color:var(--text-muted);">Sem PIN, você não conseguirá executar ações sensíveis (exclusões, fechar folha, cancelar NF). Admin/owner não precisam.</p>
+          <label style="font-size:12px;">Senha atual *
+            <input id="pinRmSenha" type="password" autocomplete="current-password" style="width:100%; margin-top:4px;">
+          </label>
+          <button id="pinRmBtn" style="margin-top:10px; background:transparent; border:1px solid #842; color:#a55;">🗑 Remover PIN</button>
+        </div>` : ''}
+    </div>
+  `;
+  document.getElementById('pinFormSalvar').onclick = async () => {
+    const senha = document.getElementById('pinFormSenha').value;
+    const pin = document.getElementById('pinFormPin').value;
+    if (!senha) { showToast('Senha atual obrigatória', 'error'); return; }
+    if (!/^\d{4}$/.test(pin)) { showToast('PIN deve ter exatamente 4 dígitos numéricos', 'error'); return; }
+    try {
+      await api('/api/auth/me/pin', { method: 'POST', body: JSON.stringify({ senha, pin }) });
+      showToast('✅ PIN ' + (st.has_pin ? 'trocado' : 'cadastrado') + ' com sucesso', 'success');
+      renderCfgSeguranca();
+    } catch (e) { showToast('Erro: ' + e.message, 'error'); }
+  };
+  const rmBtn = document.getElementById('pinRmBtn');
+  if (rmBtn) rmBtn.onclick = async () => {
+    const senha = document.getElementById('pinRmSenha').value;
+    if (!senha) { showToast('Senha atual obrigatória', 'error'); return; }
+    if (!confirm('Remover seu PIN? Você não conseguirá fazer ações sensíveis até cadastrar de novo.')) return;
+    try {
+      await api('/api/auth/me/pin', { method: 'DELETE', body: JSON.stringify({ senha }) });
+      showToast('PIN removido', 'info');
+      renderCfgSeguranca();
+    } catch (e) { showToast('Erro: ' + e.message, 'error'); }
+  };
+}
+
+// v3.50.0: modal reutilizavel pra confirmar acao sensivel com PIN.
+// Retorna Promise<string|null> — string com PIN se confirmou, null se cancelou.
+// Admin/owner: pula o modal e retorna ''.
+async function pinConfirmar(titulo, descricao) {
+  // Checa status pra ver se eh admin bypass
+  let st = null;
+  try { st = await api('/api/auth/me/pin/status'); } catch {}
+  if (st && st.bypass) return ''; // admin/owner — passa direto
+  // Mostra modal
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.75);z-index:9999;display:flex;align-items:center;justify-content:center;padding:20px;';
+    overlay.innerHTML = `
+      <div style="background:var(--bg-elev,#1a1f1a); border:1px solid var(--border,#333); border-radius:10px; padding:20px; max-width:380px; width:100%;">
+        <p style="margin:0 0 8px; font-weight:700; font-size:15px;">🔐 ${escape(titulo || 'Confirme com seu PIN')}</p>
+        <p style="margin:0 0 14px; font-size:12px; color:var(--text-muted,#888);">${escape(descricao || 'Esta ação é sensível. Digite seu PIN de 4 dígitos para confirmar.')}</p>
+        <input id="pinModalInput" type="password" inputmode="numeric" pattern="\\d{4}" maxlength="4" autocomplete="off" autofocus style="width:100%; font-family:monospace; letter-spacing:12px; text-align:center; font-size:24px; padding:10px;">
+        <div id="pinModalErro" style="font-size:11px; color:#dc2626; min-height:14px; margin-top:6px;"></div>
+        <div style="display:flex; gap:8px; margin-top:14px;">
+          <button id="pinModalCancel" style="flex:1; background:transparent; border:1px solid #444; color:#888;">Cancelar</button>
+          <button id="pinModalOk" style="flex:1; background:#1F5C3A; color:#fff; border-color:#1F5C3A; font-weight:600;">Confirmar</button>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+    const inp = document.getElementById('pinModalInput');
+    const erro = document.getElementById('pinModalErro');
+    const fechar = (val) => { overlay.remove(); resolve(val); };
+    document.getElementById('pinModalCancel').onclick = () => fechar(null);
+    const ok = () => {
+      const v = inp.value;
+      if (!/^\d{4}$/.test(v)) { erro.textContent = 'PIN deve ter 4 dígitos numéricos'; inp.focus(); return; }
+      fechar(v);
+    };
+    document.getElementById('pinModalOk').onclick = ok;
+    inp.onkeydown = (e) => { if (e.key === 'Enter') ok(); if (e.key === 'Escape') fechar(null); };
+  });
+}
+window.pinConfirmar = pinConfirmar;
 
 // v3.28.0: configuracoes de Galeria — pos-captura (defaults + reset).
 async function renderCfgGaleria() {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -252,4 +252,83 @@ router.get('/me', requireAuth, (req: Request, res: Response) => {
   });
 });
 
+// ─── PIN secundario (v3.50.0) ─────────────────────────────────────────
+// Roles admin/owner dispensam PIN em qualquer rota (bypass automatico),
+// mas TODOS podem cadastrar PIN se quiserem usar o sistema com outros logins.
+// Mudanca de PIN exige senha atual (confirma identidade).
+
+router.get('/me/pin/status', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const user = (req as AuthedRequest).user!;
+    const { statusPin } = await import('../services/pinSecundario');
+    const st = await statusPin(Number(user.sub));
+    res.json({ ...st, role: user.role, bypass: user.role === 'admin' || user.role === 'owner' });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+router.post('/me/pin', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const user = (req as AuthedRequest).user!;
+    const { senha, pin } = (req.body || {}) as { senha?: string; pin?: string };
+    if (!senha || typeof senha !== 'string') {
+      res.status(400).json({ error: 'Senha atual obrigatoria pra cadastrar/trocar PIN' });
+      return;
+    }
+    const { validarFormatoPin, definirPin } = await import('../services/pinSecundario');
+    if (!validarFormatoPin(pin)) {
+      res.status(400).json({ error: 'PIN deve ter exatamente 4 digitos numericos' });
+      return;
+    }
+    // Confirma senha atual
+    const [rows] = await pool.execute<RowDataPacket[]>(
+      `SELECT password_hash FROM users WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
+      [Number(user.sub)],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Usuario nao encontrado' });
+      return;
+    }
+    const senhaOk = await verifyPassword(senha, String(rows[0].password_hash));
+    if (!senhaOk) {
+      res.status(403).json({ error: 'Senha atual incorreta' });
+      return;
+    }
+    await definirPin(Number(user.sub), pin as string);
+    res.json({ ok: true, message: 'PIN cadastrado/atualizado com sucesso' });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+router.delete('/me/pin', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const user = (req as AuthedRequest).user!;
+    const { senha } = (req.body || {}) as { senha?: string };
+    if (!senha || typeof senha !== 'string') {
+      res.status(400).json({ error: 'Senha atual obrigatoria pra remover PIN' });
+      return;
+    }
+    const [rows] = await pool.execute<RowDataPacket[]>(
+      `SELECT password_hash FROM users WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
+      [Number(user.sub)],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Usuario nao encontrado' });
+      return;
+    }
+    const senhaOk = await verifyPassword(senha, String(rows[0].password_hash));
+    if (!senhaOk) {
+      res.status(403).json({ error: 'Senha atual incorreta' });
+      return;
+    }
+    const { removerPin } = await import('../services/pinSecundario');
+    await removerPin(Number(user.sub));
+    res.json({ ok: true, message: 'PIN removido' });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -866,6 +866,7 @@ app.delete('/api/etapas/:id', apiHandle(args => obras.apagarEtapa(args as { id: 
 // e FALHA FECHADO se CEO_API_TOKEN nao estiver setada (antes falhava aberto).
 // Implementacao moveu pra src/middleware/auth.ts pra ficar perto do requireAuth.
 import { requireCeoToken, requireAuth, type AuthedRequest } from './middleware/auth';
+import { requirePin } from './middleware/requirePin'; // v3.50.0
 
 // v1.64.0: tenant settings (white-label estrutural). GET é público, PUT só CEO.
 app.get('/api/tenant-settings', async (_req: Request, res: Response) => {
@@ -978,7 +979,7 @@ app.post('/api/recibos/preview-lote', requireCeoToken, apiHandle(async (args) =>
   const m = await import('./services/recibosQuinzena');
   return m.previewLoteQuinzena(args as { periodo?: string });
 }));
-app.post('/api/recibos/disparar', requireCeoToken, async (req: Request, res: Response) => {
+app.post('/api/recibos/disparar', requireCeoToken, requirePin, async (req: Request, res: Response) => {
   try {
     const m = await import('./services/recibosQuinzena');
     const proto = (req.get('x-forwarded-proto') as string | undefined)?.split(',')[0]?.trim() || 'https';
@@ -1147,7 +1148,7 @@ app.get   ('/api/propostas',             apiHandle(args => propostas.listarPropo
 app.get   ('/api/propostas/:id',         apiHandle(args => propostas.buscarProposta((args as { id: string }).id)));
 app.post  ('/api/propostas',             apiHandle(args => propostas.criarProposta(args as Parameters<typeof propostas.criarProposta>[0])));
 app.put   ('/api/propostas/:id',         apiHandle(args => propostas.atualizarProposta(args as Parameters<typeof propostas.atualizarProposta>[0])));
-app.delete('/api/propostas/:id',         requireCeoToken, apiHandle(args => propostas.apagarProposta(args as { id: string })));
+app.delete('/api/propostas/:id',         requireCeoToken, requirePin, apiHandle(args => propostas.apagarProposta(args as { id: string })));
 
 app.post  ('/api/propostas/:proposta_id/itens',         apiHandle(args => propostas.adicionarItemProposta(args as Parameters<typeof propostas.adicionarItemProposta>[0])));
 app.put   ('/api/proposta-itens/:id',                   apiHandle(args => propostas.atualizarItemProposta(args as Parameters<typeof propostas.atualizarItemProposta>[0])));
@@ -1715,7 +1716,7 @@ app.post('/api/laudos-demarcacao', requireCeoToken, async (req: Request, res: Re
     res.status(201).json(l);
   } catch (err) { res.status(400).json({ error: (err as Error).message }); }
 });
-app.delete('/api/laudos-demarcacao/:id', requireCeoToken, async (req: Request, res: Response) => {
+app.delete('/api/laudos-demarcacao/:id', requireCeoToken, requirePin, async (req: Request, res: Response) => {
   try {
     const m = await import('./integrations/laudos');
     const id = await m.resolverLaudoId(String(req.params.id));
@@ -3758,7 +3759,8 @@ app.post('/api/notas-fiscais',
   apiHandle(args => notasFiscais.criarRascunhoNF(args as Parameters<typeof notasFiscais.criarRascunhoNF>[0])));
 app.post('/api/notas-fiscais/:id/emitir',
   apiHandle(async args => notasFiscais.enviarNFParaProvider((args as { id: string }).id)));
-app.post('/api/notas-fiscais/:id/cancelar',
+// v3.50.0: cancelar NF emitida requer PIN (admin/owner bypass)
+app.post('/api/notas-fiscais/:id/cancelar', requireAuth, requirePin,
   apiHandle(async args => {
     const a = args as { id: string; motivo?: string };
     if (!a.motivo?.trim()) throw new Error('motivo obrigatorio pra cancelar');
@@ -3876,7 +3878,8 @@ app.post  ('/api/recibos/:id/reenviar',
     await recibos.reenviarRecibo((args as { id: string }).id);
     return { ok: true };
   }));
-app.post  ('/api/recibos/:id/cancelar',
+// v3.50.0: cancelar recibo (incluindo confirmado/NF emitida) — requer PIN
+app.post  ('/api/recibos/:id/cancelar', requireAuth, requirePin,
   apiHandle(async args => {
     const a = args as { id: string; motivo?: string };
     await recibos.cancelarRecibo(a.id, a.motivo);
@@ -3901,7 +3904,8 @@ app.post('/api/recibos/:id/enviar-telegram', async (req: Request, res: Response)
   } catch (err) { res.status(500).json({ error: (err as Error).message }); }
 });
 
-app.delete('/api/recibos/:id', async (req: Request, res: Response) => {
+// v3.50.0: exclusao de recibo requer PIN (admin/owner bypass)
+app.delete('/api/recibos/:id', requireAuth, requirePin, async (req: Request, res: Response) => {
   try {
     const id = String(req.params.id);
     const r = await recibos.buscarReciboPorId(id);
@@ -4518,7 +4522,8 @@ app.post('/api/folha/preview', async (req: Request, res: Response) => {
   } catch (err) { res.status(400).json({ error: (err as Error).message }); }
 });
 
-app.post('/api/folha/fechar', async (req: Request, res: Response) => {
+// v3.50.0: fechar folha requer PIN (admin/owner bypass)
+app.post('/api/folha/fechar', requireAuth, requirePin, async (req: Request, res: Response) => {
   try {
     const body = req.body ?? {};
     if (!body.obraId || !body.dataInicio || !body.dataFim) {
@@ -5040,6 +5045,18 @@ app.listen(PORT, () => {
       await m.runRecibosAnexosMigrations();
     } catch (err) {
       console.error('[recibos-anexos-migrations] FALHA fatal:', err);
+    }
+  })();
+
+  // v3.50.0: PIN secundario — colunas pin_hash, pin_set_at, pin_failed_attempts,
+  // pin_locked_until em users. Admin/owner bypassam, outros roles digitam PIN
+  // pra acoes destrutivas (deletar recibo, fechar folha, cancelar NF, etc.).
+  void (async () => {
+    try {
+      const m = await import('./database/migrations-pin-secundario');
+      await m.runPinSecundarioMigrations();
+    } catch (err) {
+      console.error('[pin-migrations] FALHA fatal:', err);
     }
   })();
 

--- a/src/services/pinSecundario.ts
+++ b/src/services/pinSecundario.ts
@@ -1,0 +1,172 @@
+// v3.50.0: service do PIN secundario (4 digitos numericos) + admin bypass.
+//
+// Regra: roles `admin` e `owner` dispensam PIN em qualquer rota (autoridade
+// equivalente a CEO). Outros roles digitam PIN cadastrado em Configuracoes.
+
+import bcrypt from 'bcrypt';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../database/connection';
+import type { AuthRole, JWTClaims } from './auth';
+
+export const PIN_BCRYPT_COST = 12;
+export const PIN_LENGTH = 4;
+export const PIN_MAX_FAILED_ATTEMPTS = 5;
+export const PIN_LOCK_DURATION_MS = 15 * 60 * 1000; // 15 min
+
+/** Roles que dispensam PIN em todas as rotas (mesma autoridade que CEO). */
+const ROLES_BYPASS_PIN: ReadonlySet<AuthRole> = new Set(['admin', 'owner']);
+
+export function isAdminBypassPin(claims: JWTClaims | undefined | null): boolean {
+  if (!claims) return false;
+  return ROLES_BYPASS_PIN.has(claims.role);
+}
+
+/** Valida que o PIN tem exatamente 4 digitos numericos. */
+export function validarFormatoPin(pin: unknown): pin is string {
+  return typeof pin === 'string'
+    && pin.length === PIN_LENGTH
+    && /^\d{4}$/.test(pin);
+}
+
+export async function hashPin(pin: string): Promise<string> {
+  if (!validarFormatoPin(pin)) {
+    throw new Error('PIN deve ter exatamente 4 digitos numericos');
+  }
+  return bcrypt.hash(pin, PIN_BCRYPT_COST);
+}
+
+export async function compararPin(pin: string, hash: string): Promise<boolean> {
+  if (!pin || !hash) return false;
+  return bcrypt.compare(pin, hash);
+}
+
+export interface UserPinRow extends RowDataPacket {
+  id: number;
+  pin_hash: string | null;
+  pin_set_at: Date | string | null;
+  pin_failed_attempts: number;
+  pin_locked_until: Date | string | null;
+}
+
+export async function buscarUserPin(userId: number): Promise<UserPinRow | null> {
+  const [rows] = await pool.execute<UserPinRow[]>(
+    `SELECT id, pin_hash, pin_set_at, pin_failed_attempts, pin_locked_until
+       FROM users WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
+    [Number(userId)],
+  );
+  return rows[0] ?? null;
+}
+
+export interface PinStatusResumo {
+  has_pin: boolean;
+  set_at: string | null;
+  is_locked: boolean;
+  locked_until: string | null;
+  failed_attempts: number;
+}
+
+export async function statusPin(userId: number): Promise<PinStatusResumo> {
+  const u = await buscarUserPin(userId);
+  if (!u) {
+    return { has_pin: false, set_at: null, is_locked: false, locked_until: null, failed_attempts: 0 };
+  }
+  const lockedUntil = u.pin_locked_until ? new Date(u.pin_locked_until as Date) : null;
+  const isLocked = !!(lockedUntil && lockedUntil.getTime() > Date.now());
+  return {
+    has_pin: !!u.pin_hash,
+    set_at: u.pin_set_at ? new Date(u.pin_set_at as Date).toISOString() : null,
+    is_locked: isLocked,
+    locked_until: isLocked ? lockedUntil!.toISOString() : null,
+    failed_attempts: Number(u.pin_failed_attempts || 0),
+  };
+}
+
+/** Define ou troca o PIN. Reseta tentativas falhas. */
+export async function definirPin(userId: number, pin: string): Promise<void> {
+  if (!validarFormatoPin(pin)) {
+    throw new Error('PIN deve ter exatamente 4 digitos numericos');
+  }
+  const hash = await hashPin(pin);
+  const [r] = await pool.execute<ResultSetHeader>(
+    `UPDATE users
+        SET pin_hash = ?, pin_set_at = NOW(),
+            pin_failed_attempts = 0, pin_locked_until = NULL
+      WHERE id = ? AND deleted_at IS NULL`,
+    [hash, Number(userId)],
+  );
+  if (r.affectedRows === 0) throw new Error('Usuario nao encontrado');
+}
+
+/** Remove o PIN — usuario volta a nao precisar (mas continua bloqueado em rotas que exigem). */
+export async function removerPin(userId: number): Promise<void> {
+  await pool.execute(
+    `UPDATE users
+        SET pin_hash = NULL, pin_set_at = NULL,
+            pin_failed_attempts = 0, pin_locked_until = NULL
+      WHERE id = ?`,
+    [Number(userId)],
+  );
+}
+
+export type VerificarPinResultado =
+  | { ok: true }
+  | { ok: false; motivo: 'sem_pin' | 'travado' | 'incorreto' | 'formato_invalido'; mensagem: string; restantes?: number; locked_until?: string };
+
+/** Verifica PIN do usuario. Aplica rate-limit (5 falhas -> trava 15 min). */
+export async function verificarPin(userId: number, pinInformado: string): Promise<VerificarPinResultado> {
+  if (!validarFormatoPin(pinInformado)) {
+    return { ok: false, motivo: 'formato_invalido', mensagem: 'PIN deve ter 4 digitos numericos' };
+  }
+  const u = await buscarUserPin(userId);
+  if (!u || !u.pin_hash) {
+    return { ok: false, motivo: 'sem_pin', mensagem: 'PIN nao cadastrado. Configure em Configuracoes > Seguranca.' };
+  }
+  // Checa lock
+  const lockedUntil = u.pin_locked_until ? new Date(u.pin_locked_until as Date) : null;
+  if (lockedUntil && lockedUntil.getTime() > Date.now()) {
+    const minutosRestantes = Math.ceil((lockedUntil.getTime() - Date.now()) / 60000);
+    return {
+      ok: false,
+      motivo: 'travado',
+      mensagem: `PIN travado por ${minutosRestantes} min apos varias tentativas erradas.`,
+      locked_until: lockedUntil.toISOString(),
+    };
+  }
+  // Compara
+  const ok = await compararPin(pinInformado, u.pin_hash);
+  if (ok) {
+    // Reset contadores
+    if (u.pin_failed_attempts > 0 || u.pin_locked_until) {
+      await pool.execute(
+        `UPDATE users SET pin_failed_attempts = 0, pin_locked_until = NULL WHERE id = ?`,
+        [userId],
+      );
+    }
+    return { ok: true };
+  }
+  // Errado: incrementa contador, possivel lock
+  const novasTentativas = (u.pin_failed_attempts || 0) + 1;
+  if (novasTentativas >= PIN_MAX_FAILED_ATTEMPTS) {
+    const lock = new Date(Date.now() + PIN_LOCK_DURATION_MS);
+    await pool.execute(
+      `UPDATE users SET pin_failed_attempts = ?, pin_locked_until = ? WHERE id = ?`,
+      [novasTentativas, lock, userId],
+    );
+    return {
+      ok: false,
+      motivo: 'travado',
+      mensagem: `PIN incorreto. Apos ${PIN_MAX_FAILED_ATTEMPTS} tentativas, travado por 15 min.`,
+      locked_until: lock.toISOString(),
+    };
+  }
+  await pool.execute(
+    `UPDATE users SET pin_failed_attempts = ? WHERE id = ?`,
+    [novasTentativas, userId],
+  );
+  return {
+    ok: false,
+    motivo: 'incorreto',
+    mensagem: 'PIN incorreto.',
+    restantes: PIN_MAX_FAILED_ATTEMPTS - novasTentativas,
+  };
+}

--- a/src/test/pin-secundario-v3.50.0.test.ts
+++ b/src/test/pin-secundario-v3.50.0.test.ts
@@ -1,0 +1,309 @@
+// v3.50.0: testes do PIN secundario + admin bypass.
+//
+// Cobre:
+//  - isAdminBypassPin: admin/owner true; outros roles false
+//  - validarFormatoPin: aceita 4 digitos, rejeita o resto
+//  - hashPin / compararPin (roundtrip bcrypt)
+//  - middleware requirePin: bypass admin/owner, exige PIN pros outros,
+//    aceita X-CEO-Token legacy quando sem sessao
+//  - migration: arquivo exporta runPinSecundarioMigrations, SQL contem
+//    as 4 colunas esperadas
+//  - server.ts: migration wired, requirePin importado, aplicado nas 6 rotas
+//  - rotas /api/auth/me/pin/* registradas
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  isAdminBypassPin,
+  validarFormatoPin,
+  hashPin,
+  compararPin,
+  PIN_LENGTH,
+  PIN_MAX_FAILED_ATTEMPTS,
+  PIN_LOCK_DURATION_MS,
+} from '../services/pinSecundario';
+import { requirePin } from '../middleware/requirePin';
+import type { JWTClaims, AuthRole } from '../services/auth';
+
+function mockClaims(role: AuthRole): JWTClaims {
+  return {
+    sub: '42',
+    role,
+    tenant_id: 1,
+    equipe_id: null,
+    name: 'Teste',
+    jti: 'jti-test',
+  };
+}
+
+function mockRes() {
+  const res = {} as Response;
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('pinSecundario — helpers puros (v3.50.0)', () => {
+  describe('isAdminBypassPin', () => {
+    it('retorna true para admin', () => {
+      expect(isAdminBypassPin(mockClaims('admin'))).toBe(true);
+    });
+    it('retorna true para owner', () => {
+      expect(isAdminBypassPin(mockClaims('owner'))).toBe(true);
+    });
+    it('retorna false para outros roles', () => {
+      for (const r of ['gestor', 'engenheiro', 'financeiro', 'colaborador', 'viewer'] as AuthRole[]) {
+        expect(isAdminBypassPin(mockClaims(r))).toBe(false);
+      }
+    });
+    it('retorna false quando claims ausente', () => {
+      expect(isAdminBypassPin(undefined)).toBe(false);
+      expect(isAdminBypassPin(null)).toBe(false);
+    });
+  });
+
+  describe('validarFormatoPin', () => {
+    it('aceita 4 digitos numericos', () => {
+      expect(validarFormatoPin('1234')).toBe(true);
+      expect(validarFormatoPin('0000')).toBe(true);
+      expect(validarFormatoPin('9999')).toBe(true);
+    });
+    it('rejeita comprimento diferente de 4', () => {
+      expect(validarFormatoPin('123')).toBe(false);
+      expect(validarFormatoPin('12345')).toBe(false);
+      expect(validarFormatoPin('')).toBe(false);
+    });
+    it('rejeita caracteres nao-numericos', () => {
+      expect(validarFormatoPin('12a4')).toBe(false);
+      expect(validarFormatoPin('abcd')).toBe(false);
+      expect(validarFormatoPin('12-4')).toBe(false);
+    });
+    it('rejeita tipos nao-string', () => {
+      expect(validarFormatoPin(1234)).toBe(false);
+      expect(validarFormatoPin(null)).toBe(false);
+      expect(validarFormatoPin(undefined)).toBe(false);
+    });
+  });
+
+  describe('hashPin + compararPin (roundtrip)', () => {
+    it('hash bate com o PIN original', async () => {
+      const hash = await hashPin('1234');
+      expect(hash).toMatch(/^\$2[aby]\$/); // bcrypt prefix
+      expect(await compararPin('1234', hash)).toBe(true);
+      expect(await compararPin('4321', hash)).toBe(false);
+    });
+
+    it('hashes do mesmo PIN sao diferentes (salt aleatorio)', async () => {
+      const a = await hashPin('1234');
+      const b = await hashPin('1234');
+      expect(a).not.toBe(b);
+    });
+
+    it('hashPin lanca erro pra formato invalido', async () => {
+      await expect(hashPin('abc')).rejects.toThrow(/4 digitos/);
+    });
+  });
+
+  describe('constantes', () => {
+    it('PIN_LENGTH = 4', () => expect(PIN_LENGTH).toBe(4));
+    it('PIN_MAX_FAILED_ATTEMPTS = 5', () => expect(PIN_MAX_FAILED_ATTEMPTS).toBe(5));
+    it('PIN_LOCK_DURATION_MS = 15 min', () => expect(PIN_LOCK_DURATION_MS).toBe(15 * 60 * 1000));
+  });
+});
+
+describe('requirePin middleware (v3.50.0)', () => {
+  it('admin bypassa sem PIN — next() chamado', () => {
+    const req = { user: mockClaims('admin'), body: {}, headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+    requirePin(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('owner bypassa sem PIN', () => {
+    const req = { user: mockClaims('owner'), body: {}, headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+    requirePin(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('sem sessao + sem X-CEO-Token = 401', () => {
+    const req = { body: {}, headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+    delete process.env.CEO_API_TOKEN;
+    requirePin(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('X-CEO-Token valido bypassa quando sem sessao', () => {
+    const oldEnv = process.env.CEO_API_TOKEN;
+    process.env.CEO_API_TOKEN = 'token-secreto';
+    const req = { body: {}, headers: { 'x-ceo-token': 'token-secreto' } } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+    requirePin(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    if (oldEnv === undefined) delete process.env.CEO_API_TOKEN; else process.env.CEO_API_TOKEN = oldEnv;
+  });
+
+  it('role nao-admin sem PIN retorna 403 PIN_REQUIRED', () => {
+    const req = {
+      user: mockClaims('gestor'),
+      body: {},
+      headers: {},
+    } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+    requirePin(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    const callArgs = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.code).toBe('PIN_REQUIRED');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('migration pin-secundario (v3.50.0)', () => {
+  it('exporta runPinSecundarioMigrations', async () => {
+    const mod = await import('../database/migrations-pin-secundario');
+    expect(typeof mod.runPinSecundarioMigrations).toBe('function');
+  });
+
+  it('SQL contem as 4 colunas esperadas em users', () => {
+    const code = readFileSync(
+      join(__dirname, '..', 'database', 'migrations-pin-secundario.ts'),
+      'utf8',
+    );
+    expect(code).toContain('pin_hash VARCHAR(255) NULL');
+    expect(code).toContain('pin_set_at DATETIME NULL');
+    expect(code).toContain('pin_failed_attempts INT UNSIGNED NOT NULL DEFAULT 0');
+    expect(code).toContain('pin_locked_until DATETIME NULL');
+  });
+
+  it('checa columnExists pra ser idempotente', () => {
+    const code = readFileSync(
+      join(__dirname, '..', 'database', 'migrations-pin-secundario.ts'),
+      'utf8',
+    );
+    expect(code).toContain('columnExists');
+    expect(code).toMatch(/Duplicate column\|already exists/i);
+  });
+});
+
+describe('server.ts — wiring PIN (v3.50.0)', () => {
+  const serverTs = readFileSync(
+    join(__dirname, '..', 'server.ts'),
+    'utf8',
+  );
+
+  it('migration pin-secundario eh chamada no boot', () => {
+    expect(serverTs).toContain("await import('./database/migrations-pin-secundario')");
+    expect(serverTs).toContain('runPinSecundarioMigrations()');
+  });
+
+  it('requirePin esta importado', () => {
+    expect(serverTs).toContain("from './middleware/requirePin'");
+  });
+
+  it('aplicado em DELETE /api/recibos/:id (excluir recibo)', () => {
+    expect(serverTs).toMatch(/app\.delete\(['"]\/api\/recibos\/:id['"]\s*,\s*requireAuth\s*,\s*requirePin/);
+  });
+
+  it('aplicado em POST /api/recibos/:id/cancelar', () => {
+    expect(serverTs).toMatch(/\/api\/recibos\/:id\/cancelar['"]\s*,\s*requireAuth\s*,\s*requirePin/);
+  });
+
+  it('aplicado em POST /api/recibos/disparar (fechar quinzena)', () => {
+    expect(serverTs).toMatch(/\/api\/recibos\/disparar['"]\s*,\s*requireCeoToken\s*,\s*requirePin/);
+  });
+
+  it('aplicado em POST /api/folha/fechar', () => {
+    expect(serverTs).toMatch(/\/api\/folha\/fechar['"]\s*,\s*requireAuth\s*,\s*requirePin/);
+  });
+
+  it('aplicado em DELETE /api/laudos-demarcacao/:id', () => {
+    expect(serverTs).toMatch(/\/api\/laudos-demarcacao\/:id['"]\s*,\s*requireCeoToken\s*,\s*requirePin/);
+  });
+
+  it('aplicado em DELETE /api/propostas/:id', () => {
+    expect(serverTs).toMatch(/app\.delete\(['"]\/api\/propostas\/:id['"]\s*,\s*requireCeoToken\s*,\s*requirePin/);
+  });
+
+  it('aplicado em POST /api/notas-fiscais/:id/cancelar', () => {
+    expect(serverTs).toMatch(/\/api\/notas-fiscais\/:id\/cancelar['"]\s*,\s*requireAuth\s*,\s*requirePin/);
+  });
+});
+
+describe('routes/auth.ts — endpoints /api/auth/me/pin/* (v3.50.0)', () => {
+  const authTs = readFileSync(
+    join(__dirname, '..', 'routes', 'auth.ts'),
+    'utf8',
+  );
+
+  it('GET /me/pin/status registrado', () => {
+    expect(authTs).toMatch(/router\.get\(['"]\/me\/pin\/status['"]/);
+  });
+
+  it('POST /me/pin (cadastra/troca) registrado', () => {
+    expect(authTs).toMatch(/router\.post\(['"]\/me\/pin['"]/);
+  });
+
+  it('DELETE /me/pin (remove) registrado', () => {
+    expect(authTs).toMatch(/router\.delete\(['"]\/me\/pin['"]/);
+  });
+
+  it('cadastro/troca exige senha atual antes do PIN (anti-takeover)', () => {
+    expect(authTs).toContain('Senha atual obrigatoria');
+    expect(authTs).toContain('verifyPassword');
+  });
+});
+
+describe('frontend obras.html — UI PIN + modal (v3.50.0)', () => {
+  const obrasHtml = readFileSync(
+    join(__dirname, '..', 'public', 'obras.html'),
+    'utf8',
+  );
+
+  it('aba Seguranca aparece em Configuracoes', () => {
+    expect(obrasHtml).toContain('data-sub="seguranca"');
+    expect(obrasHtml).toContain('🔐 Segurança');
+  });
+
+  it('renderCfgSeguranca chama /api/auth/me/pin/status', () => {
+    expect(obrasHtml).toContain("api('/api/auth/me/pin/status')");
+  });
+
+  it('helper pinConfirmar exposto em window.pinConfirmar', () => {
+    expect(obrasHtml).toContain('async function pinConfirmar(');
+    expect(obrasHtml).toContain('window.pinConfirmar = pinConfirmar');
+  });
+
+  it('modal exige 4 digitos numericos (regex client-side)', () => {
+    expect(obrasHtml).toMatch(/\/\^\\d\{4\}\$\//);
+  });
+
+  it('admin bypass na UI — modal retorna string vazia se bypass', () => {
+    expect(obrasHtml).toContain('if (st && st.bypass) return');
+  });
+
+  it('handler data-rec-del chama pinConfirmar antes da DELETE', () => {
+    expect(obrasHtml).toMatch(/data-rec-del[\s\S]*?pinConfirmar/);
+  });
+
+  it('handler data-nf-cancelar chama pinConfirmar', () => {
+    expect(obrasHtml).toMatch(/data-nf-cancelar[\s\S]*?pinConfirmar/);
+  });
+
+  it('handler data-laudo-del chama pinConfirmar', () => {
+    expect(obrasHtml).toMatch(/data-laudo-del[\s\S]*?pinConfirmar/);
+  });
+
+  it('handler data-del-prop chama pinConfirmar', () => {
+    expect(obrasHtml).toMatch(/data-del-prop[\s\S]*?pinConfirmar/);
+  });
+});


### PR DESCRIPTION
Roles admin/owner dispensam PIN em todas as rotas; demais roles (gestor, engenheiro, financeiro, colaborador, viewer) cadastram PIN em Configuracoes
> Seguranca e digitam num modal antes de acoes sensiveis.

Backend:
- Migration users.pin_hash + pin_set_at + pin_failed_attempts + pin_locked_until (bcrypt cost 12, idempotente via columnExists)
- service pinSecundario.ts: hash/comparar/verificar/definir/remover/status
  + rate limit (5 tentativas -> trava 15 min)
- middleware requirePin: bypass admin/owner + bypass X-CEO-Token legacy
- 3 endpoints /api/auth/me/pin/* (status/cadastrar/remover) — todos exigem senha atual antes de mexer no PIN (anti-takeover)
- Aplicado em 7 rotas: DELETE recibo/laudo/proposta, POST recibo cancelar, recibo disparar (folha), folha fechar, NF cancelar

Frontend:
- Nova aba Seguranca em Configuracoes (cadastra/troca/remove PIN)
- Helper window.pinConfirmar() reutilizavel — modal nativo 4 digitos
- Admin/owner: modal pulado automaticamente (status.bypass = true)
- 4 handlers patched: data-rec-del, data-del-prop, data-laudo-del, data-nf-cancelar

1209 testes passando (+44 novos), tsc limpo, zero regressao.